### PR TITLE
feat: added correct pow management

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ currencies_filter = []
 
 # User mode: "user" or "admin" (controls available actions and UI)
 user_mode = "user"
-
-# Proof-of-work difficulty for events (0 = disabled, higher = more work)
-# Not managed from tui at the moment
-pow = 0
 ```
 
 > **Note**: On first run, Mostrix generates a complete `settings.toml` with a fresh keypair. The example above shows the default values used.
@@ -117,10 +113,6 @@ pow = 0
 - **`user_mode`**  
   - `"user"` (default): normal user interface and actions.  
   - `"admin"`: enables admin-specific capabilities; typically used with `admin_privkey`.
-
-- **`pow`**  
-  - Required proof-of-work difficulty for Nostr events created by Mostrix.  
-  - `0` disables additional PoW; higher values increase CPU cost per event but can help with relay anti-spam policies.
 
 #### Fiat currencies and Mostro instance info
 

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -13,6 +13,10 @@ Mostrix uses two Nostr protocols for secure communication:
 1. **NIP-59 (Gift Wrap)**: Primary method for communicating with the Mostro daemon. Provides encryption and authentication.
 2. **NIP-44 (Encrypted Direct Messages)**: Alternative method for peer-to-peer communication (used in some scenarios).
 
+### Proof-of-work (NIP-13)
+
+Required difficulty comes from the Mostro **instance status** event (kind **38385**, tag `pow`), not from `settings.toml`. Mostrix derives mining bits with `nostr_pow_from_instance`, threads cached `AppState.mostro_info` into `send_dm` and related publishers, and applies PoW to the **published** event—including the **outer** Gift Wrap (kind 1059), via a local helper that extends the rust-nostr `gift_wrap` path. See **[POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md)** for implementation details and file pointers.
+
 ## Order Creation Flow
 
 When a user creates a new order through the TUI, the following sequence occurs:

--- a/docs/POW_AND_OUTBOUND_EVENTS.md
+++ b/docs/POW_AND_OUTBOUND_EVENTS.md
@@ -1,0 +1,42 @@
+# PoW and outbound Nostr events
+
+This document describes how Mostrix applies **NIP-13 proof-of-work** to events it publishes toward Mostro and related flows. It is intended for contributors and AI-assisted codegen so outbound signing behavior stays consistent with the Mostro instance policy.
+
+## Source of difficulty
+
+- The Mostro **instance status** event (kind **38385**) includes an optional `pow` tag (unsigned integer). Mostrix parses this into [`MostroInstanceInfo.pow`](../src/util/mostro_info.rs) (`Option<u32>`).
+- There is **no** `pow` field in [`Settings`](../src/settings.rs) or in the generated `settings.toml` template. Legacy configs may still contain `pow = …`; serde typically ignores unknown keys when deserializing.
+- **Effective bits** for signing: [`nostr_pow_from_instance`](../src/util/mostro_info.rs) maps `Option<&MostroInstanceInfo>` → `u8` by taking `info.pow`, clamping to `u8::MAX`, and using **0** when info is missing or `pow` is `None`.
+
+## Cached instance info at runtime
+
+- [`AppState.mostro_info`](../src/ui/app_state.rs) holds the latest fetched `MostroInstanceInfo`.
+- [`EnterKeyContext`](../src/ui/key_handler/mod.rs) includes `mostro_info: Option<MostroInstanceInfo>` so Enter/spawn paths can pass the same snapshot into async work without re-fetching relays per message.
+- [`send_dm`](../src/util/dm_utils/mod.rs) takes `mostro_instance: Option<&MostroInstanceInfo>` and computes `pow = nostr_pow_from_instance(mostro_instance)` once per send.
+
+If instance info has not been loaded yet (e.g. slow startup), PoW may be **0** until a successful fetch or manual refresh (Mostro Info tab / background refresh tasks). Users may see rejects from strict instances until 38385 is cached.
+
+## Private direct messages (NIP-17 / kind 14)
+
+[`create_private_dm_event`](../src/util/dm_utils/dm_helpers.rs) builds the published event with `EventBuilder::new(Kind::PrivateDirectMessage, …).pow(pow).…` so the **event that hits relays** is mined to the required difficulty.
+
+## Gift Wrap (NIP-59 / kind 1059)
+
+Mostro protocol traffic uses encrypted Gift Wraps. The **rust-nostr** helper `EventBuilder::gift_wrap` composes seal → wrap but, in the versions Mostrix uses, does **not** apply PoW to the **outer** Gift Wrap event (the one relays and daemons index).
+
+Mostrix therefore:
+
+1. Builds the **rumor** (inner unsigned note) as today (including `.pow(pow)` on the rumor builder where applicable).
+2. Builds and signs the **seal** with `EventBuilder::seal` + `sign`.
+3. Wraps with a local [`gift_wrap_from_seal_with_pow`](../src/util/dm_utils/dm_helpers.rs) that mirrors upstream `gift_wrap_from_seal` (NIP-44 encrypt seal JSON, kind 1059, tweaked `created_at`, ephemeral keys) but adds **`.pow(pow)`** on the **Gift Wrap** `EventBuilder` **before** `sign_with_keys`, so the **published** envelope id satisfies instance PoW policy.
+
+Admin dispute chat gift wraps use the same instance-derived PoW via [`send_admin_chat_message_via_shared_key`](../src/util/chat_utils.rs) and `nostr_pow_from_instance`.
+
+## Call sites (high level)
+
+Anything that publishes to Mostro should receive cached instance info where possible: order flows under [`src/util/order_utils/`](../src/util/order_utils/), admin dispute actions in [`src/ui/key_handler/admin_handlers.rs`](../src/ui/key_handler/admin_handlers.rs), and message/rating handlers in [`src/ui/key_handler/message_handlers.rs`](../src/ui/key_handler/message_handlers.rs).
+
+## Related docs
+
+- [STARTUP_AND_CONFIG.md](STARTUP_AND_CONFIG.md) — settings shape (no local `pow`)
+- [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) — protocol overview; links here for PoW detail

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 - **Startup & Configuration**: [STARTUP_AND_CONFIG.md](STARTUP_AND_CONFIG.md) — Boot sequence, settings, background tasks, DM router wiring, reconnect
 - **DM listener & router**: [DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md) — `listen_for_order_messages`, TrackOrder vs waiter, startup `fetch_events` replay, in-memory `OrderMessage` list
 - **Message Flow & Protocol**: [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) — How Mostrix talks to Mostro over Nostr (orders, GiftWrap, restarts, cooperative cancel / `TradeClosed`)
+- **PoW & outbound events**: [POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md) — Instance `pow` (kind 38385), `nostr_pow_from_instance`, Gift Wrap outer mining (`gift_wrap_from_seal_with_pow`)
 - **Database**: [DATABASE.md](DATABASE.md) — SQLite schema, `orders` / `users` / `admin_disputes`, migrations
 - **Key Management**: [KEY_MANAGEMENT.md](KEY_MANAGEMENT.md) — Deterministic derivation (NIP-06 path), identity vs trade keys
 

--- a/docs/SETTINGS_ANALYSIS.md
+++ b/docs/SETTINGS_ANALYSIS.md
@@ -21,6 +21,10 @@ This document provides a comprehensive analysis of the Settings tab features imp
 - **Restart requirement**: After saving the mnemonic, Mostrix must be restarted so the app can use the rotated keys everywhere.
 - **First-launch behavior**: If Mostrix had to bootstrap a brand-new `settings.toml`, the backup popup is shown immediately as an overlay on the initial Orders/Disputes tab (no forced navigation to Settings).
 
+### Instance PoW (not a settings field)
+
+Proof-of-work for **published Nostr events** is **not** configured in the Settings tab or in `settings.toml`. It comes from the Mostro instance status event (kind 38385, tag `pow`) and is applied in code paths described in **[POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md)**. Older `settings.toml` files may still list `pow`; that key is ignored when loading `Settings`.
+
 ### 4. Validation Enhancements
 - **Mostro Pubkey Validation**: Changed from `npub` format to hex format validation
 - **Relay Validation**: Added validation to ensure relay URLs start with `wss://`

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -85,8 +85,8 @@ The TUI uses `ratatui` with the `crossterm` backend.
 
 The `Settings` struct defines all available configuration options.
 
