### PR TITLE
fix: fix for pasting observer key in win10 cmd

### DIFF
--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -197,6 +197,16 @@ fn cycle_finalization_button(selected_button: &mut usize, direction: KeyCode, is
     }
 }
 
+fn read_clipboard_text_best_effort() -> Option<String> {
+    match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
+        Ok(t) => Some(t),
+        Err(e) => {
+            log::warn!("Failed to read clipboard text: {}", e);
+            None
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Main key event handler - dispatches to appropriate handlers
 pub fn handle_key_event(
@@ -255,6 +265,32 @@ pub fn handle_key_event(
                 return Some(true);
             }
             _ => {}
+        }
+    }
+
+    // Observer tab paste fallback for terminals without bracketed paste (notably cmd.exe):
+    // - Shift+Insert (classic Windows paste)
+    // - Ctrl+Shift+V (Windows Terminal-style paste shortcut)
+    // - Ctrl+V when the console delivers it as a key event
+    if let Tab::Admin(AdminTab::Observer) = app.active_tab {
+        let is_ctrl = key_event.modifiers.contains(KeyModifiers::CONTROL);
+        let is_shift = key_event.modifiers.contains(KeyModifiers::SHIFT);
+        let is_paste_shortcut = match key_event.code {
+            KeyCode::Insert => is_shift,
+            KeyCode::Char('v') | KeyCode::Char('V') => is_ctrl,
+            _ => false,
+        } || (is_ctrl
+            && is_shift
+            && matches!(key_event.code, KeyCode::Char('v') | KeyCode::Char('V')));
+
+        if is_paste_shortcut {
+            if let Some(text) = read_clipboard_text_best_effort() {
+                let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
+                if !filtered.is_empty() {
+                    app.observer_shared_key_input.push_str(&filtered);
+                    return Some(true);
+                }
+            }
         }
     }
 

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -295,6 +295,8 @@ pub fn handle_key_event(
                     return Some(true);
                 }
             }
+        }
+    }
     // Rate counterparty: 1..=5 stars (Left/Right or +/-).
     if let UiMode::RatingOrder(ref mut s) = app.mode {
         match code {

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -164,9 +164,14 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
     );
     f.render_widget(key_input, input_chunks[0]);
 
-    let footer = Paragraph::new(
-        "Ctrl+H: Help | Tab/Shift+Tab: Switch focus | Ctrl+Shift+V: Paste shared key\n\
-Enter: Load chat | Esc: Clear error | Ctrl+C: Clear all | Ctrl+S: Save attachment | ↑↓/PgUp/PgDn: Scroll",
-    );
+    let paste_hint = if cfg!(windows) {
+        "Shift+Insert / Ctrl+Shift+V / right-click"
+    } else {
+        "Ctrl+Shift+V / middle-click"
+    };
+    let footer = Paragraph::new(format!(
+        "Ctrl+H: Help | Tab/Shift+Tab: Switch focus | Paste shared key ({paste_hint})\n\
+Enter: Load chat | Esc: Clear error | Ctrl+C: Clear all | Ctrl+S: Save attachment | ↑↓/PgUp/PgDn: Scroll"
+    ));
     f.render_widget(footer, input_chunks[1]);
 }

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -165,9 +165,9 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
     f.render_widget(key_input, input_chunks[0]);
 
     let paste_hint = if cfg!(windows) {
-        "Shift+Insert / Ctrl+Shift+V / right-click"
+        "Shift+Insert / Ctrl+V / Ctrl+Shift+V / right-click"
     } else {
-        "Ctrl+Shift+V / middle-click"
+        "Ctrl+V / Ctrl+Shift+V / middle-click"
     };
     let footer = Paragraph::new(format!(
         "Ctrl+H: Help | Tab/Shift+Tab: Switch focus | Paste shared key ({paste_hint})\n\


### PR DESCRIPTION
## Summary

introduced paste compatibility of key pasting in observer mode in windows 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observer tab accepts pasted text via common paste shortcuts (e.g., Shift+Insert, Ctrl+Shift+V, Ctrl+V delivered as key events); pasted content is filtered for control characters and appended to the shared key input.
  * Footer UI now shows platform-specific paste hints (Windows vs. others) so displayed shortcuts match your OS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->