-**Source**: `src/settings.rs:8`
-```8:19:src/settings.rs
+**Source**: `src/settings.rs`
+```rust
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub mostro_pubkey: String,
@@ -95,7 +95,6 @@ pub struct Settings {
     pub relays: Vec<String>,
     pub log_level: String,
     pub currencies_filter: Vec<String>,
-    pub pow: u8,
     #[serde(default = "default_user_mode")]
     pub user_mode: String, // "user" or "admin", default "user"
 }
@@ -110,8 +109,9 @@ pub struct Settings {
 - **`currencies_filter`**: Optional list of fiat currency **filters** (ISO codes).  
   - When empty, all currencies published by the Mostro instance are shown.  
   - When non-empty (e.g. `["USD"]`, `["USD", "EUR"]`), only orders whose fiat code is in this list are displayed.
-- **`pow`**: Proof-of-work difficulty requirement for publishing events.
 - **`user_mode`**: Either "user" or "admin". Controls the UI and available actions.
+
+Proof-of-work for published events is taken from the Mostro instance status event (kind 38385, tag `pow`), not from `settings.toml`.
 
 ## Nostr & Background Tasks
 

--- a/settings.toml
+++ b/settings.toml
@@ -13,5 +13,3 @@ currencies_filter = ["VES", "ARS", "USD"]
 nsec_privkey = 'nsec1_privkey_format'
 # User mode: "user" or "admin"
 user_mode = "user"
-# Proof-of-work difficulty
-pow = 0

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,7 +17,6 @@ pub struct Settings {
     pub relays: Vec<String>,
     pub log_level: String,
     pub currencies_filter: Vec<String>,
-    pub pow: u8,
     #[serde(default = "default_user_mode")]
     pub user_mode: String, // "user" or "admin", default "user"
 }
@@ -42,7 +41,6 @@ impl Default for Settings {
             relays: Vec::new(),
             log_level: "info".to_string(),
             currencies_filter: Vec::new(),
-            pow: 0,
             user_mode: "user".to_string(),
         }
     }
@@ -221,7 +219,6 @@ with your real keys before running Mostrix again.",
     settings.nsec_privkey = nsec;
     settings.relays = vec!["wss://relay.mostro.network".to_string()];
     settings.user_mode = "user".to_string();
-    settings.pow = 0;
     settings.currencies_filter = Vec::new();
     settings.mostro_pubkey = MOSTRO_STAGING_PUBKEY.to_string();
 
@@ -353,7 +350,6 @@ mod tests {
             relays = ["wss://relay.example.com"]
             log_level = "info"
             currencies = ["USD", "EUR"]
-            pow = 0
         "#;
         // Direct deserialization (bypassing validate_currencies_config) should now fail
         // because the Settings struct no longer has a serde alias for `currencies`.

--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -37,12 +37,14 @@ pub(crate) fn execute_take_dispute_action(
     let client_clone = ctx.client.clone();
     let result_tx = ctx.order_result_tx.clone();
     let pool_clone = ctx.pool.clone();
+    let mostro_info = ctx.mostro_info.clone();
     tokio::spawn(async move {
         match execute_take_dispute(
             &dispute_id,
             &client_clone,
             current_mostro_pubkey,
             &pool_clone,
+            mostro_info.as_ref(),
         )
         .await
         {
@@ -86,9 +88,15 @@ pub(crate) fn execute_add_solver_action(
         return;
     };
 
+    let mostro_info = ctx.mostro_info.clone();
     tokio::spawn(async move {
-        match execute_admin_add_solver(&solver_pubkey_clone, &client_clone, current_mostro_pubkey)
-            .await
+        match execute_admin_add_solver(
+            &solver_pubkey_clone,
+            &client_clone,
+            current_mostro_pubkey,
+            mostro_info.as_ref(),
+        )
+        .await
         {
             Ok(_) => {
                 let _ = result_tx.send(OperationResult::Info(
@@ -128,6 +136,7 @@ pub(crate) fn execute_finalize_dispute_action(
     let client_clone = ctx.client.clone();
     let result_tx = ctx.order_result_tx.clone();
     let pool_clone = ctx.pool.clone();
+    let mostro_info = ctx.mostro_info.clone();
     tokio::spawn(async move {
         match execute_finalize_dispute(
             &dispute_id,
@@ -135,6 +144,7 @@ pub(crate) fn execute_finalize_dispute_action(
             current_mostro_pubkey,
             &pool_clone,
             is_settle,
+            mostro_info.as_ref(),
         )
         .await
         {

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -646,6 +646,7 @@ pub fn spawn_send_new_order_task(ctx: &EnterKeyContext<'_>, form: FormState) {
     let dm_subscription_tx = ctx.dm_subscription_tx.clone();
     let fallback_mostro_pubkey = ctx.mostro_pubkey;
     let current_mostro_pubkey = Arc::clone(ctx.current_mostro_pubkey);
+    let mostro_info = ctx.mostro_info.clone();
     tokio::spawn(async move {
         let mostro_pubkey = match current_mostro_pubkey.lock() {
             Ok(guard) => *guard,
@@ -662,6 +663,7 @@ pub fn spawn_send_new_order_task(ctx: &EnterKeyContext<'_>, form: FormState) {
             mostro_pubkey,
             form,
             Some(&dm_subscription_tx),
+            mostro_info.as_ref(),
         )
         .await
         {
@@ -680,24 +682,24 @@ pub fn spawn_send_new_order_task(ctx: &EnterKeyContext<'_>, form: FormState) {
 pub fn spawn_take_order_task(
     pool: SqlitePool,
     client: Client,
-    settings: Settings,
     mostro_pubkey: PublicKey,
     take_state: TakeOrderState,
     amount: Option<i64>,
     invoice: Option<String>,
     result_tx: UnboundedSender<OperationResult>,
     dm_subscription_tx: UnboundedSender<OrderDmSubscriptionCmd>,
+    mostro_info: Option<crate::util::MostroInstanceInfo>,
 ) {
     tokio::spawn(async move {
         match crate::util::take_order(
             &pool,
             &client,
-            &settings,
             mostro_pubkey,
             &take_state.order,
             amount,
             invoice,
             Some(&dm_subscription_tx),
+            mostro_info.as_ref(),
         )
         .await
         {

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -100,6 +100,7 @@ pub fn handle_confirm_key(
                 ctx.mostro_pubkey,
                 ctx.order_result_tx,
                 ctx.dm_subscription_tx,
+                ctx.mostro_info.clone(),
             );
             true
         }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -291,6 +291,7 @@ pub fn handle_enter_key(app: &mut AppState, ctx: &super::EnterKeyContext<'_>) ->
                             &app.admin_chat_input,
                             ctx.client,
                             ctx.admin_chat_keys,
+                            ctx.mostro_info.clone(),
                         );
 
                         message_counter(app, &dispute_id_key);

--- a/src/ui/key_handler/input_helpers.rs
+++ b/src/ui/key_handler/input_helpers.rs
@@ -105,6 +105,7 @@ pub fn send_admin_chat_message_via_shared_key(
     message_content: &str,
     client: &Client,
     admin_chat_keys: Option<&Keys>,
+    mostro_instance: Option<crate::util::MostroInstanceInfo>,
 ) {
     let Some(admin_keys) = admin_chat_keys else {
         log::warn!(
@@ -137,6 +138,7 @@ pub fn send_admin_chat_message_via_shared_key(
             &admin_keys,
             &shared_keys,
             &message_content,
+            mostro_instance.as_ref(),
         )
         .await
         {

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -60,6 +60,7 @@ pub fn handle_enter_viewing_message(
     let mostro_pubkey = ctx.mostro_pubkey;
     let result_tx = ctx.order_result_tx.clone();
     let source_action = view_state.action.clone();
+    let mostro_info = ctx.mostro_info.clone();
 
     tokio::spawn(async move {
         match execute_send_msg(
@@ -68,6 +69,7 @@ pub fn handle_enter_viewing_message(
             &pool_clone,
             &client_clone,
             mostro_pubkey,
+            mostro_info.as_ref(),
         )
         .await
         {
@@ -135,6 +137,7 @@ pub fn handle_enter_message_notification(
                     let pool_clone = ctx.pool.clone();
                     let client_clone = ctx.client.clone();
                     let mostro_pubkey = ctx.mostro_pubkey;
+                    let mostro_info = ctx.mostro_info.clone();
                     tokio::spawn(async move {
                         match execute_add_invoice(
                             &order_id,
@@ -142,6 +145,7 @@ pub fn handle_enter_message_notification(
                             &pool_clone,
                             &client_clone,
                             mostro_pubkey,
+                            mostro_info.as_ref(),
                         )
                         .await
                         {
@@ -187,9 +191,18 @@ pub fn handle_enter_rating_order(
     let client_clone = ctx.client.clone();
     let mostro_pubkey = ctx.mostro_pubkey;
     let result_tx = ctx.order_result_tx.clone();
+    let mostro_info = ctx.mostro_info.clone();
 
     tokio::spawn(async move {
-        match execute_rate_user(&order_id, rating, &pool_clone, &client_clone, mostro_pubkey).await
+        match execute_rate_user(
+            &order_id,
+            rating,
+            &pool_clone,
+            &client_clone,
+            mostro_pubkey,
+            mostro_info.as_ref(),
+        )
+        .await
         {
             Ok(()) => {
                 let _ = result_tx.send(OperationResult::Info(

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -17,6 +17,7 @@ use crate::ui::{
     AdminMode, AdminTab, AppState, ChatAttachment, ChatSender, DisputeFilter,
     MostroInfoFetchResult, OperationResult, Tab, TakeOrderState, UiMode, UserMode, UserTab,
 };
+use crate::util::MostroInstanceInfo;
 use crate::util::OrderDmSubscriptionCmd;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mostro_core::prelude::*;
@@ -39,6 +40,8 @@ pub struct EnterKeyContext<'a> {
     pub key_rotation_tx: &'a UnboundedSender<Result<Zeroizing<String>, String>>,
     pub seed_words_tx: &'a UnboundedSender<Result<Zeroizing<String>, String>>,
     pub mostro_info_tx: &'a UnboundedSender<MostroInfoFetchResult>,
+    /// Cached kind 38385 instance info (PoW bits for outbound events).
+    pub mostro_info: Option<MostroInstanceInfo>,
     pub admin_chat_keys: Option<&'a Keys>,
     pub dm_subscription_tx: &'a UnboundedSender<OrderDmSubscriptionCmd>,
 }
@@ -741,6 +744,7 @@ pub fn handle_key_event(
                 key_rotation_tx,
                 seed_words_tx,
                 mostro_info_tx,
+                mostro_info: app.mostro_info.clone(),
                 admin_chat_keys,
                 dm_subscription_tx,
             };

--- a/src/ui/key_handler/user_handlers.rs
+++ b/src/ui/key_handler/user_handlers.rs
@@ -34,6 +34,7 @@ pub fn handle_enter_taking_order(
             ctx.mostro_pubkey,
             ctx.order_result_tx,
             ctx.dm_subscription_tx,
+            ctx.mostro_info.clone(),
         );
     } else {
         // NO selected - cancel and return to the appropriate normal mode
@@ -57,6 +58,7 @@ pub(crate) fn execute_take_order_action(
     mostro_pubkey: nostr_sdk::PublicKey,
     order_result_tx: &UnboundedSender<crate::ui::OperationResult>,
     dm_subscription_tx: &UnboundedSender<crate::util::OrderDmSubscriptionCmd>,
+    mostro_info: Option<crate::util::MostroInstanceInfo>,
 ) -> bool {
     // Validate range order if needed
     if take_state.is_range_order {
@@ -86,27 +88,17 @@ pub(crate) fn execute_take_order_action(
     // For buy orders (taking sell), we'd need invoice, but for now we'll pass None
     // TODO: Add invoice input for buy orders
     let invoice = None;
-    let runtime_settings = match crate::settings::load_settings_from_disk() {
-        Ok(s) => s,
-        Err(e) => {
-            app.mode = UiMode::OperationResult(crate::ui::OperationResult::Error(format!(
-                "Failed to load settings for taking order: {}",
-                e
-            )));
-            return false;
-        }
-    };
 
     spawn_take_order_task(
         pool.clone(),
         client.clone(),
-        runtime_settings,
         mostro_pubkey,
         take_state_clone,
         amount,
         invoice,
         order_result_tx.clone(),
         dm_subscription_tx.clone(),
+        mostro_info,
     );
 
     true

--- a/src/ui/key_handler/user_handlers.rs
+++ b/src/ui/key_handler/user_handlers.rs
@@ -50,6 +50,7 @@ pub fn handle_enter_taking_order(
 ///
 /// This avoids code duplication between Enter key and 'y' key handlers.
 /// Validates the take_state, sets the UI mode to waiting, and spawns an async task to take the order.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_take_order_action(
     app: &mut AppState,
     take_state: TakeOrderState,

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -9,7 +9,7 @@ use crate::models::AdminDispute;
 use crate::ui::{AdminChatLastSeen, AdminChatUpdate, ChatParty, ChatSender, DisputeChatMessage};
 use crate::util::dm_utils::FETCH_EVENTS_TIMEOUT;
 use crate::util::filters::filter_giftwrap_to_recipient;
-use crate::SETTINGS;
+use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 
 /// Messages grouped by (dispute_id, party); value is (content, timestamp, sender_pubkey).
 type AdminChatByKey = HashMap<(String, ChatParty), Vec<(String, i64, PublicKey)>>;
@@ -58,6 +58,7 @@ async fn build_custom_wrap_event(
     sender: &Keys,
     recipient_pubkey: &PublicKey,
     message: &str,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<Event> {
     // Message is just sent inside rumor as per https://mostro.network/protocol/chat.html please check that.
     let inner_message = EventBuilder::text_note(message)
@@ -77,13 +78,7 @@ async fn build_custom_wrap_event(
     // Build tags for the wrapper event, the recipient pubkey is the shared key pubkey
     let tag = Tag::public_key(*recipient_pubkey);
 
-    // Get the pow from the settings
-    let pow: u8 = SETTINGS
-        .get()
-        .ok_or_else(|| {
-            anyhow::anyhow!("Settings not initialized. Please restart the application.")
-        })?
-        .pow;
+    let pow = nostr_pow_from_instance(mostro_instance);
     // Build the wrapped event
     let wrapped_event = EventBuilder::new(Kind::GiftWrap, encrypted_content)
         .tag(tag)
@@ -106,13 +101,15 @@ pub async fn send_admin_chat_message_via_shared_key(
     admin_keys: &Keys,
     shared_keys: &Keys,
     content: &str,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     let content = content.trim();
     if content.is_empty() {
         return Err(anyhow::anyhow!("Cannot send empty admin chat message"));
     }
     let recipient_pubkey = shared_keys.public_key();
-    let event = build_custom_wrap_event(admin_keys, &recipient_pubkey, content).await?;
+    let event =
+        build_custom_wrap_event(admin_keys, &recipient_pubkey, content, mostro_instance).await?;
     // Send the event to the relay
     client
         .send_event(&event)

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -19,7 +19,8 @@ fn gift_wrap_from_seal_with_pow(
     seal: &Event,
     extra_tags: impl IntoIterator<Item = Tag>,
     pow: u8,
-) -> Result<Event> { // or map to anyhow in create_gift_wrap_event
+) -> Result<Event> {
+    // or map to anyhow in create_gift_wrap_event
     if seal.kind != nostr_sdk::Kind::Seal {
         // same validation as upstream, or map_err to anyhow
         return Err(anyhow::anyhow!("Invalid kind"));
@@ -40,7 +41,8 @@ fn gift_wrap_from_seal_with_pow(
         .tags(tags)
         .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
         .pow(pow) // <-- this is what the SDK’s gift_wrap path does NOT do
-        .sign_with_keys(&ephem).map_err(|e| anyhow::anyhow!("Failed to sign gift wrap: {e}"))
+        .sign_with_keys(&ephem)
+        .map_err(|e| anyhow::anyhow!("Failed to sign gift wrap: {e}"))
 }
 
 /// Subscription behavior for GiftWrap filters.
@@ -118,11 +120,11 @@ pub(crate) async fn create_gift_wrap_event(
     };
 
     let seal: Event = EventBuilder::seal(signer_keys, receiver_pubkey, rumor)
-    .await?
-    .sign(signer_keys)
-    .await?;
-   
-    Ok(gift_wrap_from_seal_with_pow(receiver_pubkey, &seal, tags, pow)?)
+        .await?
+        .sign(signer_keys)
+        .await?;
+
+    gift_wrap_from_seal_with_pow(receiver_pubkey, &seal, tags, pow)
 }
 
 /// Subscribe GiftWrap for a trade pubkey and remember the returned subscription id.

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -13,16 +13,21 @@ use crate::ui::{AdminChatLastSeen, AppState, ChatParty};
 use crate::util::filters::filter_giftwrap_to_recipient;
 use crate::util::types::create_expiration_tags;
 
-// nip59::RANGE_RANDOM_TIMESTAMP_TWEAK — you already use `nip59::` elsewhere in the project
+/// Builds the published NIP-59 **Gift Wrap** (kind 1059) from a signed **Seal** event.
+///
+/// Rust-nostr’s `EventBuilder::gift_wrap` seals and wraps but does not apply NIP-13 PoW to the
+/// outer Gift Wrap; Mostro may require that difficulty on the relay-visible event. This helper
+/// mirrors the SDK’s seal→wrap steps: reject non-seal inputs, encrypt the seal JSON to `receiver`
+/// with NIP-44 using an **ephemeral** key pair, attach `p` and optional tags, set
+/// [`nip59::RANGE_RANDOM_TIMESTAMP_TWEAK`]-style `created_at`, mine with [`EventBuilder::pow`],
+/// then sign the wrap with the ephemeral keys.
 fn gift_wrap_from_seal_with_pow(
     receiver: &PublicKey,
     seal: &Event,
     extra_tags: impl IntoIterator<Item = Tag>,
     pow: u8,
 ) -> Result<Event> {
-    // or map to anyhow in create_gift_wrap_event
     if seal.kind != nostr_sdk::Kind::Seal {
-        // same validation as upstream, or map_err to anyhow
         return Err(anyhow::anyhow!("Invalid kind"));
     }
 
@@ -40,7 +45,7 @@ fn gift_wrap_from_seal_with_pow(
     EventBuilder::new(nostr_sdk::Kind::GiftWrap, content)
         .tags(tags)
         .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
-        .pow(pow) // <-- this is what the SDK’s gift_wrap path does NOT do
+        .pow(pow)
         .sign_with_keys(&ephem)
         .map_err(|e| anyhow::anyhow!("Failed to sign gift wrap: {e}"))
 }

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -13,6 +13,36 @@ use crate::ui::{AdminChatLastSeen, AppState, ChatParty};
 use crate::util::filters::filter_giftwrap_to_recipient;
 use crate::util::types::create_expiration_tags;
 
+// nip59::RANGE_RANDOM_TIMESTAMP_TWEAK — you already use `nip59::` elsewhere in the project
+fn gift_wrap_from_seal_with_pow(
+    receiver: &PublicKey,
+    seal: &Event,
+    extra_tags: impl IntoIterator<Item = Tag>,
+    pow: u8,
+) -> Result<Event> { // or map to anyhow in create_gift_wrap_event
+    if seal.kind != nostr_sdk::Kind::Seal {
+        // same validation as upstream, or map_err to anyhow
+        return Err(anyhow::anyhow!("Invalid kind"));
+    }
+
+    let ephem = Keys::generate();
+    let content = nip44::encrypt(
+        ephem.secret_key(),
+        receiver,
+        seal.as_json(),
+        nip44::Version::default(),
+    )?;
+
+    let mut tags: Vec<Tag> = extra_tags.into_iter().collect();
+    tags.push(Tag::public_key(*receiver));
+
+    EventBuilder::new(nostr_sdk::Kind::GiftWrap, content)
+        .tags(tags)
+        .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
+        .pow(pow) // <-- this is what the SDK’s gift_wrap path does NOT do
+        .sign_with_keys(&ephem).map_err(|e| anyhow::anyhow!("Failed to sign gift wrap: {e}"))
+}
+
 /// Subscription behavior for GiftWrap filters.
 pub(crate) enum GiftWrapSubscriptionMode {
     /// Startup catch-up: request the latest retained event for this pubkey.
@@ -87,7 +117,12 @@ pub(crate) async fn create_gift_wrap_event(
         trade_keys
     };
 
-    Ok(EventBuilder::gift_wrap(signer_keys, receiver_pubkey, rumor, tags).await?)
+    let seal: Event = EventBuilder::seal(signer_keys, receiver_pubkey, rumor)
+    .await?
+    .sign(signer_keys)
+    .await?;
+   
+    Ok(gift_wrap_from_seal_with_pow(receiver_pubkey, &seal, tags, pow)?)
 }
 
 /// Subscribe GiftWrap for a trade pubkey and remember the returned subscription id.

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -30,8 +30,8 @@ use crate::util::filters::filter_giftwrap_to_recipient;
 use crate::util::order_utils::{
     inferred_status_from_trade_action, map_action_to_status, should_apply_status_transition,
 };
+use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 use crate::util::types::{determine_message_type, MessageType};
-use crate::SETTINGS;
 
 pub const FETCH_EVENTS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const PENDING_WAITER_GC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
@@ -176,13 +176,9 @@ pub async fn send_dm(
     payload: String,
     expiration: Option<Timestamp>,
     to_user: bool,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
-    let pow: u8 = SETTINGS
-        .get()
-        .ok_or_else(|| {
-            anyhow::anyhow!("Settings not initialized. Please restart the application.")
-        })?
-        .pow;
+    let pow = nostr_pow_from_instance(mostro_instance);
     let message_type = determine_message_type(to_user, false);
 
     let event = match message_type {

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -27,10 +27,10 @@ use crate::ui::order_message_to_notification;
 use crate::ui::{MessageNotification, OrderMessage};
 use crate::util::db_utils::{delete_order_by_id, update_order_status};
 use crate::util::filters::filter_giftwrap_to_recipient;
+use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 use crate::util::order_utils::{
     inferred_status_from_trade_action, map_action_to_status, should_apply_status_transition,
 };
-use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 use crate::util::types::{determine_message_type, MessageType};
 
 pub const FETCH_EVENTS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
@@ -168,6 +168,7 @@ fn trade_message_is_terminal(message: &Message) -> bool {
 }
 
 /// Send a direct message to a receiver
+#[allow(clippy::too_many_arguments)]
 pub async fn send_dm(
     client: &Client,
     identity_keys: Option<&Keys>,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -29,7 +29,7 @@ pub use fatal::{
 pub use filters::{create_filter, create_seven_days_filter, filter_giftwrap_to_recipient};
 pub use mostro_info::{
     fetch_mostro_instance_info, fetch_mostro_instance_info_from_settings, format_instance_info_age,
-    mostro_info_from_tags, MostroInstanceInfo, MOSTRO_INSTANCE_INFO_KIND,
+    mostro_info_from_tags, nostr_pow_from_instance, MostroInstanceInfo, MOSTRO_INSTANCE_INFO_KIND,
 };
 pub use network::{any_relay_reachable, connect_client_safely};
 pub use order_utils::{fetch_events_list, get_disputes, get_orders, send_new_order, take_order};

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -314,13 +314,27 @@ mod tests {
 
     #[test]
     fn nostr_pow_from_instance_uses_tag_and_clamps() {
-        let mut info = MostroInstanceInfo::default();
-        info.pow = Some(0);
-        assert_eq!(nostr_pow_from_instance(Some(&info)), 0);
-        info.pow = Some(8);
-        assert_eq!(nostr_pow_from_instance(Some(&info)), 8);
-        info.pow = Some(u32::MAX);
-        assert_eq!(nostr_pow_from_instance(Some(&info)), u8::MAX);
+        assert_eq!(
+            nostr_pow_from_instance(Some(&MostroInstanceInfo {
+                pow: Some(0),
+                ..Default::default()
+            })),
+            0
+        );
+        assert_eq!(
+            nostr_pow_from_instance(Some(&MostroInstanceInfo {
+                pow: Some(8),
+                ..Default::default()
+            })),
+            8
+        );
+        assert_eq!(
+            nostr_pow_from_instance(Some(&MostroInstanceInfo {
+                pow: Some(u32::MAX),
+                ..Default::default()
+            })),
+            u8::MAX
+        );
     }
 
     // Fetch tests would require a mock or test double for nostr_sdk::Client

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -92,6 +92,15 @@ impl MostroInstanceInfo {
     }
 }
 
+/// NIP-13 difficulty bits for outbound events from cached Mostro instance info (kind 38385 tag `pow`).
+/// Returns `0` when info is missing or the tag is absent. Values above `u8::MAX` clamp to 255.
+pub fn nostr_pow_from_instance(instance: Option<&MostroInstanceInfo>) -> u8 {
+    instance
+        .and_then(|i| i.pow)
+        .map(|n| (n.min(u8::MAX as u32)) as u8)
+        .unwrap_or(0)
+}
+
 /// Build a `MostroInstanceInfo` from the tags of a kind 38385 event.
 ///
 /// Unknown tags are ignored. Missing tags simply leave the corresponding
@@ -292,6 +301,26 @@ mod tests {
         assert_eq!(result.mostro_version.as_deref(), Some("0.1.0"));
         assert_eq!(result.max_order_amount, Some(1_000_000));
         assert_eq!(result.fiat_currencies_accepted, vec!["USD", "EUR"]);
+    }
+
+    #[test]
+    fn nostr_pow_from_instance_none_or_missing_tag_is_zero() {
+        assert_eq!(nostr_pow_from_instance(None), 0);
+        assert_eq!(
+            nostr_pow_from_instance(Some(&MostroInstanceInfo::default())),
+            0
+        );
+    }
+
+    #[test]
+    fn nostr_pow_from_instance_uses_tag_and_clamps() {
+        let mut info = MostroInstanceInfo::default();
+        info.pow = Some(0);
+        assert_eq!(nostr_pow_from_instance(Some(&info)), 0);
+        info.pow = Some(8);
+        assert_eq!(nostr_pow_from_instance(Some(&info)), 8);
+        info.pow = Some(u32::MAX);
+        assert_eq!(nostr_pow_from_instance(Some(&info)), u8::MAX);
     }
 
     // Fetch tests would require a mock or test double for nostr_sdk::Client

--- a/src/util/order_utils/execute_add_invoice.rs
+++ b/src/util/order_utils/execute_add_invoice.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::models::Order;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::handle_mostro_response;
 
 /// Verify if an invoice is valid
@@ -28,6 +29,7 @@ pub async fn execute_add_invoice(
     pool: &sqlx::sqlite::SqlitePool,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get order from order id
     let order = Order::get_by_id(pool, &order_id.to_string()).await?;
@@ -80,6 +82,7 @@ pub async fn execute_add_invoice(
         message_json,
         None,
         false,
+        mostro_instance,
     );
 
     // Wait for the DM to be sent from mostro

--- a/src/util/order_utils/execute_admin_add_solver.rs
+++ b/src/util/order_utils/execute_admin_add_solver.rs
@@ -5,6 +5,7 @@ use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
 use crate::util::dm_utils::send_dm;
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::SETTINGS;
 
 /// Add a new solver to the Mostro network
@@ -13,6 +14,7 @@ pub async fn execute_admin_add_solver(
     solver_pubkey: &str,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get admin keys from settings
     let settings = SETTINGS
@@ -46,6 +48,7 @@ pub async fn execute_admin_add_solver(
         add_solver_message,
         None,
         false,
+        mostro_instance,
     )
     .await?;
 

--- a/src/util/order_utils/execute_admin_cancel.rs
+++ b/src/util/order_utils/execute_admin_cancel.rs
@@ -5,6 +5,7 @@ use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
 use crate::util::dm_utils::send_dm;
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::SETTINGS;
 
 /// Cancel a dispute and refund the seller (AdminCancel action).
@@ -39,6 +40,7 @@ pub async fn execute_admin_cancel(
     order_id: &Uuid,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get admin keys from settings
     let settings = SETTINGS
@@ -67,6 +69,7 @@ pub async fn execute_admin_cancel(
         cancel_message,
         None,
         false,
+        mostro_instance,
     )
     .await?;
 

--- a/src/util/order_utils/execute_admin_settle.rs
+++ b/src/util/order_utils/execute_admin_settle.rs
@@ -5,6 +5,7 @@ use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
 use crate::util::dm_utils::send_dm;
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::SETTINGS;
 
 /// Settle a dispute in favor of the buyer (AdminSettle action).
@@ -39,6 +40,7 @@ pub async fn execute_admin_settle(
     order_id: &Uuid,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get admin keys from settings
     let settings = SETTINGS
@@ -67,6 +69,7 @@ pub async fn execute_admin_settle(
         settle_message,
         None,
         false,
+        mostro_instance,
     )
     .await?;
 

--- a/src/util/order_utils/execute_finalize_dispute.rs
+++ b/src/util/order_utils/execute_finalize_dispute.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::models::AdminDispute;
+use crate::util::mostro_info::MostroInstanceInfo;
 
 use super::{execute_admin_cancel, execute_admin_settle};
 
@@ -48,6 +49,7 @@ pub async fn execute_finalize_dispute(
     mostro_pubkey: PublicKey,
     pool: &SqlitePool,
     is_settle: bool,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // First, fetch the dispute and check if it's already finalized
     let dispute_id_str = dispute_id.to_string();
@@ -92,9 +94,9 @@ pub async fn execute_finalize_dispute(
 
     // Execute the appropriate action (settle or cancel) using the order ID
     let result = if is_settle {
-        execute_admin_settle(&order_id, client, mostro_pubkey).await
+        execute_admin_settle(&order_id, client, mostro_pubkey, mostro_instance).await
     } else {
-        execute_admin_cancel(&order_id, client, mostro_pubkey).await
+        execute_admin_cancel(&order_id, client, mostro_pubkey, mostro_instance).await
     };
 
     result?; // Propagate error if action failed

--- a/src/util/order_utils/execute_send_msg.rs
+++ b/src/util/order_utils/execute_send_msg.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::models::{Order, User};
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::handle_mostro_response;
 
 async fn create_msg_payload(
@@ -47,6 +48,7 @@ pub async fn execute_send_msg(
     pool: &sqlx::SqlitePool,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get order from database
     let order = Order::get_by_id(pool, &order_id.to_string()).await?;
@@ -92,6 +94,7 @@ pub async fn execute_send_msg(
         message_json,
         None,
         false,
+        mostro_instance,
     );
 
     // Wait for the DM response from Mostro
@@ -148,6 +151,7 @@ pub async fn execute_rate_user(
     pool: &sqlx::SqlitePool,
     client: &Client,
     mostro_pubkey: PublicKey,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     if !(MIN_RATING..=MAX_RATING).contains(&rating) {
         return Err(anyhow::anyhow!(
@@ -186,6 +190,7 @@ pub async fn execute_rate_user(
         message_json,
         None,
         false,
+        mostro_instance,
     );
 
     let recv_event = wait_for_dm(&order_trade_keys, FETCH_EVENTS_TIMEOUT, sent_message).await?;

--- a/src/util/order_utils/execute_take_dispute.rs
+++ b/src/util/order_utils/execute_take_dispute.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 use crate::models::AdminDispute;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::fetch_order_fiat_from_relay;
 use crate::SETTINGS;
 
@@ -46,6 +47,7 @@ pub async fn execute_take_dispute(
     client: &Client,
     mostro_pubkey: PublicKey,
     pool: &SqlitePool,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
     // Get admin keys from settings
     let settings = SETTINGS
@@ -78,6 +80,7 @@ pub async fn execute_take_dispute(
         take_dispute_message,
         None,
         false,
+        mostro_instance,
     );
 
     // Wait for incoming DM response

--- a/src/util/order_utils/send_new_order.rs
+++ b/src/util/order_utils/send_new_order.rs
@@ -9,6 +9,7 @@ use crate::models::User;
 use crate::ui::FormState;
 use crate::util::db_utils::save_order;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::{create_order_result_success, handle_mostro_response};
 use crate::util::OrderDmSubscriptionCmd;
 use sqlx::SqlitePool;
@@ -21,6 +22,7 @@ pub async fn send_new_order(
     mostro_pubkey: PublicKey,
     form: FormState,
     dm_subscription_tx: Option<&UnboundedSender<OrderDmSubscriptionCmd>>,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<crate::ui::OperationResult, anyhow::Error> {
     // Parse form data
     let kind_str = if form.kind.trim().is_empty() {
@@ -137,6 +139,7 @@ pub async fn send_new_order(
         message_json,
         None,
         false,
+        mostro_instance,
     );
 
     // Wait for Mostro response (subscribes first, then sends message to avoid missing messages)

--- a/src/util/order_utils/take_order.rs
+++ b/src/util/order_utils/take_order.rs
@@ -4,10 +4,10 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 
 use crate::models::User;
-use crate::settings::Settings;
 use crate::ui::OperationResult;
 use crate::util::db_utils::save_order;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
+use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::{create_order_result_success, handle_mostro_response};
 use crate::util::OrderDmSubscriptionCmd;
 use tokio::sync::mpsc::UnboundedSender;
@@ -40,12 +40,12 @@ fn create_take_order_payload(
 pub async fn take_order(
     pool: &sqlx::sqlite::SqlitePool,
     client: &Client,
-    _settings: &Settings,
     mostro_pubkey: PublicKey,
     order: &SmallOrder,
     amount: Option<i64>,
     invoice: Option<String>,
     dm_subscription_tx: Option<&UnboundedSender<OrderDmSubscriptionCmd>>,
+    mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<crate::ui::OperationResult, anyhow::Error> {
     // Determine action based on order kind
     let action = match order.kind {
@@ -127,6 +127,7 @@ pub async fn take_order(
         message_json,
         None,
         false,
+        mostro_instance,
     );
 
     // Wait for Mostro response (subscribes first, then sends message to avoid missing messages)


### PR DESCRIPTION
## Summary

- **PoW source**: Remove local `pow` from `settings.toml` / `Settings`. NIP-13 difficulty for published events comes from the Mostro **instance status** event (kind **38385**, tag `pow`), via `nostr_pow_from_instance` (`src/util/mostro_info.rs`).
- **Threading**: `AppState.mostro_info` is passed through `EnterKeyContext` and into `send_dm`, all order/dispute/admin paths that publish to Mostro, and admin dispute chat (`chat_utils` / `input_helpers`).
- **Gift Wrap fix**: `EventBuilder::gift_wrap` in rust-nostr does not apply PoW to the **outer** kind **1059** event. We build the seal with `EventBuilder::seal` + `sign`, then wrap with a local `gift_wrap_from_seal_with_pow` that mirrors the SDK’s `gift_wrap_from_seal` but adds `.pow(pow)` before signing the **published** Gift Wrap so instances that require PoW accept the event.

## Breaking / migration

- **`pow` removed from settings**: Existing `settings.toml` files may still contain `pow = …`; serde ignores unknown keys. Users should rely on instance info (Mostro Info tab / startup fetch).

## Docs

- README and `docs/STARTUP_AND_CONFIG.md` updated to describe PoW from 38385, not settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Proof-of-work difficulty is now sourced from the Mostro instance status event (kind 38385); the `pow` setting was removed from settings.toml and UI-generated defaults.

* **Behavior**
  * Outbound messages (DMs and wrapped Gift Wrap events) apply instance-derived PoW when publishing.

* **Documentation**
  * Updated docs to describe instance-based PoW sourcing and outbound PoW handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->