### PR TITLE
feat(ui): hold-invoice YES/NO/CANCEL popup and cooperative cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -226,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -309,9 +309,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -431,7 +431,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -537,8 +537,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.0.7+spec-1.1.0",
- "winnow 1.0.0",
+ "toml 1.1.2+spec-1.1.0",
+ "winnow 1.0.2",
  "yaml-rust2",
 ]
 
@@ -665,7 +665,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -841,7 +841,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -1263,7 +1263,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1337,6 +1337,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1442,9 +1448,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1456,7 +1462,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1464,15 +1469,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1527,12 +1531,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1540,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1553,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1567,15 +1572,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1587,15 +1592,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1655,12 +1660,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1717,9 +1722,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1749,7 +1754,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1758,9 +1763,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -1774,10 +1801,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1827,9 +1856,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1839,14 +1868,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1882,11 +1911,11 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1897,9 +1926,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1943,9 +1972,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2015,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2061,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.8.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f746949447c5ce5d869205fc9f4b3792b28122b68f3171b2c97274a79b94dc"
+checksum = "08956454941d9577a2cde63ae6ee5d8bac4ffeee8398d02aa844ad4b3638723a"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -2096,7 +2125,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2188,16 +2217,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2264,7 +2293,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -2276,7 +2305,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -2287,7 +2316,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2306,7 +2335,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2317,7 +2346,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2506,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2538,12 +2567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2582,7 +2605,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2608,9 +2631,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2651,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -2691,7 +2714,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2740,9 +2763,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2751,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2761,13 +2784,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2810,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2834,7 +2857,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -2886,7 +2909,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -2905,16 +2928,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3011,11 +3034,11 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3055,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3074,7 +3097,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3083,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3148,9 +3171,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3222,7 +3245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -3242,7 +3265,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3261,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3322,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3412,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3561,7 +3584,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -3582,7 +3605,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -3603,7 +3626,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3620,7 +3643,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -3783,7 +3806,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -3903,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3928,9 +3951,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3945,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4033,15 +4056,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4055,27 +4078,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4098,7 +4121,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4162,9 +4185,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-scrollview"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ada5290cf63e5e718a13111020398979975d4df556a55ae88014aa8850f171"
+checksum = "94a94f467c7ac7c291039b0733e3b2d379c77884e34fc27d167921fc1ab4842f"
 dependencies = [
  "indoc",
  "ratatui-core",
@@ -4182,7 +4205,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -4198,9 +4221,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -4237,9 +4260,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -4331,14 +4354,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -4391,11 +4414,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4404,7 +4427,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4415,9 +4438,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4428,23 +4451,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4452,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4465,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4500,7 +4519,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4508,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4528,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4541,14 +4560,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5027,9 +5046,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -5042,6 +5061,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5092,7 +5117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -5124,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11rb"
@@ -5158,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5169,9 +5194,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5181,18 +5206,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5201,18 +5226,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5228,9 +5253,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5239,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5250,9 +5275,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5273,9 +5298,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -232,6 +232,7 @@ The `orders` table is essential for:
 - **Order Recovery**: Allows the client to recover active orders on startup (`Order::get_startup_active_orders`, `hydrate_startup_active_order_dm_state`)
 - **State Synchronization**: Enables the "fetch-on-startup" strategy to sync with Mostro daemon
 - **Trade History**: Maintains a local record of orders and trades
+- **My Trades static header (UI)**: on user history sync, `sync_user_order_history_messages_from_db` in `src/ui/helpers/startup.rs` seeds `AppState.order_chat_static` from existing `orders` rows (`id`, `kind`, `created_at`, `trade_index`, `is_mine`, and trade public key derived from `trade_keys`) so the in-app header (order id, type, created time, trade index, initiator) is stable across process restarts without re-folding the DM list.
 
 #### Data Persistence
 

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -456,6 +456,22 @@ When the counterparty initiates cooperative cancel, Mostrix receives a trade DM 
 
 When the relay later delivers **`CooperativeCancelAccepted`**, the DM listener treats it as **terminal** (`trade_message_is_terminal`), may update status again if needed, and performs the usual subscription cleanup. See **DM_LISTENER_FLOW.md** (terminal cleanup, status inference).
 
+### Invoice notifications in Messages tab
+
+For invoice-related trade actions, the Messages Enter path uses `UiMode::NewMessageNotification` with a dual-action popup model:
+
+- Action mapping:
+  - `AddInvoice` and `WaitingBuyerInvoice` -> AddInvoice popup mode.
+  - `PayInvoice` and `WaitingSellerToPay` -> PayInvoice popup mode.
+- Popup selection:
+  - Left/Right toggles between **Primary** and **Cancel Order**.
+  - Enter confirms the selected action.
+- Cancel path:
+  - Selecting **Cancel Order** sends `Action::Cancel` through `execute_send_msg`, reusing the existing async order-result channel flow.
+- Paste/copy details:
+  - AddInvoice supports bracketed paste plus key/mouse fallbacks where terminals do not emit `Event::Paste`.
+  - PayInvoice keeps copy (`C`) + scroll behavior while supporting cancel selection.
+
 ### Rating the counterparty (`RateUser`)
 
 After a successful trade, Mostro may prompt with a DM whose **`action`** is **`rate`** and **`payload`** is **`null`**, while the local DB row may still show **`success`**. The client must not infer the UI step from **`Status::Success` alone** for that message.

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -309,9 +309,10 @@ In addition to relay-driven trade DMs, Mostrix keeps a lightweight local transcr
 - **Incremental merge**: `apply_user_order_chat_updates` deduplicates by `(timestamp, content)`, persists new entries, and advances per-order cursors.
 - **Compatibility parsing**: legacy sender labels from older files (`Admin`, `Admin to Buyer`, `Admin to Seller`, `Buyer`, `Seller`) are mapped to `You/Peer` when loading.
 - **UI selection safety**: the "My Trades" sidebar and Enter/send handlers resolve the active order list from the same shared projection (`helpers::build_active_order_chat_list`), ensuring `selected_order_chat_idx` cannot target a different order than the highlighted row.
-- **Header fields from DMs**: that projection walks `AppState.messages` per order and merges `Payload::Order` (trade pubkeys, amounts, etc.) with `Payload::Peer` so counterparty **`UserInfo`** can populate buyer/seller rating display when the daemon includes peer reputation events.
+- **My Trades static header (`order_chat_static`)**: in-memory map `AppState.order_chat_static` (see `src/ui/orders.rs` — `OrderChatStaticHeader`) is written by `handle_operation_result` in `src/util/dm_utils/order_ch_mng.rs` on `OperationResult::Success` and `PaymentRequestRequired` (after take / PayInvoice path), and populated from the local `orders` table during `sync_user_order_history_messages_from_db` in `src/ui/helpers/startup.rs`. It is cleared for removed trades when `TradeClosed` / `OrderHistoryDeleted` are handled. It supplies stable header fields (order id, kind, created time, trade index, initiator) so the UI does not depend on folding those out of the DM stream.
+- **Live fields from DMs**: the projection over `AppState.messages` per order merges `Payload::Order` (first economic snapshot, buyer/seller trade pubkeys) with `Payload::Peer` so counterparty `UserInfo` can populate buyer/seller rating, and `order_status` updates status for the header and for `resolve_selected_mytrades_order_status` in `src/ui/key_handler/chat_helpers.rs`.
 
-**Source**: `src/ui/helpers/startup.rs`, `src/ui/helpers/chat_storage.rs`, `src/ui/helpers/order_chat_projection.rs`, `src/util/chat_utils.rs`
+**Source**: `src/ui/helpers/startup.rs`, `src/ui/helpers/chat_storage.rs`, `src/ui/helpers/order_chat_projection.rs`, `src/util/dm_utils/order_ch_mng.rs`, `src/util/chat_utils.rs`
 
 ### Message Parsing
 **Source**: `src/util/dm_utils/mod.rs:137`

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 
 ## UI & order flows
 
-- **TUI Interface**: [TUI_INTERFACE.md](TUI_INTERFACE.md) — Navigation, modes, state
+- **TUI Interface**: [TUI_INTERFACE.md](TUI_INTERFACE.md) — Navigation, modes, state; My Trades (static `order_chat_static` header vs `build_active_order_chat_list` live fields)
 - **UI constants** (`src/ui/constants.rs`): Shared copy (footers, help, **`StepLabel`** for the Messages tab buy/sell timeline)
 - **Buy order flow (spec)**: [buy order flow.md](buy%20order%20flow.md)
 - **Sell order flow (spec)**: [sell order flow.md](sell%20order%20flow.md)

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -201,6 +201,9 @@ The `handle_key_event` function dispatches keys based on the current `UiMode`.
 
 - **Forms**: Character input and Backspace are handled by `handle_char_input` and `handle_backspace` for fields in `FormState`.
 - **Invoices**: `handle_invoice_input` handles text entry for Lightning invoices, including support for bracketed paste mode.
+  - `AddInvoice` popup paste fallback: when `Event::Paste` is unavailable, key shortcuts (`Shift+Insert`, `Ctrl+V`, `Ctrl+Shift+V` where emitted) paste from clipboard.
+  - Windows right-click fallback: mouse right-click in `AddInvoice` popup tries clipboard paste via a dedicated `Event::Mouse` path.
+  - `just_pasted` is preserved so immediate `Enter` after paste does not accidentally submit.
 - **Admin Chat**: `handle_admin_chat_input` handles direct text input in the "Disputes in Progress" tab:
   - Takes priority over other input handling (except invoice and key input)
   - Supports direct character input and backspace
@@ -226,6 +229,11 @@ Displays a list of direct messages related to the user's trades. Messages are tr
 
 - **Enter** on a row: opens an invoice popup, a confirmation popup, the **rating** overlay (`RatingOrder`) when the daemon sent **`action: rate`**, or an info line for other actions (`src/ui/key_handler/enter_handlers.rs`).
 - **Rating overlay**: `render_rating_order` in `src/ui/tabs/tab_content.rs`; keys **Left/Right** or **+/-** adjust stars, **Enter** submits, **Esc** closes.
+- **Invoice popups (`NewMessageNotification`)**:
+  - `AddInvoice` / `WaitingBuyerInvoice` map to invoice-submit popup mode.
+  - `PayInvoice` / `WaitingSellerToPay` map to payment popup mode.
+  - Both popups provide two actions (`Primary` + `Cancel Order`) via Left/Right selection; Enter confirms the selected action.
+  - `PayInvoice` keeps copy (`C`) and scroll (`Up/Down`, `PageUp/PageDown`) behavior while adding cancel selection.
 
 **`ViewingMessage` (trade confirmations)** — `render_message_view` in `src/ui/tabs/tab_content.rs`:
 

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -253,7 +253,9 @@ A stateful form for creating new orders. It supports both fixed amounts and fiat
 
 The My Trades workspace (`src/ui/tabs/order_in_progress_tab.rs`) now shows richer order context and cleaner chat readability:
 
-- **Header metadata**: includes order id, trade index, kind, status, initiator role/pubkey (truncated), created-at timestamp, amount, payment method, and premium.
+- **Header metadata (two layers)**:
+  - **Stable (one-time)**: order id, kind, created-at, trade index, and initiator (role: Maker/Taker + truncated trade pubkey) come from `OrderChatStaticHeader` in `AppState.order_chat_static`. The map is filled when the user **creates** an order (maker) or **takes** an order (taker, including the `PaymentRequestRequired` / PayInvoice path), and from `sync_user_order_history_messages_from_db` in `src/ui/helpers/startup.rs` (parses local `orders` rows so restarts do not lose the header). Entries are removed when a trade is closed or history cleanup deletes the row (`handle_operation_result` in `src/util/dm_utils/order_ch_mng.rs`).
+  - **Live (from DMs)**: **status**, **amount / fiats**, **payment method**, **premium**, and **buyer/seller rating** (when present) still come from the message projection (see below).
 - **Privacy / ratings**: there is no placeholder row for **`Privacy:`** / **`Buyer -`** / **`Seller -`** until trade privacy can be sourced from the same context as disputes (DM `SmallOrder` does not carry those flags). **Buyer Rating:** / **Seller Rating:** lines are shown only when reputation exists: `helpers::build_active_order_chat_list` merges `Payload::Peer` with `UserInfo` when `peer.pubkey` matches `buyer_trade_pubkey` / `seller_trade_pubkey` from `Payload::Order`, and the header uses `helpers::format_user_rating` for display.
 - **Chat rendering**: user/peer messages are wrapped to fit pane width (including splitting overlong tokens by **Unicode character** count so lines do not overflow); peer messages are right-aligned for better sender separation.
 - **Empty states**: sidebar/main panel copy is clearer ("No active orders yet"), and the help hint remains visible in the footer.
@@ -264,8 +266,8 @@ The My Trades workspace (`src/ui/tabs/order_in_progress_tab.rs`) now shows riche
   - **Shift+R** release sats (YES/NO popup).
   - **Shift+V** rate counterparty (opens 1–5 star rating picker).
   - **Shift+H** opens the shortcuts popup for the current tab.
-- **Data extraction**: active-order list rows now retain extra fields (kind, created_at, trade_index, payment_method, premium, initiator metadata) so rendering does not need to re-derive them later.
-- **Selection correctness (shared projection)**: both the sidebar list and Enter/send handlers derive the selected order from the same projection (`helpers::build_active_order_chat_list`), with identical filtering and ordering. This prevents UI/action desync where `selected_order_chat_idx` could resolve a different trade than the highlighted row.
+- **Projection vs static**: the DM-based list row (`OrderChatListItem` in `src/ui/helpers/order_chat_projection.rs`) holds **live** fields only: `status`, first-seen **economic** snapshot from `Payload::Order` (amount, fiat, payment, premium), `trade_index` (from any message in the order), and buyer/seller **trade pubkeys** plus **reputation** from `Payload::Peer`. It no longer carries kind, `created_at`, or initiator metadata (those are on `order_chat_static` above).
+- **Selection correctness (shared projection)**: both the sidebar list and Enter/send handlers derive the selected order from the same projection (`helpers::build_active_order_chat_list`), with identical filtering and ordering. This prevents UI/action desync where `selected_order_chat_idx` could resolve a different trade than the highlighted row. **Trade ID** in the header still falls back to projection `trade_index` if a static entry is not yet in the map (e.g. race before the result handler runs).
 
 **Source**: `src/ui/tabs/order_in_progress_tab.rs`
 
@@ -300,8 +302,8 @@ The previous monolithic helper file was split into focused modules under `src/ui
 - `chat_render.rs`: wrapped line formatting plus list/scrollview builders.
 - `chat_storage.rs`: transcript parse/load/save logic for disputes and user order chat.
 - `attachments.rs`: attachment JSON parsing, placeholders, and toast expiration/building.
-- `order_chat_projection.rs`: shared "My Trades" active-order projection (single source of truth for sidebar ordering and Enter/action resolution); merges `Payload::Order` fields and attributes `Payload::Peer` reputation to buyer/seller when pubkeys match trade pubkeys.
-- `startup.rs`: startup hydration/recovery and applying chat updates to app state.
+- `order_chat_projection.rs`: shared "My Trades" active-order projection (single source of truth for sidebar ordering and Enter/action resolution). Merges `Payload::Order` (economic first snapshot, buyer/seller trade pubkeys) and `Payload::Peer` (reputation when pubkeys match). Payload merge runs even when `order_kind` is missing on a message, so **Peer** reputation is not skipped for odd DM shapes.
+- `startup.rs`: startup hydration/recovery, applying chat updates to app state, and seeding **`order_chat_static`** from `orders` when syncing user history.
 
 #### Data Structures
 

--- a/docs/buy order flow.md
+++ b/docs/buy order flow.md
@@ -86,13 +86,15 @@ For actions that require explicit confirmation (e.g. **`HoldInvoicePaymentAccept
 ### Cancel and dispute from `active`
 
 - From **`active`** (and adjacent states if the protocol allows), Enter should offer paths toward **cooperative cancel** and **dispute** (e.g. submenu or dedicated mode), not only passive info.
-- **Before `active`**, unilateral cancel (if supported) should be reachable from the same surface or a documented alternative (key binding / command). Exact UX is **TBD**; this spec only requires that Messages tab not rely solely on “info” popups for those intents.
+- **Before `active`**, unilateral cancel is reachable from the same Messages popup surface for invoice/payment phases (see current implementation pointer below).
 
 ### Current implementation pointer (non-normative)
 
 In **`src/ui/key_handler/enter_handlers.rs`**, Messages **Enter** is routed by **`Action`** (and by **`order_id`** where required):
 
 - **`AddInvoice` / `PayInvoice`** → invoice / payment notification popup (`NewMessageNotification`).
+- **`WaitingBuyerInvoice` / `WaitingSellerToPay`** also map to the same invoice/payment popup modes on Enter.
+- Invoice/payment popup action model now includes **primary action + `Cancel Order`** (Left/Right select, Enter confirm), so pre-active cancel is directly available from the popup.
 - **`HoldInvoicePaymentAccepted` / `FiatSentOk`** → confirmation popup (`ViewingMessage` with yes/no where applicable).
 - **`Rate`** → **rating popup** (`UiMode::RatingOrder`): choose **1–5** stars, **Enter** submits **`RateUser`** + **`RatingUser`** via **`execute_rate_user`** in `src/util/order_utils/execute_send_msg.rs` (Mostro resolves the counterparty; only **`order_id`** + rating are sent).
 - **Else** → informational `OperationResult::Info` (no send).

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::settings::{init_settings, Settings};
 use crate::ui::helpers::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     expire_attachment_toast, hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
-    load_user_order_chats_at_startup,
+    load_user_order_chats_at_startup, sync_user_order_history_messages_from_db,
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
@@ -353,6 +353,9 @@ async fn main() -> Result<(), anyhow::Error> {
                         || (msg.contains("Dispute") && (msg.contains("settled") || msg.contains("canceled"))));
 
                     handle_operation_result(result, &mut app);
+                    if app.user_role == UserRole::User {
+                        sync_user_order_history_messages_from_db(&pool, &mut app).await;
+                    }
 
                     // If this is an Info result about taking or finalizing a dispute, refresh the disputes list
                     if is_dispute_related && app.user_role == UserRole::Admin {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use crate::ui::helpers::{
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
-    reload_runtime_session_after_reconnect, spawn_refresh_mostro_info_task, AppChannels,
-    RuntimeReconnectContext,
+    handle_mouse_invoice_paste_fallback, reload_runtime_session_after_reconnect,
+    spawn_refresh_mostro_info_task, AppChannels, RuntimeReconnectContext,
 };
 use crate::ui::network_status::spawn_network_status_monitor;
 use crate::ui::{MostroInfoFetchResult, OperationResult};
@@ -43,7 +43,7 @@ use crossterm::terminal::{
 };
 use crossterm::{
     self,
-    event::{Event, KeyEvent, MouseButton, MouseEventKind},
+    event::{Event, KeyEvent},
 };
 use fern::Dispatch;
 use futures::StreamExt;
@@ -59,16 +59,6 @@ use zeroize::Zeroizing;
 pub static SETTINGS: OnceLock<Settings> = OnceLock::new();
 
 use crate::ui::{AdminMode, AdminTab, AppState, Tab, UiMode, UserRole};
-
-fn read_clipboard_text_best_effort() -> Option<String> {
-    match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
-        Ok(t) => Some(t),
-        Err(e) => {
-            log::warn!("Failed to read clipboard text: {}", e);
-            None
-        }
-    }
-}
 
 /// Initialize logger function
 fn setup_logger(level: &str) -> Result<(), fern::InitError> {
@@ -524,50 +514,8 @@ async fn main() -> Result<(), anyhow::Error> {
                     continue;
                 }
 
-                // Mouse right-click paste fallback for terminals that do not emit Event::Paste.
-                if let Event::Mouse(mouse_event) = event {
-                    if matches!(
-                        mouse_event.kind,
-                        MouseEventKind::Down(MouseButton::Right)
-                    ) {
-                        log::debug!(
-                            "Detected right-click mouse event at x={}, y={}",
-                            mouse_event.column,
-                            mouse_event.row
-                        );
-                        if let UiMode::NewMessageNotification(
-                            _,
-                            Action::AddInvoice,
-                            ref mut invoice_state,
-                        ) = app.mode
-                        {
-                            if invoice_state.focused {
-                                if let Some(text) = read_clipboard_text_best_effort() {
-                                    let filtered_text: String = text
-                                        .chars()
-                                        .filter(|c| !c.is_control() || *c == '\t')
-                                        .collect();
-                                    if !filtered_text.is_empty() {
-                                        log::debug!(
-                                            "Right-click paste fallback appended {} chars to AddInvoice input",
-                                            filtered_text.chars().count()
-                                        );
-                                        invoice_state.invoice_input.push_str(&filtered_text);
-                                        invoice_state.just_pasted = true;
-                                    } else {
-                                        log::debug!(
-                                            "Right-click paste fallback found only control characters"
-                                        );
-                                    }
-                                } else {
-                                    log::debug!(
-                                        "Right-click paste fallback could not read clipboard text"
-                                    );
-                                }
-                                continue;
-                            }
-                        }
-                    }
+                if handle_mouse_invoice_paste_fallback(&event, &mut app) {
+                    continue;
                 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::settings::{init_settings, Settings};
 use crate::ui::helpers::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     expire_attachment_toast, hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
-    load_user_order_chats_at_startup, sync_user_order_history_messages_from_db,
+    load_user_order_chats_at_startup,
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
@@ -43,7 +43,7 @@ use crossterm::terminal::{
 };
 use crossterm::{
     self,
-    event::{Event, KeyEvent},
+    event::{Event, KeyEvent, MouseButton, MouseEventKind},
 };
 use fern::Dispatch;
 use futures::StreamExt;
@@ -59,6 +59,16 @@ use zeroize::Zeroizing;
 pub static SETTINGS: OnceLock<Settings> = OnceLock::new();
 
 use crate::ui::{AdminMode, AdminTab, AppState, Tab, UiMode, UserRole};
+
+fn read_clipboard_text_best_effort() -> Option<String> {
+    match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
+        Ok(t) => Some(t),
+        Err(e) => {
+            log::warn!("Failed to read clipboard text: {}", e);
+            None
+        }
+    }
+}
 
 /// Initialize logger function
 fn setup_logger(level: &str) -> Result<(), fern::InitError> {
@@ -353,9 +363,10 @@ async fn main() -> Result<(), anyhow::Error> {
                         || (msg.contains("Dispute") && (msg.contains("settled") || msg.contains("canceled"))));
 
                     handle_operation_result(result, &mut app);
-                    if app.user_role == UserRole::User {
-                        sync_user_order_history_messages_from_db(&pool, &mut app).await;
-                    }
+                    // TODO: Uncomment this when we have a way to sync user order history messages from the DB
+                    // if app.user_role == UserRole::User {
+                    //     sync_user_order_history_messages_from_db(&pool, &mut app).await;
+                    // }
 
                     // If this is an Info result about taking or finalizing a dispute, refresh the disputes list
                     if is_dispute_related && app.user_role == UserRole::Admin {
@@ -511,6 +522,52 @@ async fn main() -> Result<(), anyhow::Error> {
                         app.observer_shared_key_input.push_str(&filtered_text);
                     }
                     continue;
+                }
+
+                // Mouse right-click paste fallback for terminals that do not emit Event::Paste.
+                if let Event::Mouse(mouse_event) = event {
+                    if matches!(
+                        mouse_event.kind,
+                        MouseEventKind::Down(MouseButton::Right)
+                    ) {
+                        log::debug!(
+                            "Detected right-click mouse event at x={}, y={}",
+                            mouse_event.column,
+                            mouse_event.row
+                        );
+                        if let UiMode::NewMessageNotification(
+                            _,
+                            Action::AddInvoice,
+                            ref mut invoice_state,
+                        ) = app.mode
+                        {
+                            if invoice_state.focused {
+                                if let Some(text) = read_clipboard_text_best_effort() {
+                                    let filtered_text: String = text
+                                        .chars()
+                                        .filter(|c| !c.is_control() || *c == '\t')
+                                        .collect();
+                                    if !filtered_text.is_empty() {
+                                        log::debug!(
+                                            "Right-click paste fallback appended {} chars to AddInvoice input",
+                                            filtered_text.chars().count()
+                                        );
+                                        invoice_state.invoice_input.push_str(&filtered_text);
+                                        invoice_state.just_pasted = true;
+                                    } else {
+                                        log::debug!(
+                                            "Right-click paste fallback found only control characters"
+                                        );
+                                    }
+                                } else {
+                                    log::debug!(
+                                        "Right-click paste fallback could not read clipboard text"
+                                    );
+                                }
+                                continue;
+                            }
+                        }
+                    }
                 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::settings::{init_settings, Settings};
 use crate::ui::helpers::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     expire_attachment_toast, hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
-    load_user_order_chats_at_startup,
+    load_user_order_chats_at_startup, sync_user_order_history_messages_from_db,
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
@@ -272,6 +272,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let messages_clone = Arc::clone(&app.messages);
     let message_notification_tx_clone = message_notification_tx.clone();
     let pending_notifications_clone = Arc::clone(&app.pending_notifications);
+    let dropped_user_history_clone = Arc::clone(&app.dropped_user_history_order_ids);
     let mut message_listener_handle: JoinHandle<()> = tokio::spawn(async move {
         catch_unwind_request_fatal_restart("trade DM listener", async move {
             listen_for_order_messages(
@@ -282,6 +283,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 messages_clone,
                 message_notification_tx_clone,
                 pending_notifications_clone,
+                dropped_user_history_clone,
                 dm_subscription_rx,
             )
             .await;
@@ -351,12 +353,12 @@ async fn main() -> Result<(), anyhow::Error> {
                     let is_dispute_related = matches!(&result, OperationResult::Info(msg)
                         if (msg.contains("Dispute") && msg.contains("taken successfully"))
                         || (msg.contains("Dispute") && (msg.contains("settled") || msg.contains("canceled"))));
+                    let resync_my_trades_from_db = matches!(&result, OperationResult::OrderHistoryDeleted { .. });
 
                     handle_operation_result(result, &mut app);
-                    // TODO: Uncomment this when we have a way to sync user order history messages from the DB
-                    // if app.user_role == UserRole::User {
-                    //     sync_user_order_history_messages_from_db(&pool, &mut app).await;
-                    // }
+                    if resync_my_trades_from_db && app.user_role == UserRole::User {
+                        sync_user_order_history_messages_from_db(&pool, &mut app).await;
+                    }
 
                     // If this is an Info result about taking or finalizing a dispute, refresh the disputes list
                     if is_dispute_related && app.user_role == UserRole::Admin {

--- a/src/models.rs
+++ b/src/models.rs
@@ -198,6 +198,20 @@ pub const TERMINAL_DM_STATUSES: &[&str] = &[
     "cooperatively-canceled",
 ];
 
+/// Kebab-case terminal statuses for order-history retention/cleanup operations.
+pub const TERMINAL_ORDER_HISTORY_STATUSES: &[&str] = &[
+    "success",
+    "canceled",
+    "canceled-by-admin",
+    "settled-by-admin",
+    "completed-by-admin",
+    "expired",
+    "cooperatively-canceled",
+];
+
+/// Kebab-case statuses eligible for bulk user cleanup in My Trades.
+pub const ORDER_HISTORY_BULK_DELETE_STATUSES: &[&str] = &["success", "canceled"];
+
 impl Order {
     /// Delete every row in `orders`. Used when rotating the user mnemonic so persisted trade keys
     /// cannot reference the previous seed.
@@ -541,6 +555,55 @@ impl Order {
             .fetch_all(pool)
             .await?;
         Ok(rows)
+    }
+
+    /// Fetches all locally-known user trade rows (maker + taker history) with persisted trade keys.
+    pub async fn get_user_history_orders(pool: &SqlitePool) -> Result<Vec<Order>> {
+        let rows = sqlx::query_as::<_, Order>(
+            r#"
+            SELECT * FROM orders
+            WHERE trade_keys IS NOT NULL
+              AND trade_keys != ''
+            ORDER BY COALESCE(last_seen_dm_ts, created_at, 0) DESC, id DESC
+            "#,
+        )
+        .fetch_all(pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Deletes one order row when it is in a terminal status.
+    /// Returns number of deleted rows (0 when order is non-terminal or missing).
+    pub async fn delete_terminal_order_by_id(pool: &SqlitePool, order_id: &str) -> Result<u64> {
+        let mut qb: QueryBuilder<'_, Sqlite> = QueryBuilder::new(
+            "DELETE FROM orders WHERE id = ? AND lower(COALESCE(status, '')) IN (",
+        );
+        qb.push_bind(order_id);
+        {
+            let mut separated = qb.separated(", ");
+            for s in TERMINAL_ORDER_HISTORY_STATUSES {
+                separated.push_bind(*s);
+            }
+        }
+        qb.push(")");
+        let result = qb.build().execute(pool).await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Deletes only success/canceled rows for user bulk cleanup.
+    /// Returns number of deleted rows.
+    pub async fn delete_bulk_history_cleanup_orders(pool: &SqlitePool) -> Result<u64> {
+        let mut qb: QueryBuilder<'_, Sqlite> =
+            QueryBuilder::new("DELETE FROM orders WHERE lower(COALESCE(status, '')) IN (");
+        {
+            let mut separated = qb.separated(", ");
+            for s in ORDER_HISTORY_BULK_DELETE_STATUSES {
+                separated.push_bind(*s);
+            }
+        }
+        qb.push(")");
+        let result = qb.build().execute(pool).await?;
+        Ok(result.rows_affected())
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -575,10 +575,9 @@ impl Order {
     /// Deletes one order row when it is in a terminal status.
     /// Returns number of deleted rows (0 when order is non-terminal or missing).
     pub async fn delete_terminal_order_by_id(pool: &SqlitePool, order_id: &str) -> Result<u64> {
-        let mut qb: QueryBuilder<'_, Sqlite> = QueryBuilder::new(
-            "DELETE FROM orders WHERE id = ? AND lower(COALESCE(status, '')) IN (",
-        );
+        let mut qb: QueryBuilder<'_, Sqlite> = QueryBuilder::new("DELETE FROM orders WHERE id = ");
         qb.push_bind(order_id);
+        qb.push(" AND lower(COALESCE(status, '')) IN (");
         {
             let mut separated = qb.separated(", ");
             for s in TERMINAL_ORDER_HISTORY_STATUSES {

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use uuid::Uuid;
 
 use mostro_core::prelude::Action;
 use zeroize::{Zeroize, Zeroizing};
@@ -14,7 +16,7 @@ use crate::ui::chat::{
 use crate::ui::navigation::{Tab, UserRole};
 use crate::ui::orders::{
     InvoiceInputState, KeyInputState, MessageNotification, MessageViewState, OperationResult,
-    OrderMessage, RatingOrderState,
+    OrderChatStaticHeader, OrderMessage, RatingOrderState,
 };
 use crate::ui::user_state::UserMode;
 use crate::util::MostroInstanceInfo;
@@ -130,6 +132,9 @@ pub struct AppState {
     pub mode: UiMode,
     pub messages: Arc<Mutex<Vec<OrderMessage>>>, // Messages related to orders
     pub active_order_trade_indices: Arc<Mutex<HashMap<uuid::Uuid, i64>>>, // Map order_id -> trade_index
+    /// Orders the user removed from local history this session; trade DMs for these ids are ignored
+    /// so relays cannot re-upsert deleted rows back into the UI.
+    pub dropped_user_history_order_ids: Arc<Mutex<HashSet<uuid::Uuid>>>,
     /// Per-order startup floor for invoice popups: notifications at or below this rumor timestamp
     /// are treated as historical and must not auto-open AddInvoice/PayInvoice modal.
     pub startup_popup_floor_ts: HashMap<uuid::Uuid, i64>,
@@ -137,6 +142,8 @@ pub struct AppState {
     pub selected_order_chat_idx: usize, // Selected order in Order Chat sidebar
     pub order_chat_input: String,
     pub order_chat_input_enabled: bool,
+    /// Per-order static header (id, kind, created_at, trade index, initiator) from take/create and DB.
+    pub order_chat_static: HashMap<Uuid, OrderChatStaticHeader>,
     pub order_chats: HashMap<String, Vec<UserOrderChatMessage>>, // Chat messages per order id
     pub order_chat_scrollview_state: tui_scrollview::ScrollViewState,
     pub order_chat_selected_message_idx: Option<usize>,
@@ -210,11 +217,13 @@ impl AppState {
             mode: UiMode::Normal,
             messages: Arc::new(Mutex::new(Vec::new())),
             active_order_trade_indices: Arc::new(Mutex::new(HashMap::new())),
+            dropped_user_history_order_ids: Arc::new(Mutex::new(HashSet::new())),
             startup_popup_floor_ts: HashMap::new(),
             selected_message_idx: 0,
             selected_order_chat_idx: 0,
             order_chat_input: String::new(),
             order_chat_input_enabled: true,
+            order_chat_static: HashMap::new(),
             order_chats: HashMap::new(),
             order_chat_scrollview_state: tui_scrollview::ScrollViewState::default(),
             order_chat_selected_message_idx: None,

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -94,7 +94,9 @@ impl Clone for UiMode {
             UiMode::ConfirmDeleteHistoryOrder(order_id, selected) => {
                 UiMode::ConfirmDeleteHistoryOrder(*order_id, *selected)
             }
-            UiMode::ConfirmBulkDeleteHistory(selected) => UiMode::ConfirmBulkDeleteHistory(*selected),
+            UiMode::ConfirmBulkDeleteHistory(selected) => {
+                UiMode::ConfirmBulkDeleteHistory(*selected)
+            }
             UiMode::ConfirmExit(selected) => UiMode::ConfirmExit(*selected),
             UiMode::ConfirmGenerateNewKeys(selected) => UiMode::ConfirmGenerateNewKeys(*selected),
             // Clamp cloning of secret mnemonic to avoid duplicating sensitive seed words.

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -43,6 +43,8 @@ pub enum UiMode {
     AddCurrency(KeyInputState),
     ConfirmCurrency(String, bool), // (currency_string, selected_button: true=Yes, false=No)
     ConfirmClearCurrencies(bool),  // (selected_button: true=Yes, false=No)
+    ConfirmDeleteHistoryOrder(uuid::Uuid, bool), // (order_id, selected_button)
+    ConfirmBulkDeleteHistory(bool), // (selected_button)
     ConfirmExit(bool),             // (selected_button: true=Yes, false=No)
 
     // Generate new keys flow (Settings tab)
@@ -89,6 +91,10 @@ impl Clone for UiMode {
                 UiMode::ConfirmCurrency(currency.clone(), *selected)
             }
             UiMode::ConfirmClearCurrencies(selected) => UiMode::ConfirmClearCurrencies(*selected),
+            UiMode::ConfirmDeleteHistoryOrder(order_id, selected) => {
+                UiMode::ConfirmDeleteHistoryOrder(*order_id, *selected)
+            }
+            UiMode::ConfirmBulkDeleteHistory(selected) => UiMode::ConfirmBulkDeleteHistory(*selected),
             UiMode::ConfirmExit(selected) => UiMode::ConfirmExit(*selected),
             UiMode::ConfirmGenerateNewKeys(selected) => UiMode::ConfirmGenerateNewKeys(*selected),
             // Clamp cloning of secret mnemonic to avoid duplicating sensitive seed words.

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -101,6 +101,19 @@ pub const HELP_MY_TRADES_FIAT_SENT_MSG: &str =
 pub const HELP_MY_TRADES_RELEASE_MSG: &str =
     "Release sats for this order? This sends a Release message.";
 
+/// Multi-line body for Messages-tab confirmation when Mostro reports hold invoice paid (`HoldInvoicePaymentAccepted`).
+/// Last line matches [`HELP_MY_TRADES_CANCEL_MSG`] (cooperative cancel).
+pub const VIEW_MESSAGE_HOLD_INVOICE_PREVIEW: &str = concat!(
+    "Hold invoice payment accepted — confirm fiat was sent?\n",
+    "\n",
+    "YES — Send FiatSent (you sent fiat).\n",
+    "NO — Close without sending.\n",
+    "CANCEL — Start cooperative cancel (both sides must agree; same as My Trades Shift+C).\n",
+    "\n",
+    "Cancel path: ",
+    "Cancel this order? This sends a cooperative Cancel request.",
+);
+
 // Help popup lines (Messages)
 pub const HELP_MSG_ENTER_OPEN: &str = "Enter: Open selected message";
 pub const HELP_MSG_SELECT: &str = "↑↓: Select message";

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -114,6 +114,14 @@ pub const VIEW_MESSAGE_HOLD_INVOICE_PREVIEW: &str = concat!(
     "Cancel this order? This sends a cooperative Cancel request.",
 );
 
+/// Multi-line body for `Action::BuyerTookOrder` in the Messages tab (waiting for buyer fiat; optional cooperative cancel).
+pub const VIEW_MESSAGE_BUYER_TOOK_ORDER_PREVIEW: &str = concat!(
+    "Buyer took order — do you want to start a cooperative cancel?\n",
+    "\n",
+    "CANCEL — Start cooperative cancel (both sides must agree; same as My Trades Shift+C).\n",
+    "NO — Close without canceling.\n",
+);
+
 // Help popup lines (Messages)
 pub const HELP_MSG_ENTER_OPEN: &str = "Enter: Open selected message";
 pub const HELP_MSG_SELECT: &str = "↑↓: Select message";

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -267,6 +267,24 @@ pub fn ui_draw(
             Some("Are you sure you want to clear all currencies filters?"),
         );
     }
+    if let UiMode::ConfirmDeleteHistoryOrder(order_id, selected_button) = &app.mode {
+        admin_key_confirm::render_admin_key_confirm_with_message(
+            f,
+            "🗑 Delete Order History",
+            &order_id.to_string(),
+            *selected_button,
+            Some("Delete selected terminal order from local database history?"),
+        );
+    }
+    if let UiMode::ConfirmBulkDeleteHistory(selected_button) = &app.mode {
+        admin_key_confirm::render_admin_key_confirm_with_message(
+            f,
+            "🧹 Clean Up Terminal History",
+            "",
+            *selected_button,
+            Some("Delete all success/canceled orders from local database history?"),
+        );
+    }
 
     // Admin key input popup overlay
     if let UiMode::AdminMode(AdminMode::AddSolver(key_state)) = &app.mode {

--- a/src/ui/helpers/layout.rs
+++ b/src/ui/helpers/layout.rs
@@ -44,7 +44,7 @@ pub fn render_yes_no_buttons(
     yes_label: &str,
     no_label: &str,
 ) {
-    let button_width = 15;
+    let button_width = 18;
     let separator_width = 1;
     let total_button_width = (button_width * 2) + separator_width;
 

--- a/src/ui/helpers/layout.rs
+++ b/src/ui/helpers/layout.rs
@@ -147,9 +147,13 @@ pub fn render_yes_no_cancel_buttons(
     let button_chunks = Layout::new(
         Direction::Horizontal,
         [
+            // spacer to avoid buttons from touching the frame border
+            Constraint::Length(2),
             Constraint::Percentage(33),
             Constraint::Percentage(34),
             Constraint::Percentage(33),
+            // spacer to avoid buttons from touching the frame border
+            Constraint::Length(2),
         ],
     )
     .split(area);
@@ -186,7 +190,7 @@ pub fn render_yes_no_cancel_buttons(
 
     render_one(
         0,
-        button_chunks[0],
+        button_chunks[1],
         yes_label,
         selected,
         Color::Green,
@@ -194,7 +198,7 @@ pub fn render_yes_no_cancel_buttons(
     );
     render_one(
         1,
-        button_chunks[1],
+        button_chunks[2],
         no_label,
         selected,
         Color::Red,
@@ -202,7 +206,7 @@ pub fn render_yes_no_cancel_buttons(
     );
     render_one(
         2,
-        button_chunks[2],
+        button_chunks[3],
         cancel_label,
         selected,
         Color::Yellow,

--- a/src/ui/helpers/layout.rs
+++ b/src/ui/helpers/layout.rs
@@ -154,46 +154,52 @@ pub fn render_yes_no_cancel_buttons(
     )
     .split(area);
 
-    let mut render_one = |idx: u8,
-                      chunk: Rect,
-                      label: &str,
-                      current: u8,
-                      base_fg: Color,
-                      selected_bg: Color| {
-        let is_on = current == idx;
-        let block_style = if is_on {
-            Style::default()
-                .bg(selected_bg)
-                .fg(Color::Black)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(base_fg).add_modifier(Modifier::BOLD)
-        };
-        let block = ratatui::widgets::Block::default()
-            .borders(Borders::ALL)
-            .style(block_style);
-        f.render_widget(block, chunk);
-        let inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
-            .margin(1)
-            .split(chunk);
-        f.render_widget(
-            Paragraph::new(Line::from(vec![Span::styled(
-                label,
+    let mut render_one =
+        |idx: u8, chunk: Rect, label: &str, current: u8, base_fg: Color, selected_bg: Color| {
+            let is_on = current == idx;
+            let block_style = if is_on {
                 Style::default()
-                    .fg(if is_on {
-                        Color::Black
-                    } else {
-                        base_fg
-                    })
-                    .add_modifier(Modifier::BOLD),
-            )]))
-            .alignment(ratatui::layout::Alignment::Center),
-            inner[0],
-        );
-    };
+                    .bg(selected_bg)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(base_fg).add_modifier(Modifier::BOLD)
+            };
+            let block = ratatui::widgets::Block::default()
+                .borders(Borders::ALL)
+                .style(block_style);
+            f.render_widget(block, chunk);
+            let inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
+                .margin(1)
+                .split(chunk);
+            f.render_widget(
+                Paragraph::new(Line::from(vec![Span::styled(
+                    label,
+                    Style::default()
+                        .fg(if is_on { Color::Black } else { base_fg })
+                        .add_modifier(Modifier::BOLD),
+                )]))
+                .alignment(ratatui::layout::Alignment::Center),
+                inner[0],
+            );
+        };
 
-    render_one(0, button_chunks[0], yes_label, selected, Color::Green, Color::Green);
-    render_one(1, button_chunks[1], no_label, selected, Color::Red, Color::Red);
+    render_one(
+        0,
+        button_chunks[0],
+        yes_label,
+        selected,
+        Color::Green,
+        Color::Green,
+    );
+    render_one(
+        1,
+        button_chunks[1],
+        no_label,
+        selected,
+        Color::Red,
+        Color::Red,
+    );
     render_one(
         2,
         button_chunks[2],

--- a/src/ui/helpers/layout.rs
+++ b/src/ui/helpers/layout.rs
@@ -134,3 +134,72 @@ pub fn render_yes_no_buttons(
         no_inner[0],
     );
 }
+
+/// Three buttons: YES (green), NO (red), CANCEL (yellow). `selected` is `0`, `1`, or `2`.
+pub fn render_yes_no_cancel_buttons(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    selected: u8,
+    yes_label: &str,
+    no_label: &str,
+    cancel_label: &str,
+) {
+    let button_chunks = Layout::new(
+        Direction::Horizontal,
+        [
+            Constraint::Percentage(33),
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+        ],
+    )
+    .split(area);
+
+    let mut render_one = |idx: u8,
+                      chunk: Rect,
+                      label: &str,
+                      current: u8,
+                      base_fg: Color,
+                      selected_bg: Color| {
+        let is_on = current == idx;
+        let block_style = if is_on {
+            Style::default()
+                .bg(selected_bg)
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(base_fg).add_modifier(Modifier::BOLD)
+        };
+        let block = ratatui::widgets::Block::default()
+            .borders(Borders::ALL)
+            .style(block_style);
+        f.render_widget(block, chunk);
+        let inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
+            .margin(1)
+            .split(chunk);
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                label,
+                Style::default()
+                    .fg(if is_on {
+                        Color::Black
+                    } else {
+                        base_fg
+                    })
+                    .add_modifier(Modifier::BOLD),
+            )]))
+            .alignment(ratatui::layout::Alignment::Center),
+            inner[0],
+        );
+    };
+
+    render_one(0, button_chunks[0], yes_label, selected, Color::Green, Color::Green);
+    render_one(1, button_chunks[1], no_label, selected, Color::Red, Color::Red);
+    render_one(
+        2,
+        button_chunks[2],
+        cancel_label,
+        selected,
+        Color::Yellow,
+        Color::Yellow,
+    );
+}

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -21,7 +21,9 @@ pub use chat_visibility::{
     message_visible_for_party,
 };
 pub use formatting::{format_order_id, format_user_rating, is_dispute_finalized};
-pub use layout::{create_centered_popup, render_help_text, render_yes_no_buttons};
+pub use layout::{
+    create_centered_popup, render_help_text, render_yes_no_buttons, render_yes_no_cancel_buttons,
+};
 pub use order_chat_projection::{build_active_order_chat_list, OrderChatListItem};
 pub use startup::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -29,4 +29,5 @@ pub use startup::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
     load_user_order_chats_at_startup, recover_admin_chat_from_files,
+    sync_user_order_history_messages_from_db,
 };

--- a/src/ui/helpers/order_chat_projection.rs
+++ b/src/ui/helpers/order_chat_projection.rs
@@ -5,19 +5,17 @@ use mostro_core::prelude::{Payload, Peer, SmallOrder, Status, UserInfo};
 
 use crate::ui::OrderMessage;
 
+/// One row in the My Trades sidebar, derived from order DMs. Live status, amounts, and `Payload::Peer`
+/// ratings. Static id/kind/created/trade/initiator come from [`crate::ui::AppState::order_chat_static`].
 #[derive(Clone)]
 pub struct OrderChatListItem {
     pub order_id: String,
     pub status: Option<Status>,
-    pub kind: Option<String>,
     pub amount: Option<i64>,
     pub fiat: Option<(i64, String)>,
-    pub created_at: Option<i64>,
     pub trade_index: Option<i64>,
     pub payment_method: Option<String>,
     pub premium: Option<i64>,
-    pub initiator_pubkey: Option<String>,
-    pub is_mine: Option<bool>,
     /// From latest `Payload::Order` seen for this trade (used to attribute `Payload::Peer` reputation).
     pub buyer_trade_pubkey: Option<String>,
     pub seller_trade_pubkey: Option<String>,
@@ -36,14 +34,10 @@ fn merge_order_fields(entry: &mut OrderChatListItem, order: &SmallOrder, msg: &O
     if entry.amount.is_none() {
         entry.amount = Some(order.amount);
         entry.fiat = Some((order.fiat_amount, order.fiat_code.clone()));
-        entry.kind = order.kind.map(|k| k.to_string());
-        entry.created_at = order.created_at;
-        entry.trade_index = Some(msg.trade_index);
         entry.payment_method = Some(order.payment_method.clone());
         entry.premium = Some(order.premium);
-        entry.initiator_pubkey = Some(msg.sender.to_string());
-        entry.is_mine = msg.is_mine;
     }
+    entry.trade_index = entry.trade_index.or(Some(msg.trade_index));
 }
 
 fn merge_peer_fields(entry: &mut OrderChatListItem, peer: &Peer) {
@@ -59,6 +53,7 @@ fn merge_peer_fields(entry: &mut OrderChatListItem, peer: &Peer) {
 }
 
 fn merge_message_into_entry(entry: &mut OrderChatListItem, msg: &OrderMessage) {
+    entry.trade_index = entry.trade_index.or(Some(msg.trade_index));
     entry.status = status_from_message(msg).or(entry.status);
     let Some(payload) = &msg.message.get_inner_message_kind().payload else {
         return;
@@ -96,15 +91,11 @@ pub fn build_active_order_chat_list(messages: &[OrderMessage]) -> Vec<OrderChatL
                 let mut entry = OrderChatListItem {
                     order_id: key,
                     status: status_from_message(msg),
-                    kind: None,
                     amount: None,
                     fiat: None,
-                    created_at: None,
                     trade_index: Some(msg.trade_index),
                     payment_method: None,
                     premium: None,
-                    initiator_pubkey: Some(msg.sender.to_string()),
-                    is_mine: msg.is_mine,
                     buyer_trade_pubkey: None,
                     seller_trade_pubkey: None,
                     buyer_reputation: None,

--- a/src/ui/helpers/order_chat_projection.rs
+++ b/src/ui/helpers/order_chat_projection.rs
@@ -69,8 +69,22 @@ fn status_from_message(msg: &OrderMessage) -> Option<Status> {
     msg.order_status
 }
 
-fn is_order_chat_actionable(_status: Option<Status>) -> bool {
-    true
+/// My Trades sidebar: only **in-flight** trade phases. Excludes book/terminal states (e.g. `Pending`,
+/// `Success`, `Canceled`, `CooperativelyCanceled`, …). `None` is kept so rows still appear until
+/// status is merged from DMs/DB.
+fn is_order_chat_actionable(status: Option<Status>) -> bool {
+    match status {
+        None => true,
+        Some(s) => matches!(
+            s,
+            Status::WaitingPayment
+                | Status::WaitingBuyerInvoice
+                | Status::SettledHoldInvoice
+                | Status::InProgress
+                | Status::Active
+                | Status::FiatSent
+        ),
+    }
 }
 
 /// Shared projection for the "My Trades" sidebar and Enter/action handlers.

--- a/src/ui/helpers/order_chat_projection.rs
+++ b/src/ui/helpers/order_chat_projection.rs
@@ -74,14 +74,8 @@ fn status_from_message(msg: &OrderMessage) -> Option<Status> {
     msg.order_status
 }
 
-fn is_order_chat_actionable(status: Option<Status>) -> bool {
-    matches!(
-        status,
-        Some(Status::SettledHoldInvoice)
-            | Some(Status::Active)
-            | Some(Status::FiatSent)
-            | Some(Status::Success)
-    )
+fn is_order_chat_actionable(_status: Option<Status>) -> bool {
+    true
 }
 
 /// Shared projection for the "My Trades" sidebar and Enter/action handlers.

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -162,14 +162,12 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         .as_deref()
         .and_then(|k| OrderKind::from_str(k).ok());
 
-    let action = if order.is_mine {
-        Action::NewOrder
-    } else {
-        match kind {
-            Some(OrderKind::Buy) => Action::TakeBuy,
-            Some(OrderKind::Sell) => Action::TakeSell,
-            None => Action::NewOrder,
-        }
+    // Use non-NewOrder actions for history projection so My Trades can be DB-fed
+    // without polluting Messages-tab rows that are intentionally stripped.
+    let action = match kind {
+        Some(OrderKind::Buy) => Action::TakeBuy,
+        Some(OrderKind::Sell) => Action::TakeSell,
+        None => Action::WaitingSellerToPay,
     };
 
     let mut payload_order = SmallOrder::default();
@@ -196,7 +194,7 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         Some(Payload::Order(payload_order)),
     );
 
-    Some(OrderMessage {
+    let history_message = OrderMessage {
         message,
         timestamp: order
             .last_seen_dm_ts
@@ -212,7 +210,8 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         order_status: status,
         read: true,
         auto_popup_shown: true,
-    })
+    };
+    Some(history_message)
 }
 
 pub async fn sync_user_order_history_messages_from_db(pool: &SqlitePool, app: &mut AppState) {

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -9,7 +9,8 @@ use uuid::Uuid;
 use crate::models::{AdminDispute, Order, User};
 use crate::ui::{
     AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage,
-    OrderChatLastSeen, OrderMessage, UserChatSender, UserOrderChatMessage, UserRole,
+    OrderChatLastSeen, OrderChatStaticHeader, OrderMessage, UserChatSender, UserOrderChatMessage,
+    UserRole,
 };
 use crate::util::{chat_utils::fetch_user_order_chat_updates, seed_admin_chat_last_seen};
 
@@ -216,6 +217,26 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
     Some(history_message)
 }
 
+fn order_chat_static_from_db_order(row: &Order) -> Option<OrderChatStaticHeader> {
+    let id_str = row.id.as_deref()?;
+    let order_id = Uuid::parse_str(id_str).ok()?;
+    let kind = row
+        .kind
+        .as_deref()
+        .and_then(|s| OrderKind::from_str(s).ok());
+    let trade_index = row.trade_index?;
+    let keys_hex = row.trade_keys.as_deref()?;
+    let trade_keys = Keys::parse(keys_hex).ok()?;
+    Some(OrderChatStaticHeader {
+        order_id,
+        kind,
+        created_at: row.created_at,
+        trade_index,
+        initiator_trade_pubkey: trade_keys.public_key().to_string(),
+        is_mine: row.is_mine,
+    })
+}
+
 pub async fn sync_user_order_history_messages_from_db(pool: &SqlitePool, app: &mut AppState) {
     let identity_keys = match User::get_identity_keys(pool).await {
         Ok(k) => k,
@@ -253,6 +274,11 @@ pub async fn sync_user_order_history_messages_from_db(pool: &SqlitePool, app: &m
             crate::util::request_fatal_restart(format!(
                 "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
             ));
+        }
+    }
+    for row in &rows {
+        if let Some(h) = order_chat_static_from_db_order(row) {
+            app.order_chat_static.insert(h.order_id, h);
         }
     }
 }

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 use crate::models::{AdminDispute, Order, User};
 use crate::ui::{
-    AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage, OrderMessage,
-    OrderChatLastSeen, UserChatSender, UserOrderChatMessage, UserRole,
+    AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage,
+    OrderChatLastSeen, OrderMessage, UserChatSender, UserOrderChatMessage, UserRole,
 };
 use crate::util::{chat_utils::fetch_user_order_chat_updates, seed_admin_chat_last_seen};
 
@@ -153,7 +153,10 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
     let order_id_str = order.id.as_deref()?;
     let order_id = Uuid::parse_str(order_id_str).ok()?;
     let trade_index = order.trade_index?;
-    let status = order.status.as_deref().and_then(|s| Status::from_str(s).ok());
+    let status = order
+        .status
+        .as_deref()
+        .and_then(|s| Status::from_str(s).ok());
     let kind = order
         .kind
         .as_deref()

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -170,20 +170,22 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         None => Action::WaitingSellerToPay,
     };
 
-    let mut payload_order = SmallOrder::default();
-    payload_order.id = Some(order_id);
-    payload_order.kind = kind;
-    payload_order.status = status;
-    payload_order.amount = order.amount;
-    payload_order.fiat_code = order.fiat_code.clone();
-    payload_order.min_amount = order.min_amount;
-    payload_order.max_amount = order.max_amount;
-    payload_order.fiat_amount = order.fiat_amount;
-    payload_order.payment_method = order.payment_method.clone();
-    payload_order.premium = order.premium;
-    payload_order.buyer_invoice = order.buyer_invoice.clone();
-    payload_order.created_at = order.created_at;
-    payload_order.expires_at = order.expires_at;
+    let payload_order = SmallOrder {
+        id: Some(order_id),
+        kind,
+        status,
+        amount: order.amount,
+        fiat_code: order.fiat_code.clone(),
+        min_amount: order.min_amount,
+        max_amount: order.max_amount,
+        fiat_amount: order.fiat_amount,
+        payment_method: order.payment_method.clone(),
+        premium: order.premium,
+        buyer_invoice: order.buyer_invoice.clone(),
+        created_at: order.created_at,
+        expires_at: order.expires_at,
+        ..Default::default()
+    };
 
     let request_id = order.request_id.and_then(|id| u64::try_from(id).ok());
     let message = Message::new_order(

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use mostro_core::prelude::{Action, Kind as OrderKind, Message, Payload, SmallOrder, Status};
 use nostr_sdk::prelude::{Client, Keys, PublicKey};
 use sqlx::SqlitePool;
+use uuid::Uuid;
 
-use crate::models::{AdminDispute, Order};
+use crate::models::{AdminDispute, Order, User};
 use crate::ui::{
-    AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage,
+    AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage, OrderMessage,
     OrderChatLastSeen, UserChatSender, UserOrderChatMessage, UserRole,
 };
 use crate::util::{chat_utils::fetch_user_order_chat_updates, seed_admin_chat_last_seen};
@@ -122,6 +124,7 @@ pub async fn load_user_order_chats_at_startup(
     if app.user_role != UserRole::User {
         return;
     }
+    sync_user_order_history_messages_from_db(pool, app).await;
     let Ok(rows) = Order::get_startup_active_orders(pool).await else {
         return;
     };
@@ -144,6 +147,110 @@ pub async fn load_user_order_chats_at_startup(
         .await
         .unwrap_or_default();
     apply_user_order_chat_updates(app, updates);
+}
+
+fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<OrderMessage> {
+    let order_id_str = order.id.as_deref()?;
+    let order_id = Uuid::parse_str(order_id_str).ok()?;
+    let trade_index = order.trade_index?;
+    let status = order.status.as_deref().and_then(|s| Status::from_str(s).ok());
+    let kind = order
+        .kind
+        .as_deref()
+        .and_then(|k| OrderKind::from_str(k).ok());
+
+    let action = if order.is_mine {
+        Action::NewOrder
+    } else {
+        match kind {
+            Some(OrderKind::Buy) => Action::TakeBuy,
+            Some(OrderKind::Sell) => Action::TakeSell,
+            None => Action::NewOrder,
+        }
+    };
+
+    let mut payload_order = SmallOrder::default();
+    payload_order.id = Some(order_id);
+    payload_order.kind = kind;
+    payload_order.status = status;
+    payload_order.amount = order.amount;
+    payload_order.fiat_code = order.fiat_code.clone();
+    payload_order.min_amount = order.min_amount;
+    payload_order.max_amount = order.max_amount;
+    payload_order.fiat_amount = order.fiat_amount;
+    payload_order.payment_method = order.payment_method.clone();
+    payload_order.premium = order.premium;
+    payload_order.buyer_invoice = order.buyer_invoice.clone();
+    payload_order.created_at = order.created_at;
+    payload_order.expires_at = order.expires_at;
+
+    let request_id = order.request_id.and_then(|id| u64::try_from(id).ok());
+    let message = Message::new_order(
+        Some(order_id),
+        request_id,
+        Some(trade_index),
+        action,
+        Some(Payload::Order(payload_order)),
+    );
+
+    Some(OrderMessage {
+        message,
+        timestamp: order
+            .last_seen_dm_ts
+            .or(order.created_at)
+            .unwrap_or_else(|| chrono::Utc::now().timestamp()),
+        sender,
+        order_id: Some(order_id),
+        trade_index,
+        sat_amount: None,
+        buyer_invoice: order.buyer_invoice.clone(),
+        order_kind: kind,
+        is_mine: Some(order.is_mine),
+        order_status: status,
+        read: true,
+        auto_popup_shown: true,
+    })
+}
+
+pub async fn sync_user_order_history_messages_from_db(pool: &SqlitePool, app: &mut AppState) {
+    let identity_keys = match User::get_identity_keys(pool).await {
+        Ok(k) => k,
+        Err(e) => {
+            log::warn!(
+                "Failed to derive identity keys for DB history sender attribution: {}",
+                e
+            );
+            return;
+        }
+    };
+    let sender = identity_keys.public_key();
+    let rows = match Order::get_user_history_orders(pool).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            log::warn!("Failed to load user order history rows at startup: {}", e);
+            return;
+        }
+    };
+    let mut history_messages: Vec<OrderMessage> = rows
+        .iter()
+        .filter_map(|row| db_order_to_history_message(row, sender))
+        .collect();
+    history_messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    match app.messages.lock() {
+        Ok(mut messages) => {
+            for msg in history_messages {
+                messages.retain(|m| m.order_id != msg.order_id);
+                messages.push(msg);
+            }
+            messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        }
+        Err(e) => {
+            crate::util::request_fatal_restart(format!(
+                "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
+            ));
+        }
+    }
 }
 
 /// Merge fetched user order chat updates into app state and persist them to file.

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -47,77 +47,94 @@ pub struct RuntimeReconnectContext<'a> {
     pub settings: &'a Settings,
 }
 
+const POISONED_UI_FATAL: &str = "Internal error. Please restart Mostrix.";
+
+/// Shared by runtime reset paths: log fatal, set exit-on-close, show error mode.
+fn apply_poisoned_mutex_ui_fatal(app: &mut AppState, user_message: String) {
+    request_fatal_restart(user_message);
+    app.fatal_exit_on_close = true;
+    app.mode = UiMode::OperationResult(OperationResult::Error(POISONED_UI_FATAL.to_string()));
+}
+
+fn clear_messages_or_fatal(app: &mut AppState) -> Result<(), ()> {
+    let poison_message = {
+        let lock_result = app.messages.lock();
+        match lock_result {
+            Ok(mut messages) => {
+                messages.clear();
+                return Ok(());
+            }
+            Err(e) => {
+                format!(
+                    "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
+                )
+            }
+        }
+    };
+    apply_poisoned_mutex_ui_fatal(app, poison_message);
+    Err(())
+}
+
+/// Clears `active_order_trade_indices` or applies fatal UI state and returns `Err(())` on poison.
+fn clear_active_order_indices_or_fatal(app: &mut AppState) -> Result<(), ()> {
+    let poison_message = {
+        let lock_result = app.active_order_trade_indices.lock();
+        match lock_result {
+            Ok(mut active) => {
+                active.clear();
+                return Ok(());
+            }
+            Err(e) => {
+                format!(
+                    "Mostrix encountered an internal error (poisoned active order indices lock: {e}). Please restart the app."
+                )
+            }
+        }
+    };
+    apply_poisoned_mutex_ui_fatal(app, poison_message);
+    Err(())
+}
+
+/// Resets `pending_notifications` to 0 or applies fatal UI state and returns `Err(())` on poison.
+fn reset_pending_notifications_or_fatal(app: &mut AppState) -> Result<(), ()> {
+    let poison_message = {
+        let lock_result = app.pending_notifications.lock();
+        match lock_result {
+            Ok(mut pending) => {
+                *pending = 0;
+                return Ok(());
+            }
+            Err(e) => {
+                format!(
+                    "Mostrix encountered an internal error (poisoned pending notifications lock: {e}). Please restart the app."
+                )
+            }
+        }
+    };
+    apply_poisoned_mutex_ui_fatal(app, poison_message);
+    Err(())
+}
+
 fn clear_runtime_session_state(app: &mut AppState) {
-    match app.messages.lock() {
-        Ok(mut messages) => {
-            messages.clear();
-        }
-        Err(e) => {
-            request_fatal_restart(format!(
-                "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
-            ));
-            app.fatal_exit_on_close = true;
-            app.mode = UiMode::OperationResult(OperationResult::Error(
-                "Internal error. Please restart Mostrix.".to_string(),
-            ));
-            return;
-        }
+    if clear_messages_or_fatal(app).is_err() {
+        return;
     }
-    match app.active_order_trade_indices.lock() {
-        Ok(mut active) => active.clear(),
-        Err(e) => {
-            request_fatal_restart(format!(
-                "Mostrix encountered an internal error (poisoned active order indices lock: {e}). Please restart the app."
-            ));
-            app.fatal_exit_on_close = true;
-            app.mode = UiMode::OperationResult(OperationResult::Error(
-                "Internal error. Please restart Mostrix.".to_string(),
-            ));
-            return;
-        }
+    if clear_active_order_indices_or_fatal(app).is_err() {
+        return;
     }
-    match app.pending_notifications.lock() {
-        Ok(mut pending) => *pending = 0,
-        Err(e) => {
-            request_fatal_restart(format!(
-                "Mostrix encountered an internal error (poisoned pending notifications lock: {e}). Please restart the app."
-            ));
-            app.fatal_exit_on_close = true;
-            app.mode = UiMode::OperationResult(OperationResult::Error(
-                "Internal error. Please restart Mostrix.".to_string(),
-            ));
-        }
+    if reset_pending_notifications_or_fatal(app).is_err() {
+        return;
     }
     app.selected_message_idx = 0;
     app.pending_post_take_operation_result = None;
 }
 
 fn clear_runtime_tracking_state_preserve_messages(app: &mut AppState) {
-    match app.active_order_trade_indices.lock() {
-        Ok(mut active) => active.clear(),
-        Err(e) => {
-            request_fatal_restart(format!(
-                "Mostrix encountered an internal error (poisoned active order indices lock: {e}). Please restart the app."
-            ));
-            app.fatal_exit_on_close = true;
-            app.mode = UiMode::OperationResult(OperationResult::Error(
-                "Internal error. Please restart Mostrix.".to_string(),
-            ));
-            return;
-        }
+    if clear_active_order_indices_or_fatal(app).is_err() {
+        return;
     }
-    match app.pending_notifications.lock() {
-        Ok(mut pending) => *pending = 0,
-        Err(e) => {
-            request_fatal_restart(format!(
-                "Mostrix encountered an internal error (poisoned pending notifications lock: {e}). Please restart the app."
-            ));
-            app.fatal_exit_on_close = true;
-            app.mode = UiMode::OperationResult(OperationResult::Error(
-                "Internal error. Please restart Mostrix.".to_string(),
-            ));
-            return;
-        }
+    if reset_pending_notifications_or_fatal(app).is_err() {
+        return;
     }
     app.selected_message_idx = 0;
     app.pending_post_take_operation_result = None;

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -20,8 +20,6 @@ use crate::util::{
 use mostro_core::prelude::{Dispute, SmallOrder};
 use nostr_sdk::prelude::{Client, Keys, PublicKey};
 use sqlx::SqlitePool;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{
@@ -31,25 +29,6 @@ use std::{
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use zeroize::Zeroizing;
-
-fn debug_log_runtime(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
 
 pub struct RuntimeReconnectContext<'a> {
     pub app: &'a mut AppState,
@@ -71,19 +50,7 @@ pub struct RuntimeReconnectContext<'a> {
 fn clear_runtime_session_state(app: &mut AppState) {
     match app.messages.lock() {
         Ok(mut messages) => {
-            let before_len = messages.len();
             messages.clear();
-            // #region agent log
-            debug_log_runtime(
-                "H11",
-                "src/ui/key_handler/async_tasks.rs:clear_runtime_session_state",
-                "Runtime session state cleared messages list",
-                serde_json::json!({
-                    "before_len": before_len,
-                    "after_len": messages.len(),
-                }),
-            );
-            // #endregion
         }
         Err(e) => {
             request_fatal_restart(format!(
@@ -154,14 +121,6 @@ fn clear_runtime_tracking_state_preserve_messages(app: &mut AppState) {
     }
     app.selected_message_idx = 0;
     app.pending_post_take_operation_result = None;
-    // #region agent log
-    debug_log_runtime(
-        "H12",
-        "src/ui/key_handler/async_tasks.rs:clear_runtime_tracking_state_preserve_messages",
-        "Reconnect path preserved messages while clearing runtime tracking state",
-        serde_json::json!({}),
-    );
-    // #endregion
 }
 
 /// Reload Nostr client, Mostro pubkey, and message listener after the user persisted new keys

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -20,6 +20,8 @@ use crate::util::{
 use mostro_core::prelude::{Dispute, SmallOrder};
 use nostr_sdk::prelude::{Client, Keys, PublicKey};
 use sqlx::SqlitePool;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{
@@ -29,6 +31,25 @@ use std::{
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use zeroize::Zeroizing;
+
+fn debug_log_runtime(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
 
 pub struct RuntimeReconnectContext<'a> {
     pub app: &'a mut AppState,
@@ -49,7 +70,21 @@ pub struct RuntimeReconnectContext<'a> {
 
 fn clear_runtime_session_state(app: &mut AppState) {
     match app.messages.lock() {
-        Ok(mut messages) => messages.clear(),
+        Ok(mut messages) => {
+            let before_len = messages.len();
+            messages.clear();
+            // #region agent log
+            debug_log_runtime(
+                "H11",
+                "src/ui/key_handler/async_tasks.rs:clear_runtime_session_state",
+                "Runtime session state cleared messages list",
+                serde_json::json!({
+                    "before_len": before_len,
+                    "after_len": messages.len(),
+                }),
+            );
+            // #endregion
+        }
         Err(e) => {
             request_fatal_restart(format!(
                 "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
@@ -88,6 +123,45 @@ fn clear_runtime_session_state(app: &mut AppState) {
     }
     app.selected_message_idx = 0;
     app.pending_post_take_operation_result = None;
+}
+
+fn clear_runtime_tracking_state_preserve_messages(app: &mut AppState) {
+    match app.active_order_trade_indices.lock() {
+        Ok(mut active) => active.clear(),
+        Err(e) => {
+            request_fatal_restart(format!(
+                "Mostrix encountered an internal error (poisoned active order indices lock: {e}). Please restart the app."
+            ));
+            app.fatal_exit_on_close = true;
+            app.mode = UiMode::OperationResult(OperationResult::Error(
+                "Internal error. Please restart Mostrix.".to_string(),
+            ));
+            return;
+        }
+    }
+    match app.pending_notifications.lock() {
+        Ok(mut pending) => *pending = 0,
+        Err(e) => {
+            request_fatal_restart(format!(
+                "Mostrix encountered an internal error (poisoned pending notifications lock: {e}). Please restart the app."
+            ));
+            app.fatal_exit_on_close = true;
+            app.mode = UiMode::OperationResult(OperationResult::Error(
+                "Internal error. Please restart Mostrix.".to_string(),
+            ));
+            return;
+        }
+    }
+    app.selected_message_idx = 0;
+    app.pending_post_take_operation_result = None;
+    // #region agent log
+    debug_log_runtime(
+        "H12",
+        "src/ui/key_handler/async_tasks.rs:clear_runtime_tracking_state_preserve_messages",
+        "Reconnect path preserved messages while clearing runtime tracking state",
+        serde_json::json!({}),
+    );
+    // #endregion
 }
 
 /// Reload Nostr client, Mostro pubkey, and message listener after the user persisted new keys
@@ -487,7 +561,7 @@ pub async fn reload_runtime_session_after_reconnect(
 
     ctx.app.currencies_filter = ctx.settings.currencies_filter.clone();
     hydrate_app_admin_keys_from_privkey(ctx.app, &ctx.settings.admin_privkey);
-    clear_runtime_session_state(ctx.app);
+    clear_runtime_tracking_state_preserve_messages(ctx.app);
 
     let (o, d) = spawn_fetch_scheduler_loops(
         ctx.client.clone(),

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -121,6 +121,9 @@ fn clear_runtime_tracking_state_preserve_messages(app: &mut AppState) {
     }
     app.selected_message_idx = 0;
     app.pending_post_take_operation_result = None;
+    if let Ok(mut dropped) = app.dropped_user_history_order_ids.lock() {
+        dropped.clear();
+    }
 }
 
 /// Reload Nostr client, Mostro pubkey, and message listener after the user persisted new keys
@@ -226,6 +229,8 @@ pub async fn apply_pending_key_reload(
                     let messages_clone = Arc::clone(&app.messages);
                     let message_notification_tx_clone = message_notification_tx.clone();
                     let pending_notifications_clone = Arc::clone(&app.pending_notifications);
+                    let dropped_user_history_clone =
+                        Arc::clone(&app.dropped_user_history_order_ids);
                     let (new_dm_tx, new_dm_rx) =
                         tokio::sync::mpsc::unbounded_channel::<OrderDmSubscriptionCmd>();
                     *dm_subscription_tx = new_dm_tx;
@@ -243,6 +248,7 @@ pub async fn apply_pending_key_reload(
                                 messages_clone,
                                 message_notification_tx_clone,
                                 pending_notifications_clone,
+                                dropped_user_history_clone,
                                 new_dm_rx,
                             )
                             .await;
@@ -382,6 +388,7 @@ pub async fn apply_pending_fetch_scheduler_reload(
     let messages_clone = Arc::clone(&app.messages);
     let message_notification_tx_clone = message_notification_tx.clone();
     let pending_notifications_clone = Arc::clone(&app.pending_notifications);
+    let dropped_user_history_clone = Arc::clone(&app.dropped_user_history_order_ids);
     let (new_dm_tx, new_dm_rx) = tokio::sync::mpsc::unbounded_channel::<OrderDmSubscriptionCmd>();
     *dm_subscription_tx = new_dm_tx;
     let router_reg = set_dm_router_cmd_tx(dm_subscription_tx.clone());
@@ -398,6 +405,7 @@ pub async fn apply_pending_fetch_scheduler_reload(
                 messages_clone,
                 message_notification_tx_clone,
                 pending_notifications_clone,
+                dropped_user_history_clone,
                 new_dm_rx,
             )
             .await;
@@ -553,6 +561,7 @@ pub async fn reload_runtime_session_after_reconnect(
     let messages_clone = Arc::clone(&ctx.app.messages);
     let message_notification_tx_clone = ctx.message_notification_tx.clone();
     let pending_notifications_clone = Arc::clone(&ctx.app.pending_notifications);
+    let dropped_user_history_clone = Arc::clone(&ctx.app.dropped_user_history_order_ids);
     let (new_dm_tx, new_dm_rx) = tokio::sync::mpsc::unbounded_channel::<OrderDmSubscriptionCmd>();
     *ctx.dm_subscription_tx = new_dm_tx;
     let router_reg = set_dm_router_cmd_tx(ctx.dm_subscription_tx.clone());
@@ -569,6 +578,7 @@ pub async fn reload_runtime_session_after_reconnect(
                 messages_clone,
                 message_notification_tx_clone,
                 pending_notifications_clone,
+                dropped_user_history_clone,
                 new_dm_rx,
             )
             .await;

--- a/src/ui/key_handler/chat_helpers.rs
+++ b/src/ui/key_handler/chat_helpers.rs
@@ -2,7 +2,8 @@ use crate::ui::{
     helpers::message_visible_for_party, AdminMode, AppState, ChatParty, MessageViewState,
     OperationResult, RatingOrderState, UiMode, ViewingMessageButtonSelection,
 };
-use mostro_core::prelude::Action;
+use crate::ui::helpers::build_active_order_chat_list;
+use mostro_core::prelude::{Action, Status};
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
@@ -119,13 +120,15 @@ pub fn jump_to_chat_bottom(app: &mut AppState, dispute_id_key: &str) -> bool {
 
 /// Resolve the currently selected order id for the MyTrades (Order Chat) tab.
 pub fn resolve_selected_mytrades_order_id(app: &AppState) -> Option<Uuid> {
-    app.active_order_trade_indices.lock().ok().and_then(|map| {
-        // HashMap iteration order is arbitrary; sort keys to match the
-        // stable ordering used in the MyTrades sidebar (by order_id UUID).
-        let mut order_ids: Vec<Uuid> = map.keys().copied().collect();
-        order_ids.sort();
-        order_ids.get(app.selected_order_chat_idx).copied()
-    })
+    resolve_selected_mytrades_order_status(app).map(|(order_id, _)| order_id)
+}
+
+/// Resolve selected MyTrades order id + status from the same projection used by sidebar rendering.
+pub fn resolve_selected_mytrades_order_status(app: &AppState) -> Option<(Uuid, Option<Status>)> {
+    let messages_snapshot = app.messages.lock().ok()?.clone();
+    let rows = build_active_order_chat_list(&messages_snapshot);
+    rows.get(app.selected_order_chat_idx)
+        .and_then(|row| Uuid::parse_str(&row.order_id).ok().map(|id| (id, row.status)))
 }
 
 /// Build a confirmation `ViewingMessage` state for order actions (Cancel / FiatSent / Release).

--- a/src/ui/key_handler/chat_helpers.rs
+++ b/src/ui/key_handler/chat_helpers.rs
@@ -1,7 +1,6 @@
 use crate::ui::{
     helpers::message_visible_for_party, AdminMode, AppState, ChatParty, MessageViewState,
-    ViewingMessageButtonSelection,
-    OperationResult, RatingOrderState, UiMode,
+    OperationResult, RatingOrderState, UiMode, ViewingMessageButtonSelection,
 };
 use mostro_core::prelude::Action;
 use tokio::sync::mpsc::UnboundedSender;

--- a/src/ui/key_handler/chat_helpers.rs
+++ b/src/ui/key_handler/chat_helpers.rs
@@ -1,5 +1,6 @@
 use crate::ui::{
     helpers::message_visible_for_party, AdminMode, AppState, ChatParty, MessageViewState,
+    ViewingMessageButtonSelection,
     OperationResult, RatingOrderState, UiMode,
 };
 use mostro_core::prelude::Action;
@@ -138,7 +139,7 @@ pub fn build_order_action_view_state(
         message_content,
         order_id: Some(order_id),
         action,
-        selected_button: true, // default to YES
+        button_selection: ViewingMessageButtonSelection::Two { yes_selected: true },
     }
 }
 

--- a/src/ui/key_handler/chat_helpers.rs
+++ b/src/ui/key_handler/chat_helpers.rs
@@ -1,8 +1,8 @@
+use crate::ui::helpers::build_active_order_chat_list;
 use crate::ui::{
     helpers::message_visible_for_party, AdminMode, AppState, ChatParty, MessageViewState,
     OperationResult, RatingOrderState, UiMode, ViewingMessageButtonSelection,
 };
-use crate::ui::helpers::build_active_order_chat_list;
 use mostro_core::prelude::{Action, Status};
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
@@ -127,8 +127,11 @@ pub fn resolve_selected_mytrades_order_id(app: &AppState) -> Option<Uuid> {
 pub fn resolve_selected_mytrades_order_status(app: &AppState) -> Option<(Uuid, Option<Status>)> {
     let messages_snapshot = app.messages.lock().ok()?.clone();
     let rows = build_active_order_chat_list(&messages_snapshot);
-    rows.get(app.selected_order_chat_idx)
-        .and_then(|row| Uuid::parse_str(&row.order_id).ok().map(|id| (id, row.status)))
+    rows.get(app.selected_order_chat_idx).and_then(|row| {
+        Uuid::parse_str(&row.order_id)
+            .ok()
+            .map(|id| (id, row.status))
+    })
 }
 
 /// Build a confirmation `ViewingMessage` state for order actions (Cancel / FiatSent / Release).

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -278,6 +278,11 @@ pub fn handle_cancel_key(app: &mut AppState) {
     } else if let UiMode::ConfirmClearCurrencies(_) = &app.mode {
         // Cancel clear-all confirmation, just return to default mode
         app.mode = default_mode;
+    } else if matches!(
+        app.mode,
+        UiMode::ConfirmDeleteHistoryOrder(_, _) | UiMode::ConfirmBulkDeleteHistory(_)
+    ) {
+        app.mode = default_mode;
     } else if let UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, _)) = &app.mode {
         app.mode = handle_confirmation_esc(solver_pubkey, |input| {
             UiMode::AdminMode(AdminMode::AddSolver(create_key_input_state(input)))

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -29,8 +29,6 @@ use nostr_sdk::nips::nip06::FromMnemonic;
 use nostr_sdk::prelude::{Keys, PublicKey, SecretKey};
 use nostr_sdk::ToBech32;
 use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::str::FromStr;
 
 use crate::ui::key_handler::confirmation::{
@@ -60,25 +58,6 @@ fn derive_identity_nsec_from_mnemonic(mnemonic: &str) -> std::result::Result<Str
         .secret_key()
         .to_bech32()
         .map_err(|e| e.to_string())
-}
-
-fn debug_log_enter(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
 }
 
 #[derive(Clone)]
@@ -898,20 +877,6 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
         if let Some(msg) = messages_lock.get(app.selected_message_idx) {
             let inner_message_kind = msg.message.get_inner_message_kind();
             let action = inner_message_kind.action.clone();
-            // #region agent log
-            debug_log_enter(
-                "H8",
-                "src/ui/key_handler/enter_handlers.rs:messages_enter_selected",
-                "Pressed Enter on selected Messages row",
-                serde_json::json!({
-                    "order_id": msg.order_id.map(|id| id.to_string()),
-                    "selected_message_idx": app.selected_message_idx,
-                    "action": format!("{:?}", action),
-                    "order_status": msg.order_status.map(|s| format!("{:?}", s)),
-                    "timestamp": msg.timestamp,
-                }),
-            );
-            // #endregion
             if matches!(action, Action::AddInvoice | Action::PayInvoice)
                 && invoice_popup_allowed_for_order_status(&action, msg.order_status)
             {
@@ -945,6 +910,7 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                 Action::HoldInvoicePaymentAccepted
                     | Action::FiatSentOk
                     | Action::CooperativeCancelInitiatedByPeer
+                    | Action::BuyerTookOrder
             ) {
                 // Only these message types are actionable (send a follow-up message to Mostro).
                 let notification = order_message_to_notification(msg);
@@ -964,18 +930,6 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                     action: notification.action,
                     button_selection,
                 };
-                // #region agent log
-                debug_log_enter(
-                    "H6",
-                    "src/ui/key_handler/enter_handlers.rs:messages_open_viewing_message",
-                    "Created ViewingMessage state from Messages tab",
-                    serde_json::json!({
-                        "order_id": view_state.order_id.map(|id| id.to_string()),
-                        "action": format!("{:?}", view_state.action),
-                        "button_selection": format!("{:?}", view_state.button_selection),
-                    }),
-                );
-                // #endregion
                 app.mode = UiMode::ViewingMessage(view_state);
             } else if matches!(action, Action::Rate) {
                 if let Some(oid) = msg.order_id {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1,4 +1,5 @@
 use crate::ui::helpers::{build_active_order_chat_list, save_order_chat_message};
+use crate::models::{Order, ORDER_HISTORY_BULK_DELETE_STATUSES};
 use crate::ui::key_handler::chat_helpers::{
     handle_enter_finalize_popup, message_counter, FinalizeDisputePopupButton,
 };
@@ -28,6 +29,7 @@ use nostr_sdk::nips::nip06::FromMnemonic;
 use nostr_sdk::prelude::{Keys, PublicKey, SecretKey};
 use nostr_sdk::ToBech32;
 use std::str::FromStr;
+use std::collections::HashSet;
 
 use crate::ui::key_handler::confirmation::{
     create_key_input_state, handle_confirmation_enter, handle_input_to_confirmation,
@@ -175,6 +177,76 @@ fn spawn_user_order_chat_send_task(
         .await
         {
             log::warn!("Failed to send user order chat: {}", e);
+        }
+    });
+}
+
+fn spawn_delete_single_terminal_order_task(
+    pool: sqlx::SqlitePool,
+    order_id: uuid::Uuid,
+    order_result_tx: tokio::sync::mpsc::UnboundedSender<OperationResult>,
+) {
+    tokio::spawn(async move {
+        match Order::delete_terminal_order_by_id(&pool, &order_id.to_string()).await {
+            Ok(affected) if affected > 0 => {
+                let _ = order_result_tx.send(OperationResult::OrderHistoryDeleted {
+                    deleted_order_ids: vec![order_id],
+                    message: format!("Deleted order {} from local history.", order_id),
+                });
+            }
+            Ok(_) => {
+                let _ = order_result_tx.send(OperationResult::Error(
+                    "Selected order is not terminal or no longer exists in local database."
+                        .to_string(),
+                ));
+            }
+            Err(e) => {
+                let _ = order_result_tx.send(OperationResult::Error(format!(
+                    "Failed to delete selected order from local history: {}",
+                    e
+                )));
+            }
+        }
+    });
+}
+
+fn spawn_bulk_history_cleanup_task(
+    pool: sqlx::SqlitePool,
+    order_result_tx: tokio::sync::mpsc::UnboundedSender<OperationResult>,
+) {
+    tokio::spawn(async move {
+        let mut ids_to_remove = Vec::new();
+        let allowed: HashSet<&str> = ORDER_HISTORY_BULK_DELETE_STATUSES.iter().copied().collect();
+        if let Ok(rows) = Order::get_user_history_orders(&pool).await {
+            ids_to_remove = rows
+                .iter()
+                .filter(|row| {
+                    row.status
+                        .as_deref()
+                        .map(|status| allowed.contains(&status.to_lowercase().as_str()))
+                        .unwrap_or(false)
+                })
+                .filter_map(|row| row.id.as_deref().and_then(|id| uuid::Uuid::parse_str(id).ok()))
+                .collect();
+        }
+
+        match Order::delete_bulk_history_cleanup_orders(&pool).await {
+            Ok(affected) => {
+                let message = format!(
+                    "Removed {} success/canceled orders from local history.",
+                    affected
+                );
+                let _ = order_result_tx.send(OperationResult::OrderHistoryDeleted {
+                    deleted_order_ids: ids_to_remove,
+                    message,
+                });
+            }
+            Err(e) => {
+                let _ = order_result_tx.send(OperationResult::Error(format!(
+                    "Failed to clean up order history: {}",
+                    e
+                )));
+            }
         }
     });
 }
@@ -345,6 +417,7 @@ pub fn handle_enter_key(app: &mut AppState, ctx: &super::EnterKeyContext<'_>) ->
                 Tab::Admin(AdminTab::Settings)
                     | Tab::User(UserTab::Settings)
                     | Tab::Admin(AdminTab::Observer)
+                    | Tab::User(UserTab::MyTrades)
                     | Tab::User(UserTab::MostroInfo)
                     | Tab::Admin(AdminTab::MostroInfo)
                     | Tab::User(UserTab::Messages)
@@ -392,6 +465,32 @@ pub fn handle_enter_key(app: &mut AppState, ctx: &super::EnterKeyContext<'_>) ->
             let should_continue = handle_enter_settings_mode(app, current_mode, default_mode, ctx);
             if !should_continue {
                 return false; // Exit application
+            }
+            true
+        }
+        UiMode::ConfirmDeleteHistoryOrder(order_id, selected_button) => {
+            if selected_button {
+                app.mode = UiMode::OperationResult(OperationResult::Info(
+                    "Deleting selected terminal order from local history...".to_string(),
+                ));
+                spawn_delete_single_terminal_order_task(
+                    ctx.pool.clone(),
+                    order_id,
+                    ctx.order_result_tx.clone(),
+                );
+            } else {
+                app.mode = default_mode;
+            }
+            true
+        }
+        UiMode::ConfirmBulkDeleteHistory(selected_button) => {
+            if selected_button {
+                app.mode = UiMode::OperationResult(OperationResult::Info(
+                    "Cleaning up success/canceled orders from local history...".to_string(),
+                ));
+                spawn_bulk_history_cleanup_task(ctx.pool.clone(), ctx.order_result_tx.clone());
+            } else {
+                app.mode = default_mode;
             }
             true
         }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -12,7 +12,8 @@ use crate::ui::orders::{
 use crate::ui::{
     order_message_to_notification, AdminMode, AdminTab, AppState, ChatParty, InvoiceInputState,
     InvoiceNotificationActionSelection, MessageViewState, OperationResult, RatingOrderState, Tab,
-    TakeOrderState, UiMode, UserMode, UserRole, UserTab, ViewingMessageButtonSelection,
+    TakeOrderState, ThreeState, UiMode, UserMode, UserRole, UserTab,
+    ViewingMessageButtonSelection,
 };
 // User handlers moved to user_handlers.rs
 use crate::ui::key_handler::async_tasks::{
@@ -933,7 +934,7 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                 // Only these message types are actionable (send a follow-up message to Mostro).
                 let notification = order_message_to_notification(msg);
                 let button_selection = if matches!(action, Action::HoldInvoicePaymentAccepted) {
-                    ViewingMessageButtonSelection::Three { selected: 0 }
+                    ViewingMessageButtonSelection::Three(ThreeState::Yes)
                 } else if matches!(action, Action::CooperativeCancelInitiatedByPeer) {
                     // Safer default: Enter should not accept cooperative cancel implicitly.
                     ViewingMessageButtonSelection::Two {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -11,8 +11,8 @@ use crate::ui::orders::{
 };
 use crate::ui::{
     order_message_to_notification, AdminMode, AdminTab, AppState, ChatParty, InvoiceInputState,
-    MessageViewState, OperationResult, RatingOrderState, Tab, TakeOrderState, UiMode, UserMode,
-    UserRole, UserTab, ViewingMessageButtonSelection,
+    InvoiceNotificationActionSelection, MessageViewState, OperationResult, RatingOrderState, Tab,
+    TakeOrderState, UiMode, UserMode, UserRole, UserTab, ViewingMessageButtonSelection,
 };
 // User handlers moved to user_handlers.rs
 use crate::ui::key_handler::async_tasks::{
@@ -38,6 +38,14 @@ use crate::ui::key_handler::settings::{
     clear_currency_filters, handle_mode_switch, save_currency_to_settings,
     save_mostro_pubkey_to_settings, save_relay_to_settings,
 };
+
+fn invoice_popup_action_for_message_action(action: &Action) -> Option<Action> {
+    match action {
+        Action::AddInvoice | Action::WaitingBuyerInvoice => Some(Action::AddInvoice),
+        Action::PayInvoice | Action::WaitingSellerToPay => Some(Action::PayInvoice),
+        _ => None,
+    }
+}
 use crate::ui::key_handler::validation::{
     validate_currency, validate_mostro_pubkey, validate_relay,
 };
@@ -877,34 +885,44 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
         if let Some(msg) = messages_lock.get(app.selected_message_idx) {
             let inner_message_kind = msg.message.get_inner_message_kind();
             let action = inner_message_kind.action.clone();
-            if matches!(action, Action::AddInvoice | Action::PayInvoice)
-                && invoice_popup_allowed_for_order_status(&action, msg.order_status)
-            {
-                // Show invoice/payment popup only when the phase still requires it.
-                let notification = order_message_to_notification(msg);
-                let action = notification.action.clone();
-                let invoice_state = InvoiceInputState {
-                    invoice_input: String::new(),
-                    focused: matches!(action, Action::AddInvoice),
-                    just_pasted: false,
-                    copied_to_clipboard: false,
-                    scroll_y: 0,
-                };
+            if let Some(invoice_popup_action) = invoice_popup_action_for_message_action(&action) {
+                if invoice_popup_allowed_for_order_status(&invoice_popup_action, msg.order_status) {
+                    // Show invoice/payment popup only when the phase still requires it.
+                    let notification = order_message_to_notification(msg);
+                    let invoice_state = InvoiceInputState {
+                        invoice_input: String::new(),
+                        focused: matches!(invoice_popup_action, Action::AddInvoice),
+                        just_pasted: false,
+                        copied_to_clipboard: false,
+                        scroll_y: 0,
+                        action_selection: InvoiceNotificationActionSelection::Primary,
+                    };
 
-                app.mode = UiMode::NewMessageNotification(notification, action, invoice_state);
-            } else if matches!(action, Action::AddInvoice | Action::PayInvoice) {
-                // Stale replayed invoice/payment DMs after the trade moved on.
-                let info = if matches!(action, Action::PayInvoice)
-                    && matches!(
-                        msg.order_status,
-                        Some(mostro_core::order::Status::WaitingBuyerInvoice)
-                    ) {
-                    "Waiting for the buyer to add their invoice. Hold invoice is already paid."
-                        .to_string()
-                } else {
-                    "Trade already advanced; invoice action no longer required.".to_string()
-                };
-                app.mode = UiMode::OperationResult(OperationResult::Info(info));
+                    app.mode = UiMode::NewMessageNotification(
+                        notification,
+                        invoice_popup_action,
+                        invoice_state,
+                    );
+                } else if matches!(
+                    action,
+                    Action::AddInvoice
+                        | Action::PayInvoice
+                        | Action::WaitingBuyerInvoice
+                        | Action::WaitingSellerToPay
+                ) {
+                    // Stale replayed invoice/payment DMs after the trade moved on.
+                    let info = if matches!(action, Action::PayInvoice)
+                        && matches!(
+                            msg.order_status,
+                            Some(mostro_core::order::Status::WaitingBuyerInvoice)
+                        ) {
+                        "Waiting for the buyer to add their invoice. Hold invoice is already paid."
+                            .to_string()
+                    } else {
+                        "Trade already advanced; invoice action no longer required.".to_string()
+                    };
+                    app.mode = UiMode::OperationResult(OperationResult::Info(info));
+                }
             } else if matches!(
                 action,
                 Action::HoldInvoicePaymentAccepted

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -29,6 +29,8 @@ use nostr_sdk::nips::nip06::FromMnemonic;
 use nostr_sdk::prelude::{Keys, PublicKey, SecretKey};
 use nostr_sdk::ToBech32;
 use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::str::FromStr;
 
 use crate::ui::key_handler::confirmation::{
@@ -58,6 +60,25 @@ fn derive_identity_nsec_from_mnemonic(mnemonic: &str) -> std::result::Result<Str
         .secret_key()
         .to_bech32()
         .map_err(|e| e.to_string())
+}
+
+fn debug_log_enter(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
 }
 
 #[derive(Clone)]
@@ -877,6 +898,20 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
         if let Some(msg) = messages_lock.get(app.selected_message_idx) {
             let inner_message_kind = msg.message.get_inner_message_kind();
             let action = inner_message_kind.action.clone();
+            // #region agent log
+            debug_log_enter(
+                "H8",
+                "src/ui/key_handler/enter_handlers.rs:messages_enter_selected",
+                "Pressed Enter on selected Messages row",
+                serde_json::json!({
+                    "order_id": msg.order_id.map(|id| id.to_string()),
+                    "selected_message_idx": app.selected_message_idx,
+                    "action": format!("{:?}", action),
+                    "order_status": msg.order_status.map(|s| format!("{:?}", s)),
+                    "timestamp": msg.timestamp,
+                }),
+            );
+            // #endregion
             if matches!(action, Action::AddInvoice | Action::PayInvoice)
                 && invoice_popup_allowed_for_order_status(&action, msg.order_status)
             {
@@ -915,6 +950,11 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                 let notification = order_message_to_notification(msg);
                 let button_selection = if matches!(action, Action::HoldInvoicePaymentAccepted) {
                     ViewingMessageButtonSelection::Three { selected: 0 }
+                } else if matches!(action, Action::CooperativeCancelInitiatedByPeer) {
+                    // Safer default: Enter should not accept cooperative cancel implicitly.
+                    ViewingMessageButtonSelection::Two {
+                        yes_selected: false,
+                    }
                 } else {
                     ViewingMessageButtonSelection::Two { yes_selected: true }
                 };
@@ -924,6 +964,18 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                     action: notification.action,
                     button_selection,
                 };
+                // #region agent log
+                debug_log_enter(
+                    "H6",
+                    "src/ui/key_handler/enter_handlers.rs:messages_open_viewing_message",
+                    "Created ViewingMessage state from Messages tab",
+                    serde_json::json!({
+                        "order_id": view_state.order_id.map(|id| id.to_string()),
+                        "action": format!("{:?}", view_state.action),
+                        "button_selection": format!("{:?}", view_state.button_selection),
+                    }),
+                );
+                // #endregion
                 app.mode = UiMode::ViewingMessage(view_state);
             } else if matches!(action, Action::Rate) {
                 if let Some(oid) = msg.order_id {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1,5 +1,5 @@
-use crate::ui::helpers::{build_active_order_chat_list, save_order_chat_message};
 use crate::models::{Order, ORDER_HISTORY_BULK_DELETE_STATUSES};
+use crate::ui::helpers::{build_active_order_chat_list, save_order_chat_message};
 use crate::ui::key_handler::chat_helpers::{
     handle_enter_finalize_popup, message_counter, FinalizeDisputePopupButton,
 };
@@ -28,8 +28,8 @@ use mostro_core::prelude::*;
 use nostr_sdk::nips::nip06::FromMnemonic;
 use nostr_sdk::prelude::{Keys, PublicKey, SecretKey};
 use nostr_sdk::ToBech32;
-use std::str::FromStr;
 use std::collections::HashSet;
+use std::str::FromStr;
 
 use crate::ui::key_handler::confirmation::{
     create_key_input_state, handle_confirmation_enter, handle_input_to_confirmation,
@@ -226,7 +226,11 @@ fn spawn_bulk_history_cleanup_task(
                         .map(|status| allowed.contains(&status.to_lowercase().as_str()))
                         .unwrap_or(false)
                 })
-                .filter_map(|row| row.id.as_deref().and_then(|id| uuid::Uuid::parse_str(id).ok()))
+                .filter_map(|row| {
+                    row.id
+                        .as_deref()
+                        .and_then(|id| uuid::Uuid::parse_str(id).ok())
+                })
                 .collect();
         }
 

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -11,7 +11,7 @@ use crate::ui::orders::{
 use crate::ui::{
     order_message_to_notification, AdminMode, AdminTab, AppState, ChatParty, InvoiceInputState,
     MessageViewState, OperationResult, RatingOrderState, Tab, TakeOrderState, UiMode, UserMode,
-    UserRole, UserTab,
+    UserRole, UserTab, ViewingMessageButtonSelection,
 };
 // User handlers moved to user_handlers.rs
 use crate::ui::key_handler::async_tasks::{
@@ -810,11 +810,16 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             ) {
                 // Only these message types are actionable (send a follow-up message to Mostro).
                 let notification = order_message_to_notification(msg);
+                let button_selection = if matches!(action, Action::HoldInvoicePaymentAccepted) {
+                    ViewingMessageButtonSelection::Three { selected: 0 }
+                } else {
+                    ViewingMessageButtonSelection::Two { yes_selected: true }
+                };
                 let view_state = MessageViewState {
                     message_content: notification.message_preview,
                     order_id: notification.order_id,
                     action: notification.action,
-                    selected_button: true, // Default to YES
+                    button_selection,
                 };
                 app.mode = UiMode::ViewingMessage(view_state);
             } else if matches!(action, Action::Rate) {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -934,8 +934,12 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                 let notification = order_message_to_notification(msg);
                 let button_selection = if matches!(action, Action::HoldInvoicePaymentAccepted) {
                     ViewingMessageButtonSelection::Three(ThreeState::Yes)
-                } else if matches!(action, Action::CooperativeCancelInitiatedByPeer) {
-                    // Safer default: Enter should not accept cooperative cancel implicitly.
+                } else if matches!(
+                    action,
+                    Action::CooperativeCancelInitiatedByPeer | Action::BuyerTookOrder
+                ) {
+                    // Safer default: Enter should not send Cancel until the user selects YES.
+                    // (handle_enter_viewing_message maps both to Action::Cancel when confirming.)
                     ViewingMessageButtonSelection::Two {
                         yes_selected: false,
                     }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -12,8 +12,7 @@ use crate::ui::orders::{
 use crate::ui::{
     order_message_to_notification, AdminMode, AdminTab, AppState, ChatParty, InvoiceInputState,
     InvoiceNotificationActionSelection, MessageViewState, OperationResult, RatingOrderState, Tab,
-    TakeOrderState, ThreeState, UiMode, UserMode, UserRole, UserTab,
-    ViewingMessageButtonSelection,
+    TakeOrderState, ThreeState, UiMode, UserMode, UserRole, UserTab, ViewingMessageButtonSelection,
 };
 // User handlers moved to user_handlers.rs
 use crate::ui::key_handler::async_tasks::{

--- a/src/ui/key_handler/esc_handlers.rs
+++ b/src/ui/key_handler/esc_handlers.rs
@@ -126,6 +126,10 @@ pub fn handle_esc_key(app: &mut AppState) -> bool {
             app.mode = default_mode.clone();
             true
         }
+        UiMode::ConfirmDeleteHistoryOrder(_, _) | UiMode::ConfirmBulkDeleteHistory(_) => {
+            app.mode = default_mode.clone();
+            true
+        }
         UiMode::ConfirmGenerateNewKeys(_) => {
             // Cancel warning, return to normal mode
             app.mode = default_mode.clone();

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -1,14 +1,74 @@
 use crate::ui::key_handler::EnterKeyContext;
 use crate::ui::OperationResult;
 use crate::ui::{
-    AdminMode, AppState, MessageViewState, RatingOrderState, UiMode, UserMode, UserRole,
-    ViewingMessageButtonSelection,
+    AdminMode, AppState, InvoiceNotificationActionSelection, MessageViewState, RatingOrderState,
+    UiMode, UserMode, UserRole, ViewingMessageButtonSelection,
 };
 use crate::util::db_utils::update_order_status;
 use crate::util::order_utils::{execute_add_invoice, execute_rate_user, execute_send_msg};
 use mostro_core::order::Status;
 use mostro_core::prelude::*;
 use uuid::Uuid;
+
+fn role_default_mode(user_role: UserRole) -> UiMode {
+    match user_role {
+        UserRole::User => UiMode::UserMode(UserMode::Normal),
+        UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
+    }
+}
+
+fn role_waiting_mode(user_role: UserRole) -> UiMode {
+    match user_role {
+        UserRole::User => UiMode::UserMode(UserMode::WaitingAddInvoice),
+        UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
+    }
+}
+
+fn should_send_cancel_from_invoice_popup(selection: InvoiceNotificationActionSelection) -> bool {
+    matches!(selection, InvoiceNotificationActionSelection::Cancel)
+}
+
+fn spawn_cancel_from_notification(
+    app: &mut AppState,
+    ctx: &EnterKeyContext<'_>,
+    order_id: Option<Uuid>,
+) {
+    let Some(order_id) = order_id else {
+        let _ = ctx
+            .order_result_tx
+            .send(OperationResult::Error("No order ID in message".to_string()));
+        app.mode = role_default_mode(app.user_role);
+        return;
+    };
+
+    app.mode = role_waiting_mode(app.user_role);
+    let pool_clone = ctx.pool.clone();
+    let client_clone = ctx.client.clone();
+    let mostro_pubkey = ctx.mostro_pubkey;
+    let order_result_tx_clone = ctx.order_result_tx.clone();
+    let mostro_info = ctx.mostro_info.clone();
+    tokio::spawn(async move {
+        match execute_send_msg(
+            &order_id,
+            Action::Cancel,
+            &pool_clone,
+            &client_clone,
+            mostro_pubkey,
+            mostro_info.as_ref(),
+        )
+        .await
+        {
+            Ok(_) => {
+                let _ = order_result_tx_clone
+                    .send(OperationResult::Info("Cancel request sent.".to_string()));
+            }
+            Err(e) => {
+                log::error!("Failed to cancel order from invoice popup: {}", e);
+                let _ = order_result_tx_clone.send(OperationResult::Error(e.to_string()));
+            }
+        }
+    });
+}
 
 /// Handle Enter key when viewing a message.
 pub fn handle_enter_viewing_message(
@@ -148,15 +208,16 @@ pub fn handle_enter_message_notification(
 ) {
     match action {
         Action::AddInvoice => {
+            if should_send_cancel_from_invoice_popup(invoice_state.action_selection) {
+                spawn_cancel_from_notification(app, ctx, order_id);
+                return;
+            }
             // For AddInvoice, Enter submits the invoice
             let order_result_tx_clone = ctx.order_result_tx.clone();
             if !invoice_state.invoice_input.trim().is_empty() {
                 if let Some(order_id) = order_id {
                     // Set waiting mode based on user role
-                    let default_mode = match app.user_role {
-                        UserRole::User => UiMode::UserMode(UserMode::WaitingAddInvoice),
-                        UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
-                    };
+                    let default_mode = role_waiting_mode(app.user_role);
                     app.pending_post_take_operation_result = None;
                     app.mode = default_mode;
 
@@ -192,12 +253,34 @@ pub fn handle_enter_message_notification(
                 }
             }
         }
-        Action::PayInvoice => {}
+        Action::PayInvoice => {
+            if should_send_cancel_from_invoice_popup(invoice_state.action_selection) {
+                spawn_cancel_from_notification(app, ctx, order_id);
+                return;
+            }
+            // Primary path for PayInvoice is acknowledgement: close popup.
+            app.mode = role_default_mode(app.user_role);
+        }
         _ => {
             let _ = ctx
                 .order_result_tx
                 .send(OperationResult::Error("Invalid action".to_string()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_selection_triggers_cancel_path() {
+        assert!(should_send_cancel_from_invoice_popup(
+            InvoiceNotificationActionSelection::Cancel
+        ));
+        assert!(!should_send_cancel_from_invoice_popup(
+            InvoiceNotificationActionSelection::Primary
+        ));
     }
 }
 

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -269,21 +269,6 @@ pub fn handle_enter_message_notification(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cancel_selection_triggers_cancel_path() {
-        assert!(should_send_cancel_from_invoice_popup(
-            InvoiceNotificationActionSelection::Cancel
-        ));
-        assert!(!should_send_cancel_from_invoice_popup(
-            InvoiceNotificationActionSelection::Primary
-        ));
-    }
-}
-
 /// Confirm and send the selected star rating (`RateUser`).
 pub fn handle_enter_rating_order(
     app: &mut AppState,
@@ -326,4 +311,19 @@ pub fn handle_enter_rating_order(
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_selection_triggers_cancel_path() {
+        assert!(should_send_cancel_from_invoice_popup(
+            InvoiceNotificationActionSelection::Cancel
+        ));
+        assert!(!should_send_cancel_from_invoice_popup(
+            InvoiceNotificationActionSelection::Primary
+        ));
+    }
 }

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -8,28 +8,7 @@ use crate::util::db_utils::update_order_status;
 use crate::util::order_utils::{execute_add_invoice, execute_rate_user, execute_send_msg};
 use mostro_core::order::Status;
 use mostro_core::prelude::*;
-use std::fs::OpenOptions;
-use std::io::Write;
 use uuid::Uuid;
-
-fn debug_log_ui(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
 
 /// Handle Enter key when viewing a message.
 pub fn handle_enter_viewing_message(
@@ -37,19 +16,6 @@ pub fn handle_enter_viewing_message(
     view_state: &MessageViewState,
     ctx: &EnterKeyContext<'_>,
 ) {
-    // #region agent log
-    debug_log_ui(
-        "H1",
-        "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:entry",
-        "ViewingMessage enter pressed",
-        serde_json::json!({
-            "source_action": format!("{:?}", view_state.action),
-            "button_selection": format!("{:?}", view_state.button_selection),
-            "order_id": view_state.order_id.map(|id| id.to_string()),
-        }),
-    );
-    // #endregion
-
     let default_mode = match app.user_role {
         UserRole::User => UiMode::UserMode(UserMode::Normal),
         UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
@@ -76,6 +42,7 @@ pub fn handle_enter_viewing_message(
             ViewingMessageButtonSelection::Three { selected: 2 } => Action::Cancel,
             _ => Action::FiatSent,
         },
+        Action::BuyerTookOrder => Action::Cancel,
         Action::FiatSentOk => Action::Release,
         Action::CooperativeCancelInitiatedByPeer => Action::Cancel,
         // For Shift+C/F/R confirmations, the action is already the one we want to send.
@@ -87,17 +54,6 @@ pub fn handle_enter_viewing_message(
             return;
         }
     };
-    // #region agent log
-    debug_log_ui(
-        "H1",
-        "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:action_map",
-        "Mapped source action to outbound action",
-        serde_json::json!({
-            "source_action": format!("{:?}", view_state.action),
-            "outbound_action": format!("{:?}", action_to_send),
-        }),
-    );
-    // #endregion
 
     // Get order_id from view_state
     let Some(order_id) = view_state.order_id else {
@@ -126,9 +82,11 @@ pub fn handle_enter_viewing_message(
     let result_tx = ctx.order_result_tx.clone();
     let source_action = view_state.action.clone();
     let mostro_info = ctx.mostro_info.clone();
-    let sent_cooperative_cancel_from_hold_invoice =
-        matches!(view_state.action, Action::HoldInvoicePaymentAccepted)
-            && matches!(action_to_send, Action::Cancel);
+    let sent_cooperative_cancel_request = matches!(action_to_send, Action::Cancel)
+        && matches!(
+            view_state.action,
+            Action::HoldInvoicePaymentAccepted | Action::BuyerTookOrder
+        );
 
     tokio::spawn(async move {
         match execute_send_msg(
@@ -142,18 +100,6 @@ pub fn handle_enter_viewing_message(
         .await
         {
             Ok(_) => {
-                // #region agent log
-                debug_log_ui(
-                    "H1",
-                    "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:send_ok",
-                    "Follow-up message sent successfully",
-                    serde_json::json!({
-                        "order_id": order_id.to_string(),
-                        "source_action": format!("{:?}", source_action),
-                        "sent_cooperative_cancel_from_hold_invoice": sent_cooperative_cancel_from_hold_invoice,
-                    }),
-                );
-                // #endregion
                 let out = if source_action == Action::CooperativeCancelInitiatedByPeer {
                     match update_order_status(
                         &pool_clone,
@@ -177,7 +123,7 @@ pub fn handle_enter_viewing_message(
                             ))
                         }
                     }
-                } else if sent_cooperative_cancel_from_hold_invoice {
+                } else if sent_cooperative_cancel_request {
                     OperationResult::Info("Cooperative cancel request sent.".to_string())
                 } else {
                     OperationResult::Info("Message sent successfully".to_string())
@@ -185,18 +131,6 @@ pub fn handle_enter_viewing_message(
                 let _ = result_tx.send(out);
             }
             Err(e) => {
-                // #region agent log
-                debug_log_ui(
-                    "H1",
-                    "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:send_err",
-                    "Follow-up message failed",
-                    serde_json::json!({
-                        "order_id": order_id.to_string(),
-                        "source_action": format!("{:?}", source_action),
-                        "error": e.to_string(),
-                    }),
-                );
-                // #endregion
                 log::error!("Failed to send message: {}", e);
                 let _ = result_tx.send(OperationResult::Error(e.to_string()));
             }
@@ -218,18 +152,6 @@ pub fn handle_enter_message_notification(
             let order_result_tx_clone = ctx.order_result_tx.clone();
             if !invoice_state.invoice_input.trim().is_empty() {
                 if let Some(order_id) = order_id {
-                    // #region agent log
-                    debug_log_ui(
-                        "H2",
-                        "src/ui/key_handler/message_handlers.rs:handle_enter_message_notification:add_invoice_submit",
-                        "Submitting AddInvoice from popup",
-                        serde_json::json!({
-                            "order_id": order_id.to_string(),
-                            "invoice_len": invoice_state.invoice_input.len(),
-                            "popup_action": "AddInvoice",
-                        }),
-                    );
-                    // #endregion
                     // Set waiting mode based on user role
                     let default_mode = match app.user_role {
                         UserRole::User => UiMode::UserMode(UserMode::WaitingAddInvoice),

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -8,7 +8,28 @@ use crate::util::db_utils::update_order_status;
 use crate::util::order_utils::{execute_add_invoice, execute_rate_user, execute_send_msg};
 use mostro_core::order::Status;
 use mostro_core::prelude::*;
+use std::fs::OpenOptions;
+use std::io::Write;
 use uuid::Uuid;
+
+fn debug_log_ui(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
 
 /// Handle Enter key when viewing a message.
 pub fn handle_enter_viewing_message(
@@ -16,6 +37,19 @@ pub fn handle_enter_viewing_message(
     view_state: &MessageViewState,
     ctx: &EnterKeyContext<'_>,
 ) {
+    // #region agent log
+    debug_log_ui(
+        "H1",
+        "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:entry",
+        "ViewingMessage enter pressed",
+        serde_json::json!({
+            "source_action": format!("{:?}", view_state.action),
+            "button_selection": format!("{:?}", view_state.button_selection),
+            "order_id": view_state.order_id.map(|id| id.to_string()),
+        }),
+    );
+    // #endregion
+
     let default_mode = match app.user_role {
         UserRole::User => UiMode::UserMode(UserMode::Normal),
         UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
@@ -53,6 +87,17 @@ pub fn handle_enter_viewing_message(
             return;
         }
     };
+    // #region agent log
+    debug_log_ui(
+        "H1",
+        "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:action_map",
+        "Mapped source action to outbound action",
+        serde_json::json!({
+            "source_action": format!("{:?}", view_state.action),
+            "outbound_action": format!("{:?}", action_to_send),
+        }),
+    );
+    // #endregion
 
     // Get order_id from view_state
     let Some(order_id) = view_state.order_id else {
@@ -97,6 +142,18 @@ pub fn handle_enter_viewing_message(
         .await
         {
             Ok(_) => {
+                // #region agent log
+                debug_log_ui(
+                    "H1",
+                    "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:send_ok",
+                    "Follow-up message sent successfully",
+                    serde_json::json!({
+                        "order_id": order_id.to_string(),
+                        "source_action": format!("{:?}", source_action),
+                        "sent_cooperative_cancel_from_hold_invoice": sent_cooperative_cancel_from_hold_invoice,
+                    }),
+                );
+                // #endregion
                 let out = if source_action == Action::CooperativeCancelInitiatedByPeer {
                     match update_order_status(
                         &pool_clone,
@@ -128,6 +185,18 @@ pub fn handle_enter_viewing_message(
                 let _ = result_tx.send(out);
             }
             Err(e) => {
+                // #region agent log
+                debug_log_ui(
+                    "H1",
+                    "src/ui/key_handler/message_handlers.rs:handle_enter_viewing_message:send_err",
+                    "Follow-up message failed",
+                    serde_json::json!({
+                        "order_id": order_id.to_string(),
+                        "source_action": format!("{:?}", source_action),
+                        "error": e.to_string(),
+                    }),
+                );
+                // #endregion
                 log::error!("Failed to send message: {}", e);
                 let _ = result_tx.send(OperationResult::Error(e.to_string()));
             }
@@ -149,6 +218,18 @@ pub fn handle_enter_message_notification(
             let order_result_tx_clone = ctx.order_result_tx.clone();
             if !invoice_state.invoice_input.trim().is_empty() {
                 if let Some(order_id) = order_id {
+                    // #region agent log
+                    debug_log_ui(
+                        "H2",
+                        "src/ui/key_handler/message_handlers.rs:handle_enter_message_notification:add_invoice_submit",
+                        "Submitting AddInvoice from popup",
+                        serde_json::json!({
+                            "order_id": order_id.to_string(),
+                            "invoice_len": invoice_state.invoice_input.len(),
+                            "popup_action": "AddInvoice",
+                        }),
+                    );
+                    // #endregion
                     // Set waiting mode based on user role
                     let default_mode = match app.user_role {
                         UserRole::User => UiMode::UserMode(UserMode::WaitingAddInvoice),

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -23,7 +23,9 @@ pub fn handle_enter_viewing_message(
 
     // NO / dismiss without sending
     match &view_state.button_selection {
-        ViewingMessageButtonSelection::Two { yes_selected: false } => {
+        ViewingMessageButtonSelection::Two {
+            yes_selected: false,
+        } => {
             app.mode = default_mode;
             return;
         }

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -2,7 +2,7 @@ use crate::ui::key_handler::EnterKeyContext;
 use crate::ui::OperationResult;
 use crate::ui::{
     AdminMode, AppState, InvoiceNotificationActionSelection, MessageViewState, RatingOrderState,
-    UiMode, UserMode, UserRole, ViewingMessageButtonSelection,
+    ThreeState, UiMode, UserMode, UserRole, ViewingMessageButtonSelection,
 };
 use crate::util::db_utils::update_order_status;
 use crate::util::order_utils::{execute_add_invoice, execute_rate_user, execute_send_msg};
@@ -76,10 +76,7 @@ pub fn handle_enter_viewing_message(
     view_state: &MessageViewState,
     ctx: &EnterKeyContext<'_>,
 ) {
-    let default_mode = match app.user_role {
-        UserRole::User => UiMode::UserMode(UserMode::Normal),
-        UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
-    };
+    let default_mode = role_default_mode(app.user_role);
 
     // NO / dismiss without sending
     match &view_state.button_selection {
@@ -89,7 +86,7 @@ pub fn handle_enter_viewing_message(
             app.mode = default_mode;
             return;
         }
-        ViewingMessageButtonSelection::Three { selected: 1 } => {
+        ViewingMessageButtonSelection::Three(ThreeState::No) => {
             app.mode = default_mode;
             return;
         }
@@ -99,8 +96,17 @@ pub fn handle_enter_viewing_message(
     // Map the action from the message to the action we need to send
     let action_to_send = match &view_state.action {
         Action::HoldInvoicePaymentAccepted => match &view_state.button_selection {
-            ViewingMessageButtonSelection::Three { selected: 2 } => Action::Cancel,
-            _ => Action::FiatSent,
+            ViewingMessageButtonSelection::Three(ThreeState::Yes)
+            | ViewingMessageButtonSelection::Three(ThreeState::No) => Action::FiatSent,
+            ViewingMessageButtonSelection::Three(ThreeState::Cancel) => Action::Cancel,
+            ViewingMessageButtonSelection::Two { yes_selected } => {
+                if *yes_selected {
+                    Action::FiatSent
+                } else {
+                    app.mode = default_mode;
+                    return;
+                }
+            }
         },
         Action::BuyerTookOrder => Action::Cancel,
         Action::FiatSentOk => Action::Release,
@@ -120,20 +126,12 @@ pub fn handle_enter_viewing_message(
         let _ = ctx
             .order_result_tx
             .send(OperationResult::Error("No order ID in message".to_string()));
-        let default_mode = match app.user_role {
-            UserRole::User => UiMode::UserMode(UserMode::Normal),
-            UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
-        };
-        app.mode = default_mode;
+        app.mode = role_default_mode(app.user_role);
         return;
     };
 
     // Set waiting mode based on user role
-    let waiting_mode = match app.user_role {
-        UserRole::User => UiMode::UserMode(UserMode::WaitingAddInvoice),
-        UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
-    };
-    app.mode = waiting_mode;
+    app.mode = role_waiting_mode(app.user_role);
 
     // Spawn async task to send message
     let pool_clone = ctx.pool.clone();

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -2,6 +2,7 @@ use crate::ui::key_handler::EnterKeyContext;
 use crate::ui::OperationResult;
 use crate::ui::{
     AdminMode, AppState, MessageViewState, RatingOrderState, UiMode, UserMode, UserRole,
+    ViewingMessageButtonSelection,
 };
 use crate::util::db_utils::update_order_status;
 use crate::util::order_utils::{execute_add_invoice, execute_rate_user, execute_send_msg};
@@ -20,15 +21,25 @@ pub fn handle_enter_viewing_message(
         UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
     };
 
-    // Only proceed if YES is selected
-    if !view_state.selected_button {
-        app.mode = default_mode;
-        return;
+    // NO / dismiss without sending
+    match &view_state.button_selection {
+        ViewingMessageButtonSelection::Two { yes_selected: false } => {
+            app.mode = default_mode;
+            return;
+        }
+        ViewingMessageButtonSelection::Three { selected: 1 } => {
+            app.mode = default_mode;
+            return;
+        }
+        _ => {}
     }
 
     // Map the action from the message to the action we need to send
-    let action_to_send = match view_state.action {
-        Action::HoldInvoicePaymentAccepted => Action::FiatSent,
+    let action_to_send = match &view_state.action {
+        Action::HoldInvoicePaymentAccepted => match &view_state.button_selection {
+            ViewingMessageButtonSelection::Three { selected: 2 } => Action::Cancel,
+            _ => Action::FiatSent,
+        },
         Action::FiatSentOk => Action::Release,
         Action::CooperativeCancelInitiatedByPeer => Action::Cancel,
         // For Shift+C/F/R confirmations, the action is already the one we want to send.
@@ -68,6 +79,9 @@ pub fn handle_enter_viewing_message(
     let result_tx = ctx.order_result_tx.clone();
     let source_action = view_state.action.clone();
     let mostro_info = ctx.mostro_info.clone();
+    let sent_cooperative_cancel_from_hold_invoice =
+        matches!(view_state.action, Action::HoldInvoicePaymentAccepted)
+            && matches!(action_to_send, Action::Cancel);
 
     tokio::spawn(async move {
         match execute_send_msg(
@@ -104,6 +118,8 @@ pub fn handle_enter_viewing_message(
                             ))
                         }
                     }
+                } else if sent_cooperative_cancel_from_hold_invoice {
+                    OperationResult::Info("Cooperative cancel request sent.".to_string())
                 } else {
                     OperationResult::Info("Message sent successfully".to_string())
                 };

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -28,30 +28,9 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use sqlx::SqlitePool;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 use zeroize::Zeroizing;
-
-fn debug_log_keys(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
 
 /// Context passed to Enter and confirmation handlers to avoid too many arguments.
 pub struct EnterKeyContext<'a> {
@@ -875,22 +854,6 @@ pub fn handle_key_event(
                                 *yes_selected = true;
                             } else if code == KeyCode::Right {
                                 *yes_selected = false;
-                            }
-                            if matches!(view_state.action, Action::CooperativeCancelInitiatedByPeer)
-                            {
-                                // #region agent log
-                                debug_log_keys(
-                                    "H7",
-                                    "src/ui/key_handler/mod.rs:viewing_message_lr_toggle",
-                                    "Toggled peer cooperative-cancel confirmation selection",
-                                    serde_json::json!({
-                                        "key": format!("{:?}", code),
-                                        "action": format!("{:?}", view_state.action),
-                                        "yes_selected": *yes_selected,
-                                        "order_id": view_state.order_id.map(|id| id.to_string()),
-                                    }),
-                                );
-                                // #endregion
                             }
                         }
                         ViewingMessageButtonSelection::Three { selected } => {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -771,7 +771,8 @@ pub fn handle_key_event(
             .contains(crossterm::event::KeyModifiers::CONTROL);
         if code == KeyCode::Delete {
             if has_ctrl {
-                app.mode = UiMode::ConfirmBulkDeleteHistory(true);
+                // Default NO: avoid accidental Enter after Ctrl+Delete wiping all terminal history.
+                app.mode = UiMode::ConfirmBulkDeleteHistory(false);
                 return Some(true);
             }
             if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -796,7 +796,11 @@ pub fn handle_key_event(
                 UiMode::ViewingMessage(ref mut view_state) => {
                     match &mut view_state.button_selection {
                         ViewingMessageButtonSelection::Two { yes_selected } => {
-                            *yes_selected = !*yes_selected;
+                            if code == KeyCode::Left {
+                                *yes_selected = true;
+                            } else if code == KeyCode::Right {
+                                *yes_selected = false;
+                            }
                         }
                         ViewingMessageButtonSelection::Three { selected } => {
                             if code == KeyCode::Left {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -14,7 +14,7 @@ mod validation;
 
 use crate::ui::key_handler::chat_helpers::{
     build_order_action_view_state, build_rating_state_for_mytrades,
-    resolve_selected_mytrades_order_id,
+    resolve_selected_mytrades_order_status,
 };
 use crate::ui::{
     helpers::{get_visible_attachment_messages, is_dispute_finalized},
@@ -49,6 +49,21 @@ pub struct EnterKeyContext<'a> {
     pub mostro_info: Option<MostroInstanceInfo>,
     pub admin_chat_keys: Option<&'a Keys>,
     pub dm_subscription_tx: &'a UnboundedSender<OrderDmSubscriptionCmd>,
+}
+
+fn is_terminal_order_status(status: Option<Status>) -> bool {
+    matches!(
+        status,
+        Some(
+            Status::Success
+                | Status::Canceled
+                | Status::CanceledByAdmin
+                | Status::SettledByAdmin
+                | Status::CompletedByAdmin
+                | Status::Expired
+                | Status::CooperativelyCanceled
+        )
+    )
 }
 
 // Re-export public functions
@@ -680,6 +695,25 @@ pub fn handle_key_event(
         let has_shift = key_event
             .modifiers
             .contains(crossterm::event::KeyModifiers::SHIFT);
+        let has_ctrl = key_event
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL);
+        if code == KeyCode::Delete {
+            if has_ctrl {
+                app.mode = UiMode::ConfirmBulkDeleteHistory(true);
+                return Some(true);
+            }
+            if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
+                if is_terminal_order_status(status) {
+                    app.mode = UiMode::ConfirmDeleteHistoryOrder(order_id, true);
+                } else {
+                    app.mode = UiMode::OperationResult(OperationResult::Info(
+                        "Delete is only available for terminal orders.".to_string(),
+                    ));
+                }
+                return Some(true);
+            }
+        }
         if has_shift {
             match code {
                 KeyCode::Char('i') | KeyCode::Char('I') => {
@@ -698,7 +732,13 @@ pub fn handle_key_event(
                     }
                 }
                 KeyCode::Char('c') | KeyCode::Char('C') => {
-                    if let Some(order_id) = resolve_selected_mytrades_order_id(app) {
+                    if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
+                        if is_terminal_order_status(status) {
+                            app.mode = UiMode::OperationResult(OperationResult::Info(
+                                "Cancel is disabled for terminal orders.".to_string(),
+                            ));
+                            return Some(true);
+                        }
                         let msg = crate::ui::constants::HELP_MY_TRADES_CANCEL_MSG;
                         let view_state = build_order_action_view_state(
                             order_id,
@@ -710,7 +750,13 @@ pub fn handle_key_event(
                     }
                 }
                 KeyCode::Char('f') | KeyCode::Char('F') => {
-                    if let Some(order_id) = resolve_selected_mytrades_order_id(app) {
+                    if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
+                        if is_terminal_order_status(status) {
+                            app.mode = UiMode::OperationResult(OperationResult::Info(
+                                "FiatSent is disabled for terminal orders.".to_string(),
+                            ));
+                            return Some(true);
+                        }
                         let msg = crate::ui::constants::HELP_MY_TRADES_FIAT_SENT_MSG;
                         let view_state = build_order_action_view_state(
                             order_id,
@@ -722,7 +768,13 @@ pub fn handle_key_event(
                     }
                 }
                 KeyCode::Char('r') | KeyCode::Char('R') => {
-                    if let Some(order_id) = resolve_selected_mytrades_order_id(app) {
+                    if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
+                        if is_terminal_order_status(status) {
+                            app.mode = UiMode::OperationResult(OperationResult::Info(
+                                "Release is disabled for terminal orders.".to_string(),
+                            ));
+                            return Some(true);
+                        }
                         let msg = crate::ui::constants::HELP_MY_TRADES_RELEASE_MSG;
                         let view_state = build_order_action_view_state(
                             order_id,
@@ -788,6 +840,8 @@ pub fn handle_key_event(
                 | UiMode::ConfirmRelay(_, ref mut selected_button)
                 | UiMode::ConfirmCurrency(_, ref mut selected_button)
                 | UiMode::ConfirmClearCurrencies(ref mut selected_button)
+                | UiMode::ConfirmDeleteHistoryOrder(_, ref mut selected_button)
+                | UiMode::ConfirmBulkDeleteHistory(ref mut selected_button)
                 | UiMode::ConfirmGenerateNewKeys(ref mut selected_button)
                 | UiMode::ConfirmExit(ref mut selected_button) => {
                     *selected_button = !*selected_button; // Toggle between YES and NO

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -19,8 +19,8 @@ use crate::ui::key_handler::chat_helpers::{
 use crate::ui::{
     helpers::{get_visible_attachment_messages, is_dispute_finalized},
     AdminMode, AdminTab, AppState, ChatAttachment, ChatSender, DisputeFilter,
-    MostroInfoFetchResult, OperationResult, Tab, TakeOrderState, UiMode, UserMode, UserTab,
-    ViewingMessageButtonSelection,
+    InvoiceNotificationActionSelection, MostroInfoFetchResult, OperationResult, Tab,
+    TakeOrderState, UiMode, UserMode, UserTab, ViewingMessageButtonSelection,
 };
 use crate::util::MostroInstanceInfo;
 use crate::util::OrderDmSubscriptionCmd;
@@ -280,6 +280,33 @@ fn read_clipboard_text_best_effort() -> Option<String> {
     }
 }
 
+fn is_paste_shortcut(key_event: &KeyEvent) -> bool {
+    let is_ctrl = key_event.modifiers.contains(KeyModifiers::CONTROL);
+    let is_shift = key_event.modifiers.contains(KeyModifiers::SHIFT);
+    match key_event.code {
+        KeyCode::Insert => is_shift,
+        KeyCode::Char('v') | KeyCode::Char('V') => is_ctrl,
+        _ => false,
+    }
+}
+
+fn update_invoice_notification_action_selection(
+    code: KeyCode,
+    invoice_state: &mut crate::ui::InvoiceInputState,
+) -> bool {
+    match code {
+        KeyCode::Left => {
+            invoice_state.action_selection = InvoiceNotificationActionSelection::Primary;
+            true
+        }
+        KeyCode::Right => {
+            invoice_state.action_selection = InvoiceNotificationActionSelection::Cancel;
+            true
+        }
+        _ => false,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Main key event handler - dispatches to appropriate handlers
 pub fn handle_key_event(
@@ -356,22 +383,23 @@ pub fn handle_key_event(
         }
     }
 
-    // Observer tab paste fallback for terminals without bracketed paste (notably cmd.exe):
-    // - Shift+Insert (classic Windows paste)
-    // - Ctrl+Shift+V (Windows Terminal-style paste shortcut)
-    // - Ctrl+V when the console delivers it as a key event
-    if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-        let is_ctrl = key_event.modifiers.contains(KeyModifiers::CONTROL);
-        let is_shift = key_event.modifiers.contains(KeyModifiers::SHIFT);
-        let is_paste_shortcut = match key_event.code {
-            KeyCode::Insert => is_shift,
-            KeyCode::Char('v') | KeyCode::Char('V') => is_ctrl,
-            _ => false,
-        } || (is_ctrl
-            && is_shift
-            && matches!(key_event.code, KeyCode::Char('v') | KeyCode::Char('V')));
+    // AddInvoice popup paste fallback for terminals without bracketed paste support.
+    if let UiMode::NewMessageNotification(_, Action::AddInvoice, ref mut invoice_state) = app.mode {
+        if is_paste_shortcut(&key_event) {
+            if let Some(text) = read_clipboard_text_best_effort() {
+                let filtered_text: String = text.chars().filter(|c| !c.is_control()).collect();
+                if !filtered_text.is_empty() {
+                    invoice_state.invoice_input.push_str(&filtered_text);
+                    invoice_state.just_pasted = true;
+                    return Some(true);
+                }
+            }
+        }
+    }
 
-        if is_paste_shortcut {
+    // Observer tab paste fallback for terminals without bracketed paste (notably cmd.exe).
+    if let Tab::Admin(AdminTab::Observer) = app.active_tab {
+        if is_paste_shortcut(&key_event) {
             if let Some(text) = read_clipboard_text_best_effort() {
                 let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
                 if !filtered.is_empty() {
@@ -866,6 +894,16 @@ pub fn handle_key_event(
                     }
                     return Some(true);
                 }
+                UiMode::NewMessageNotification(
+                    _,
+                    Action::AddInvoice | Action::PayInvoice,
+                    ref mut invoice_state,
+                ) => {
+                    return Some(update_invoice_notification_action_selection(
+                        code,
+                        invoice_state,
+                    ))
+                }
                 UiMode::AdminMode(AdminMode::ReviewingDisputeForFinalization {
                     dispute_id,
                     ref mut selected_button_index,
@@ -1041,5 +1079,50 @@ pub fn handle_key_event(
             Some(true)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod key_handler_tests {
+    use super::*;
+    use crate::ui::{InvoiceInputState, InvoiceNotificationActionSelection};
+    use crossterm::event::KeyModifiers;
+
+    #[test]
+    fn paste_shortcut_accepts_shift_insert_and_ctrl_v() {
+        let shift_insert = KeyEvent::new(KeyCode::Insert, KeyModifiers::SHIFT);
+        assert!(is_paste_shortcut(&shift_insert));
+
+        let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(is_paste_shortcut(&ctrl_v));
+    }
+
+    #[test]
+    fn invoice_notification_selection_toggles_with_arrows() {
+        let mut state = InvoiceInputState {
+            invoice_input: String::new(),
+            focused: true,
+            just_pasted: false,
+            copied_to_clipboard: false,
+            scroll_y: 0,
+            action_selection: InvoiceNotificationActionSelection::Primary,
+        };
+
+        assert!(update_invoice_notification_action_selection(
+            KeyCode::Right,
+            &mut state
+        ));
+        assert_eq!(
+            state.action_selection,
+            InvoiceNotificationActionSelection::Cancel
+        );
+        assert!(update_invoice_notification_action_selection(
+            KeyCode::Left,
+            &mut state
+        ));
+        assert_eq!(
+            state.action_selection,
+            InvoiceNotificationActionSelection::Primary
+        );
     }
 }

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -24,7 +24,7 @@ use crate::ui::{
 };
 use crate::util::MostroInstanceInfo;
 use crate::util::OrderDmSubscriptionCmd;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use sqlx::SqlitePool;
@@ -278,6 +278,49 @@ fn read_clipboard_text_best_effort() -> Option<String> {
             None
         }
     }
+}
+
+/// Mouse right-click paste fallback for AddInvoice notification popup.
+///
+/// Returns `true` when the event is fully handled and should be consumed by the caller.
+pub fn handle_mouse_invoice_paste_fallback(event: &Event, app: &mut AppState) -> bool {
+    let Event::Mouse(mouse_event) = event else {
+        return false;
+    };
+    if !matches!(mouse_event.kind, MouseEventKind::Down(MouseButton::Right)) {
+        return false;
+    }
+    log::debug!(
+        "Detected right-click mouse event at x={}, y={}",
+        mouse_event.column,
+        mouse_event.row
+    );
+    let UiMode::NewMessageNotification(_, Action::AddInvoice, ref mut invoice_state) = app.mode
+    else {
+        return false;
+    };
+    if !invoice_state.focused {
+        return false;
+    }
+    if let Some(text) = read_clipboard_text_best_effort() {
+        let filtered_text: String = text
+            .chars()
+            .filter(|c| !c.is_control() || *c == '\t')
+            .collect();
+        if !filtered_text.is_empty() {
+            log::debug!(
+                "Right-click paste fallback appended {} chars to AddInvoice input",
+                filtered_text.chars().count()
+            );
+            invoice_state.invoice_input.push_str(&filtered_text);
+            invoice_state.just_pasted = true;
+        } else {
+            log::debug!("Right-click paste fallback found only control characters");
+        }
+    } else {
+        log::debug!("Right-click paste fallback could not read clipboard text");
+    }
+    true
 }
 
 fn is_paste_shortcut(key_event: &KeyEvent) -> bool {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -20,6 +20,7 @@ use crate::ui::{
     helpers::{get_visible_attachment_messages, is_dispute_finalized},
     AdminMode, AdminTab, AppState, ChatAttachment, ChatSender, DisputeFilter,
     MostroInfoFetchResult, OperationResult, Tab, TakeOrderState, UiMode, UserMode, UserTab,
+    ViewingMessageButtonSelection,
 };
 use crate::util::MostroInstanceInfo;
 use crate::util::OrderDmSubscriptionCmd;
@@ -793,7 +794,18 @@ pub fn handle_key_event(
                     return Some(true);
                 }
                 UiMode::ViewingMessage(ref mut view_state) => {
-                    view_state.selected_button = !view_state.selected_button; // Toggle between YES and NO
+                    match &mut view_state.button_selection {
+                        ViewingMessageButtonSelection::Two { yes_selected } => {
+                            *yes_selected = !*yes_selected;
+                        }
+                        ViewingMessageButtonSelection::Three { selected } => {
+                            if code == KeyCode::Left {
+                                *selected = (*selected + 2) % 3;
+                            } else {
+                                *selected = (*selected + 1) % 3;
+                            }
+                        }
+                    }
                     return Some(true);
                 }
                 UiMode::AdminMode(AdminMode::ReviewingDisputeForFinalization {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -28,9 +28,30 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use sqlx::SqlitePool;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 use zeroize::Zeroizing;
+
+fn debug_log_keys(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
 
 /// Context passed to Enter and confirmation handlers to avoid too many arguments.
 pub struct EnterKeyContext<'a> {
@@ -854,6 +875,22 @@ pub fn handle_key_event(
                                 *yes_selected = true;
                             } else if code == KeyCode::Right {
                                 *yes_selected = false;
+                            }
+                            if matches!(view_state.action, Action::CooperativeCancelInitiatedByPeer)
+                            {
+                                // #region agent log
+                                debug_log_keys(
+                                    "H7",
+                                    "src/ui/key_handler/mod.rs:viewing_message_lr_toggle",
+                                    "Toggled peer cooperative-cancel confirmation selection",
+                                    serde_json::json!({
+                                        "key": format!("{:?}", code),
+                                        "action": format!("{:?}", view_state.action),
+                                        "yes_selected": *yes_selected,
+                                        "order_id": view_state.order_id.map(|id| id.to_string()),
+                                    }),
+                                );
+                                // #endregion
                             }
                         }
                         ViewingMessageButtonSelection::Three { selected } => {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -927,11 +927,11 @@ pub fn handle_key_event(
                                 *yes_selected = false;
                             }
                         }
-                        ViewingMessageButtonSelection::Three { selected } => {
+                        selection @ ViewingMessageButtonSelection::Three(_) => {
                             if code == KeyCode::Left {
-                                *selected = (*selected + 2) % 3;
+                                selection.cycle_three_prev();
                             } else {
-                                *selected = (*selected + 1) % 3;
+                                selection.cycle_three_next();
                             }
                         }
                     }

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -1,6 +1,7 @@
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::{
     AdminMode, AdminTab, AppState, FormState, Tab, UiMode, UserMode, UserRole, UserTab,
+    ViewingMessageButtonSelection,
 };
 use crossterm::event::KeyCode;
 use mostro_core::prelude::*;
@@ -60,8 +61,14 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             take_state.selected_button = true;
         }
         UiMode::ViewingMessage(ref mut view_state) => {
-            // Switch to YES button (left side)
-            view_state.selected_button = true;
+            match &mut view_state.button_selection {
+                ViewingMessageButtonSelection::Two { yes_selected } => {
+                    *yes_selected = true;
+                }
+                ViewingMessageButtonSelection::Three { selected } => {
+                    *selected = (*selected + 2) % 3;
+                }
+            }
         }
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
@@ -122,8 +129,14 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             take_state.selected_button = false;
         }
         UiMode::ViewingMessage(ref mut view_state) => {
-            // Switch to NO button (right side)
-            view_state.selected_button = false;
+            match &mut view_state.button_selection {
+                ViewingMessageButtonSelection::Two { yes_selected } => {
+                    *yes_selected = false;
+                }
+                ViewingMessageButtonSelection::Three { selected } => {
+                    *selected = (*selected + 1) % 3;
+                }
+            }
         }
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -60,16 +60,14 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             // Switch to YES button (left side)
             take_state.selected_button = true;
         }
-        UiMode::ViewingMessage(ref mut view_state) => {
-            match &mut view_state.button_selection {
-                ViewingMessageButtonSelection::Two { yes_selected } => {
-                    *yes_selected = true;
-                }
-                ViewingMessageButtonSelection::Three { selected } => {
-                    *selected = (*selected + 2) % 3;
-                }
+        UiMode::ViewingMessage(ref mut view_state) => match &mut view_state.button_selection {
+            ViewingMessageButtonSelection::Two { yes_selected } => {
+                *yes_selected = true;
             }
-        }
+            ViewingMessageButtonSelection::Three { selected } => {
+                *selected = (*selected + 2) % 3;
+            }
+        },
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmFinalizeDispute {
@@ -128,16 +126,14 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             // Switch to NO button (right side)
             take_state.selected_button = false;
         }
-        UiMode::ViewingMessage(ref mut view_state) => {
-            match &mut view_state.button_selection {
-                ViewingMessageButtonSelection::Two { yes_selected } => {
-                    *yes_selected = false;
-                }
-                ViewingMessageButtonSelection::Three { selected } => {
-                    *selected = (*selected + 1) % 3;
-                }
+        UiMode::ViewingMessage(ref mut view_state) => match &mut view_state.button_selection {
+            ViewingMessageButtonSelection::Two { yes_selected } => {
+                *yes_selected = false;
             }
-        }
+            ViewingMessageButtonSelection::Three { selected } => {
+                *selected = (*selected + 1) % 3;
+            }
+        },
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmFinalizeDispute {

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -1,3 +1,4 @@
+use crate::ui::helpers::build_active_order_chat_list;
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::{
     AdminMode, AdminTab, AppState, FormState, Tab, UiMode, UserMode, UserRole, UserTab,
@@ -250,14 +251,11 @@ fn handle_up_key(
                     }
                 }
             } else if let Tab::User(UserTab::MyTrades) = app.active_tab {
-                let order_ids: std::collections::HashSet<String> = match app.messages.lock() {
-                    Ok(g) => g
-                        .iter()
-                        .filter_map(|m| m.order_id.map(|id| id.to_string()))
-                        .collect(),
-                    Err(_) => std::collections::HashSet::new(),
+                let n = match app.messages.lock() {
+                    Ok(g) => build_active_order_chat_list(&g).len(),
+                    Err(_) => 0,
                 };
-                if !order_ids.is_empty() && app.selected_order_chat_idx > 0 {
+                if n > 0 && app.selected_order_chat_idx > 0 {
                     app.selected_order_chat_idx -= 1;
                 }
             } else if matches!(
@@ -403,11 +401,11 @@ fn handle_down_key(
                     }
                 }
             } else if let Tab::User(UserTab::MyTrades) = app.active_tab {
-                let count = match app.messages.lock() {
-                    Ok(g) => g.iter().filter(|m| m.order_id.is_some()).count(),
+                let n = match app.messages.lock() {
+                    Ok(g) => build_active_order_chat_list(&g).len(),
                     Err(_) => 0,
                 };
-                if count > 0 && app.selected_order_chat_idx < count.saturating_sub(1) {
+                if n > 0 && app.selected_order_chat_idx < n.saturating_sub(1) {
                     app.selected_order_chat_idx += 1;
                 }
             } else if matches!(

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -78,6 +78,8 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
         | UiMode::ConfirmRelay(_, ref mut selected_button)
         | UiMode::ConfirmCurrency(_, ref mut selected_button)
         | UiMode::ConfirmClearCurrencies(ref mut selected_button)
+        | UiMode::ConfirmDeleteHistoryOrder(_, ref mut selected_button)
+        | UiMode::ConfirmBulkDeleteHistory(ref mut selected_button)
         | UiMode::ConfirmExit(ref mut selected_button) => {
             // Switch to YES button (left side)
             *selected_button = true;
@@ -144,6 +146,8 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
         | UiMode::ConfirmRelay(_, ref mut selected_button)
         | UiMode::ConfirmCurrency(_, ref mut selected_button)
         | UiMode::ConfirmClearCurrencies(ref mut selected_button)
+        | UiMode::ConfirmDeleteHistoryOrder(_, ref mut selected_button)
+        | UiMode::ConfirmBulkDeleteHistory(ref mut selected_button)
         | UiMode::ConfirmExit(ref mut selected_button) => {
             // Switch to NO button (right side)
             *selected_button = false;
@@ -296,6 +300,8 @@ fn handle_up_key(
         | UiMode::AddCurrency(_)
         | UiMode::ConfirmCurrency(_, _)
         | UiMode::ConfirmClearCurrencies(_)
+        | UiMode::ConfirmDeleteHistoryOrder(_, _)
+        | UiMode::ConfirmBulkDeleteHistory(_)
         | UiMode::ConfirmGenerateNewKeys(_)
         | UiMode::BackupNewKeys(_)
         | UiMode::ConfirmExit(_) => {
@@ -462,6 +468,8 @@ fn handle_down_key(
         | UiMode::AddCurrency(_)
         | UiMode::ConfirmCurrency(_, _)
         | UiMode::ConfirmClearCurrencies(_)
+        | UiMode::ConfirmDeleteHistoryOrder(_, _)
+        | UiMode::ConfirmBulkDeleteHistory(_)
         | UiMode::ConfirmGenerateNewKeys(_)
         | UiMode::BackupNewKeys(_)
         | UiMode::ConfirmExit(_) => {

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -64,8 +64,8 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             ViewingMessageButtonSelection::Two { yes_selected } => {
                 *yes_selected = true;
             }
-            ViewingMessageButtonSelection::Three { selected } => {
-                *selected = (*selected + 2) % 3;
+            selection @ ViewingMessageButtonSelection::Three(_) => {
+                selection.cycle_three_prev();
             }
         },
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
@@ -132,8 +132,8 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
             ViewingMessageButtonSelection::Two { yes_selected } => {
                 *yes_selected = false;
             }
-            ViewingMessageButtonSelection::Three { selected } => {
-                *selected = (*selected + 1) % 3;
+            selection @ ViewingMessageButtonSelection::Three(_) => {
+                selection.cycle_three_next();
             }
         },
         UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))

--- a/src/ui/message_notification.rs
+++ b/src/ui/message_notification.rs
@@ -3,7 +3,10 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
-use super::{helpers, InvoiceInputState, MessageNotification, BACKGROUND_COLOR, PRIMARY_COLOR};
+use super::{
+    helpers, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification,
+    BACKGROUND_COLOR, PRIMARY_COLOR,
+};
 
 /// Renders the order ID header in a notification popup
 fn render_order_id_header(f: &mut ratatui::Frame, area: Rect, order_id_str: &str) {
@@ -129,9 +132,9 @@ fn render_add_invoice(
             Constraint::Length(1), // label
             Constraint::Length(6), // invoice input field
             Constraint::Length(1), // spacer
-            Constraint::Length(1), // help text (paste instructions)
-            Constraint::Length(1), // help text (esc instructions)
-            Constraint::Length(1), // extra spacer
+            Constraint::Length(3), // action buttons
+            Constraint::Length(1), // help text (navigation)
+            Constraint::Length(1), // help text (paste/dismiss)
         ],
     )
     .split(popup);
@@ -156,31 +159,67 @@ fn render_add_invoice(
     let input_area = create_input_area(chunks[5]);
     render_invoice_input(f, input_area, invoice_state);
 
-    // Help text
+    helpers::render_yes_no_buttons(
+        f,
+        chunks[7],
+        matches!(
+            invoice_state.action_selection,
+            InvoiceNotificationActionSelection::Primary
+        ),
+        "Submit Invoice",
+        "Cancel Order",
+    );
+
     f.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("Paste invoice (", Style::default()),
+            Span::styled("Use ", Style::default()),
             Span::styled(
-                "Ctrl+Shift+V",
+                "Left/Right",
                 Style::default()
                     .fg(PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" or right-click), then press ", Style::default()),
+            Span::styled(" to select action, ", Style::default()),
             Span::styled(
                 "Enter",
                 Style::default()
                     .fg(PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" to submit", Style::default()),
+            Span::styled(" to confirm", Style::default()),
         ]))
         .alignment(ratatui::layout::Alignment::Center),
-        chunks[7],
+        chunks[8],
     );
 
-    // Esc help text
-    helpers::render_help_text(f, chunks[8], "Press ", "Esc", " to dismiss");
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Paste invoice (right-click / ", Style::default()),
+            Span::styled(
+                "Shift+Insert",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" / ", Style::default()),
+            Span::styled(
+                "Ctrl+Shift+V",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("), ", Style::default()),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" dismiss", Style::default()),
+        ]))
+        .alignment(ratatui::layout::Alignment::Center),
+        chunks[9],
+    );
 }
 
 /// Renders PayInvoice notification popup
@@ -200,6 +239,7 @@ fn render_pay_invoice(
             Constraint::Length(1), // label
             Constraint::Length(6), // invoice display field
             Constraint::Length(1), // spacer
+            Constraint::Length(3), // action buttons
             Constraint::Length(1), // help text line 1
             Constraint::Length(1), // help text line 2
         ],
@@ -227,11 +267,23 @@ fn render_pay_invoice(
         chunks[4],
     );
 
+    let invoice_area = create_input_area(chunks[5]);
     render_invoice_display(
         f,
-        chunks[5],
+        invoice_area,
         notification.invoice.as_ref(),
         invoice_state.scroll_y,
+    );
+
+    helpers::render_yes_no_buttons(
+        f,
+        chunks[7],
+        matches!(
+            invoice_state.action_selection,
+            InvoiceNotificationActionSelection::Primary
+        ),
+        "Acknowledge",
+        "Cancel Order",
     );
 
     // Help text - first line
@@ -244,7 +296,7 @@ fn render_pay_invoice(
                     .add_modifier(Modifier::BOLD),
             )]))
             .alignment(ratatui::layout::Alignment::Center),
-            chunks[7],
+            chunks[8],
         );
     } else {
         f.render_widget(
@@ -265,15 +317,15 @@ fn render_pay_invoice(
                 ),
                 Span::styled(" scroll, ", Style::default()),
                 Span::styled(
-                    "Shift",
+                    "Left/Right",
                     Style::default()
                         .fg(PRIMARY_COLOR)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled("+click to select", Style::default()),
+                Span::styled(" select action", Style::default()),
             ]))
             .alignment(ratatui::layout::Alignment::Center),
-            chunks[7],
+            chunks[8],
         );
     }
 
@@ -287,7 +339,7 @@ fn render_pay_invoice(
                     .fg(PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" to view, ", Style::default()),
+            Span::styled(" to confirm, ", Style::default()),
             Span::styled(
                 "Esc",
                 Style::default()
@@ -297,7 +349,7 @@ fn render_pay_invoice(
             Span::styled(" to dismiss", Style::default()),
         ]))
         .alignment(ratatui::layout::Alignment::Center),
-        chunks[8],
+        chunks[9],
     );
 }
 

--- a/src/ui/message_notification.rs
+++ b/src/ui/message_notification.rs
@@ -425,7 +425,7 @@ pub fn render_message_notification(
     let area = f.area();
     let (popup_width, popup_height) = match action {
         mostro_core::prelude::Action::AddInvoice | mostro_core::prelude::Action::PayInvoice => {
-            (90, 18)
+            (90, 19)
         }
         _ => (70, 8),
     };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -42,6 +42,7 @@ pub use state::{
     DisputeFilter, FormState, InvoiceInputState, InvoiceNotificationActionSelection, KeyInputState,
     MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult,
     OrderChatLastSeen, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,
-    UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab, ViewingMessageButtonSelection,
+    ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
+    ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,8 +41,8 @@ pub use state::{
     AppState, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender, DisputeChatMessage,
     DisputeFilter, FormState, InvoiceInputState, InvoiceNotificationActionSelection, KeyInputState,
     MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult,
-    OrderChatLastSeen, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,
-    ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
+    OrderChatLastSeen, OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab,
+    TakeOrderState, ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
     ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,6 +41,7 @@ pub use state::{
     AppState, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender, DisputeChatMessage,
     DisputeFilter, FormState, InvoiceInputState, KeyInputState, MessageNotification,
     MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen, OrderChatUpdate,
+    ViewingMessageButtonSelection,
     OrderMessage, RatingOrderState, Tab, TakeOrderState, UiMode, UserChatSender,
     UserOrderChatMessage, UserRole, UserTab,
 };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,8 +41,7 @@ pub use state::{
     AppState, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender, DisputeChatMessage,
     DisputeFilter, FormState, InvoiceInputState, KeyInputState, MessageNotification,
     MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen, OrderChatUpdate,
-    ViewingMessageButtonSelection,
     OrderMessage, RatingOrderState, Tab, TakeOrderState, UiMode, UserChatSender,
-    UserOrderChatMessage, UserRole, UserTab,
+    UserOrderChatMessage, UserRole, UserTab, ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,9 +39,9 @@ pub use network_status::NetworkStatus;
 pub use state::{
     apply_kind_color, order_message_to_notification, AdminChatLastSeen, AdminChatUpdate, AdminTab,
     AppState, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender, DisputeChatMessage,
-    DisputeFilter, FormState, InvoiceInputState, KeyInputState, MessageNotification,
-    MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen, OrderChatUpdate,
-    OrderMessage, RatingOrderState, Tab, TakeOrderState, UiMode, UserChatSender,
-    UserOrderChatMessage, UserRole, UserTab, ViewingMessageButtonSelection,
+    DisputeFilter, FormState, InvoiceInputState, InvoiceNotificationActionSelection, KeyInputState,
+    MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult,
+    OrderChatLastSeen, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,
+    UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab, ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -16,7 +16,8 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
         | OperationResult::ObserverChatError(_) => 8,
         OperationResult::Error(_)
         | OperationResult::Info(_)
-        | OperationResult::TradeClosed { .. } => 8,
+        | OperationResult::TradeClosed { .. }
+        | OperationResult::OrderHistoryDeleted { .. } => 8,
     };
     // Center the popup using Flex::Center
     let popup = {
@@ -168,7 +169,9 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
         }
-        OperationResult::Info(message) | OperationResult::TradeClosed { message, .. } => {
+        OperationResult::Info(message)
+        | OperationResult::TradeClosed { message, .. }
+        | OperationResult::OrderHistoryDeleted { message, .. } => {
             let block = Block::default()
                 .title("✅ Operation Successful")
                 .borders(Borders::ALL)

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -46,6 +46,7 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             premium,
             status,
             trade_index: _,
+            ..
         }) => {
             let block = Block::default()
                 .title("✅ Order Created Successfully")

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Style};
 
 use crate::ui::constants::{
     BUY_ORDER_FLOW_STEPS_MAKER, BUY_ORDER_FLOW_STEPS_TAKER, GENERIC_ORDER_FLOW_STEPS_TAKER,
-    SELL_ORDER_FLOW_STEPS_MAKER, SELL_ORDER_FLOW_STEPS_TAKER,
+    SELL_ORDER_FLOW_STEPS_MAKER, SELL_ORDER_FLOW_STEPS_TAKER, VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
 };
 
 pub use crate::ui::constants::StepLabel;
@@ -288,9 +288,7 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
         Action::FiatSentOk => "Fiat payment completed",
         Action::WaitingBuyerInvoice => "Waiting for Buyer to Add Invoice",
         Action::WaitingSellerToPay => "Waiting for Seller to Pay",
-        Action::HoldInvoicePaymentAccepted => {
-            crate::ui::constants::VIEW_MESSAGE_HOLD_INVOICE_PREVIEW
-        }
+        Action::HoldInvoicePaymentAccepted => VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
         Action::Cancel => "Cancel",
         Action::CooperativeCancelInitiatedByPeer => "Peer requested cooperative cancel",
         Action::Canceled => "Order canceled",

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -247,13 +247,22 @@ pub struct KeyInputState {
     pub just_pasted: bool, // Flag to ignore Enter immediately after paste
 }
 
+/// YES/NO selection for `ViewingMessage` popups (FiatSentOk, My Trades actions, etc.).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ViewingMessageButtonSelection {
+    /// `true` = YES highlighted, `false` = NO.
+    Two { yes_selected: bool },
+    /// Hold-invoice confirmation only: `0` = YES, `1` = NO, `2` = CANCEL (cooperative cancel).
+    Three { selected: u8 },
+}
+
 /// State for viewing a simple message popup
 #[derive(Clone, Debug)]
 pub struct MessageViewState {
     pub message_content: String, // The message content to display
     pub order_id: Option<uuid::Uuid>,
     pub action: Action,
-    pub selected_button: bool, // true for YES, false for NO
+    pub button_selection: ViewingMessageButtonSelection,
 }
 
 /// Rate counterparty after Mostro prompts with `action: rate` (daemon resolves peer by order id).
@@ -279,9 +288,7 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
         Action::FiatSentOk => "Fiat payment completed",
         Action::WaitingBuyerInvoice => "Waiting for Buyer to Add Invoice",
         Action::WaitingSellerToPay => "Waiting for Seller to Pay",
-        Action::HoldInvoicePaymentAccepted => {
-            "Hold invoice payment accepted — confirm fiat was sent?"
-        }
+        Action::HoldInvoicePaymentAccepted => crate::ui::constants::VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
         Action::Cancel => "Cancel",
         Action::CooperativeCancelInitiatedByPeer => "Peer requested cooperative cancel",
         Action::Canceled => "Order canceled",

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -288,7 +288,9 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
         Action::FiatSentOk => "Fiat payment completed",
         Action::WaitingBuyerInvoice => "Waiting for Buyer to Add Invoice",
         Action::WaitingSellerToPay => "Waiting for Seller to Pay",
-        Action::HoldInvoicePaymentAccepted => crate::ui::constants::VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
+        Action::HoldInvoicePaymentAccepted => {
+            crate::ui::constants::VIEW_MESSAGE_HOLD_INVOICE_PREVIEW
+        }
         Action::Cancel => "Cancel",
         Action::CooperativeCancelInitiatedByPeer => "Peer requested cooperative cancel",
         Action::Canceled => "Order canceled",

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -46,6 +46,11 @@ pub enum OperationResult {
         order_id: uuid::Uuid,
         message: String,
     },
+    /// Local-only history cleanup result; remove these order rows from in-memory My Trades cache.
+    OrderHistoryDeleted {
+        deleted_order_ids: Vec<uuid::Uuid>,
+        message: String,
+    },
 }
 
 /// Result of an async Mostro instance info fetch (sent from key handlers to main loop).
@@ -318,6 +323,7 @@ pub fn message_action_compact_label(action: &Action) -> &'static str {
         Action::WaitingBuyerInvoice => "Waiting Buyer Invoice",
         Action::WaitingSellerToPay => "Waiting Seller Payment",
         Action::HoldInvoicePaymentAccepted => "Hold Invoice Accepted",
+        Action::BuyerTookOrder => "Buyer Took Order",
         Action::FiatSent => "Fiat Sent",
         Action::FiatSentOk => "Fiat Confirmed",
         Action::Release | Action::Released => "Release sats",
@@ -326,8 +332,10 @@ pub fn message_action_compact_label(action: &Action) -> &'static str {
         Action::AdminCanceled => "Admin Canceled",
         Action::Rate => "Rate Counterparty",
         Action::RateReceived => "Rating Received",
-        Action::CooperativeCancelInitiatedByPeer => "Cooperative Cancel Initiated",
-        _ => "Message",
+        Action::CooperativeCancelInitiatedByPeer => "Cooperative Cancel Initiated by Peer",
+        Action::CooperativeCancelInitiatedByYou => "Cooperative Cancel Initiated by You",
+        Action::NewOrder => "New Order Created",
+        _ => "Unknown Message",
     }
 }
 

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -1,12 +1,11 @@
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use ratatui::style::{Color, Style};
-use std::fs::OpenOptions;
-use std::io::Write;
 
 use crate::ui::constants::{
     BUY_ORDER_FLOW_STEPS_MAKER, BUY_ORDER_FLOW_STEPS_TAKER, GENERIC_ORDER_FLOW_STEPS_TAKER,
-    SELL_ORDER_FLOW_STEPS_MAKER, SELL_ORDER_FLOW_STEPS_TAKER, VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
+    SELL_ORDER_FLOW_STEPS_MAKER, SELL_ORDER_FLOW_STEPS_TAKER,
+    VIEW_MESSAGE_BUYER_TOOK_ORDER_PREVIEW, VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
 };
 
 pub use crate::ui::constants::StepLabel;
@@ -187,58 +186,13 @@ pub struct OrderMessage {
     pub auto_popup_shown: bool,
 }
 
-fn debug_log_ui_state(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
-
 /// Drop `new-order` rows and fix selection. Those DMs are not shown in the Messages tab
 /// (order creation ack is handled via `send_new_order` / waiting UI).
 pub fn strip_new_order_messages_and_clamp_selected(
     messages: &mut Vec<OrderMessage>,
     selected_message_idx: &mut usize,
 ) {
-    let before_len = messages.len();
-    let before_new_order_count = messages
-        .iter()
-        .filter(|m| matches!(m.message.get_inner_message_kind().action, Action::NewOrder))
-        .count();
-    let before_non_new_order_count = before_len.saturating_sub(before_new_order_count);
-    let before_actions: Vec<String> = messages
-        .iter()
-        .take(3)
-        .map(|m| format!("{:?}", m.message.get_inner_message_kind().action))
-        .collect();
     messages.retain(|m| !matches!(m.message.get_inner_message_kind().action, Action::NewOrder));
-    if before_len > 0 && messages.is_empty() {
-        // #region agent log
-        debug_log_ui_state(
-            "H10",
-            "src/ui/orders.rs:strip_new_order_messages_and_clamp_selected",
-            "Messages list became empty after strip/clamp",
-            serde_json::json!({
-                "before_len": before_len,
-                "before_new_order_count": before_new_order_count,
-                "before_non_new_order_count": before_non_new_order_count,
-                "before_actions_sample": before_actions,
-            }),
-        );
-        // #endregion
-    }
     if *selected_message_idx >= messages.len() {
         *selected_message_idx = messages.len().saturating_sub(1);
     }
@@ -341,6 +295,7 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
         Action::WaitingBuyerInvoice => "Waiting for Buyer to Add Invoice",
         Action::WaitingSellerToPay => "Waiting for Seller to Pay",
         Action::HoldInvoicePaymentAccepted => VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
+        Action::BuyerTookOrder => VIEW_MESSAGE_BUYER_TOOK_ORDER_PREVIEW,
         Action::Cancel => "Cancel",
         Action::CooperativeCancelInitiatedByPeer => "Peer requested cooperative cancel",
         Action::Canceled => "Order canceled",
@@ -396,6 +351,8 @@ pub fn message_action_compact_label_for_message(msg: &OrderMessage) -> &'static 
         Some(Status::Canceled) => "Canceled",
         Some(Status::CanceledByAdmin) => "Admin Canceled",
         Some(Status::CooperativelyCanceled) => "Cooperatively Canceled",
+        Some(Status::WaitingBuyerInvoice) => "Waiting Buyer Invoice",
+        Some(Status::WaitingPayment) => "Waiting Seller Payment",
         Some(Status::Expired) => "Expired",
         Some(_) | None => {
             message_action_compact_label(&msg.message.get_inner_message_kind().action)
@@ -492,11 +449,8 @@ pub fn buy_listing_flow_step(msg: &OrderMessage) -> FlowStep {
     // highlighted column matches [`listing_timeline_labels`] (taker wording per kind).
     let is_maker = msg.is_mine.unwrap_or(false);
     // Post-`success` phases are action-specific (`rate` vs release); handle before status.
-    if matches!(
-        &action,
-        Action::Rate | Action::RateReceived | Action::PurchaseCompleted
-    ) {
-        return FlowStep::BuyFlowStep(StepLabelsBuy::StepRate);
+    if matches!(&action, Action::FiatSentOk) {
+        return FlowStep::BuyFlowStep(StepLabelsBuy::StepReleaseSats);
     }
     if let Some(status) = msg.order_status {
         if let Some(step) = listing_step_from_status(mostro_core::order::Kind::Buy, status) {
@@ -513,8 +467,8 @@ pub fn sell_listing_flow_step(msg: &OrderMessage) -> FlowStep {
         return message_buy_flow_step_fallback(&action);
     }
     let is_maker = msg.is_mine.unwrap_or(false);
-    if matches!(&action, Action::Rate | Action::RateReceived) {
-        return FlowStep::SellFlowStep(StepLabelsSell::StepRate);
+    if matches!(&action, Action::FiatSentOk) {
+        return FlowStep::SellFlowStep(StepLabelsSell::StepReleaseSats);
     }
     if let Some(status) = msg.order_status {
         if let Some(step) = listing_step_from_status(mostro_core::order::Kind::Sell, status) {

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -1,6 +1,8 @@
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use ratatui::style::{Color, Style};
+use std::fs::OpenOptions;
+use std::io::Write;
 
 use crate::ui::constants::{
     BUY_ORDER_FLOW_STEPS_MAKER, BUY_ORDER_FLOW_STEPS_TAKER, GENERIC_ORDER_FLOW_STEPS_TAKER,
@@ -185,13 +187,58 @@ pub struct OrderMessage {
     pub auto_popup_shown: bool,
 }
 
+fn debug_log_ui_state(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
+
 /// Drop `new-order` rows and fix selection. Those DMs are not shown in the Messages tab
 /// (order creation ack is handled via `send_new_order` / waiting UI).
 pub fn strip_new_order_messages_and_clamp_selected(
     messages: &mut Vec<OrderMessage>,
     selected_message_idx: &mut usize,
 ) {
+    let before_len = messages.len();
+    let before_new_order_count = messages
+        .iter()
+        .filter(|m| matches!(m.message.get_inner_message_kind().action, Action::NewOrder))
+        .count();
+    let before_non_new_order_count = before_len.saturating_sub(before_new_order_count);
+    let before_actions: Vec<String> = messages
+        .iter()
+        .take(3)
+        .map(|m| format!("{:?}", m.message.get_inner_message_kind().action))
+        .collect();
     messages.retain(|m| !matches!(m.message.get_inner_message_kind().action, Action::NewOrder));
+    if before_len > 0 && messages.is_empty() {
+        // #region agent log
+        debug_log_ui_state(
+            "H10",
+            "src/ui/orders.rs:strip_new_order_messages_and_clamp_selected",
+            "Messages list became empty after strip/clamp",
+            serde_json::json!({
+                "before_len": before_len,
+                "before_new_order_count": before_new_order_count,
+                "before_non_new_order_count": before_non_new_order_count,
+                "before_actions_sample": before_actions,
+            }),
+        );
+        // #endregion
+    }
     if *selected_message_idx >= messages.len() {
         *selected_message_idx = messages.len().saturating_sub(1);
     }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -10,6 +10,19 @@ use crate::ui::constants::{
 
 pub use crate::ui::constants::StepLabel;
 
+/// Stable My Trades header fields for one trade (maker publish or taker take). Not updated by later DMs.
+#[derive(Clone, Debug)]
+pub struct OrderChatStaticHeader {
+    pub order_id: uuid::Uuid,
+    pub kind: Option<mostro_core::order::Kind>,
+    pub created_at: Option<i64>,
+    pub trade_index: i64,
+    /// Local party's trade Nostr pubkey string (for display; matches DM path convention).
+    pub initiator_trade_pubkey: String,
+    /// `true` = we are maker, `false` = taker.
+    pub is_mine: bool,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct OrderSuccess {
     pub order_id: Option<uuid::Uuid>,
@@ -23,6 +36,8 @@ pub struct OrderSuccess {
     pub premium: i64,
     pub status: Option<Status>,
     pub trade_index: Option<i64>, // Trade index used for this order
+    /// Filled on successful create/take for My Trades static header.
+    pub static_header: Option<OrderChatStaticHeader>,
 }
 
 #[derive(Clone, Debug)]
@@ -34,6 +49,7 @@ pub enum OperationResult {
         invoice: String,
         sat_amount: Option<i64>,
         trade_index: i64,
+        static_header: OrderChatStaticHeader,
     },
     /// Generic informational popup (e.g. AddInvoice confirmation)
     Info(String),

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -263,12 +263,59 @@ pub struct KeyInputState {
 }
 
 /// YES/NO selection for `ViewingMessage` popups (FiatSentOk, My Trades actions, etc.).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ThreeState {
+    Yes,
+    No,
+    Cancel,
+}
+
+impl ThreeState {
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Yes => Self::No,
+            Self::No => Self::Cancel,
+            Self::Cancel => Self::Yes,
+        }
+    }
+
+    pub const fn prev(self) -> Self {
+        match self {
+            Self::Yes => Self::Cancel,
+            Self::No => Self::Yes,
+            Self::Cancel => Self::No,
+        }
+    }
+
+    pub const fn index(self) -> u8 {
+        match self {
+            Self::Yes => 0,
+            Self::No => 1,
+            Self::Cancel => 2,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ViewingMessageButtonSelection {
     /// `true` = YES highlighted, `false` = NO.
     Two { yes_selected: bool },
-    /// Hold-invoice confirmation only: `0` = YES, `1` = NO, `2` = CANCEL (cooperative cancel).
-    Three { selected: u8 },
+    /// Hold-invoice confirmation only: YES / NO / CANCEL.
+    Three(ThreeState),
+}
+
+impl ViewingMessageButtonSelection {
+    pub fn cycle_three_prev(&mut self) {
+        if let Self::Three(selected) = self {
+            *selected = selected.prev();
+        }
+    }
+
+    pub fn cycle_three_next(&mut self) {
+        if let Self::Three(selected) = self {
+            *selected = selected.next();
+        }
+    }
 }
 
 /// State for viewing a simple message popup

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -235,6 +235,13 @@ pub fn invoice_popup_allowed_for_order_status(
 }
 
 /// State for handling invoice input in AddInvoice notifications
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum InvoiceNotificationActionSelection {
+    Primary,
+    Cancel,
+}
+
+/// State for handling invoice input in AddInvoice notifications
 #[derive(Clone, Debug)]
 pub struct InvoiceInputState {
     pub invoice_input: String,
@@ -243,6 +250,8 @@ pub struct InvoiceInputState {
     pub copied_to_clipboard: bool, // Flag to show "Copied!" message
     /// Vertical scroll offset for long invoice display (PayInvoice popup).
     pub scroll_y: u16,
+    /// Selected action in AddInvoice/PayInvoice popup.
+    pub action_selection: InvoiceNotificationActionSelection,
 }
 
 /// State for handling key input (pubkey or privkey) in admin settings

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -9,5 +9,5 @@ pub use crate::ui::orders::{
     apply_kind_color, order_message_to_notification, FormState, InvoiceInputState,
     InvoiceNotificationActionSelection, KeyInputState, MessageNotification, MessageViewState,
     MostroInfoFetchResult, OperationResult, OrderMessage, OrderSuccess, RatingOrderState,
-    TakeOrderState, ViewingMessageButtonSelection,
+    TakeOrderState, ThreeState, ViewingMessageButtonSelection,
 };

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -6,7 +6,8 @@ pub use crate::ui::chat::{
 };
 pub use crate::ui::navigation::{AdminTab, Tab, UserRole, UserTab};
 pub use crate::ui::orders::{
-    apply_kind_color, order_message_to_notification, FormState, InvoiceInputState, KeyInputState,
-    MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult, OrderMessage,
-    OrderSuccess, RatingOrderState, TakeOrderState, ViewingMessageButtonSelection,
+    apply_kind_color, order_message_to_notification, FormState, InvoiceInputState,
+    InvoiceNotificationActionSelection, KeyInputState, MessageNotification, MessageViewState,
+    MostroInfoFetchResult, OperationResult, OrderMessage, OrderSuccess, RatingOrderState,
+    TakeOrderState, ViewingMessageButtonSelection,
 };

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -8,6 +8,6 @@ pub use crate::ui::navigation::{AdminTab, Tab, UserRole, UserTab};
 pub use crate::ui::orders::{
     apply_kind_color, order_message_to_notification, FormState, InvoiceInputState,
     InvoiceNotificationActionSelection, KeyInputState, MessageNotification, MessageViewState,
-    MostroInfoFetchResult, OperationResult, OrderMessage, OrderSuccess, RatingOrderState,
-    TakeOrderState, ThreeState, ViewingMessageButtonSelection,
+    MostroInfoFetchResult, OperationResult, OrderChatStaticHeader, OrderMessage, OrderSuccess,
+    RatingOrderState, TakeOrderState, ThreeState, ViewingMessageButtonSelection,
 };

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -8,5 +8,5 @@ pub use crate::ui::navigation::{AdminTab, Tab, UserRole, UserTab};
 pub use crate::ui::orders::{
     apply_kind_color, order_message_to_notification, FormState, InvoiceInputState, KeyInputState,
     MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult, OrderMessage,
-    OrderSuccess, RatingOrderState, TakeOrderState,
+    OrderSuccess, RatingOrderState, TakeOrderState, ViewingMessageButtonSelection,
 };

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -6,6 +6,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
+use uuid::Uuid;
 
 use crate::ui::constants::{
     FOOTER_MYTRADES_END_BOTTOM, FOOTER_MYTRADES_ENTER_SEND, FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
@@ -208,9 +209,14 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .status
         .map(|s| s.to_string())
         .unwrap_or_else(|| "unknown".to_string());
-    let order_kind = selected.kind.as_deref().unwrap_or("Unknown");
-    let created_str = selected
-        .created_at
+    let static_h = Uuid::parse_str(&selected.order_id)
+        .ok()
+        .and_then(|id| app.order_chat_static.get(&id));
+    let order_kind = static_h
+        .and_then(|h| h.kind.map(|k| k.to_string()))
+        .unwrap_or_else(|| "Unknown".to_string());
+    let created_str = static_h
+        .and_then(|h| h.created_at)
         .and_then(|ts| DateTime::from_timestamp(ts, 0))
         .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
         .unwrap_or_else(|| "Unknown".to_string());
@@ -221,19 +227,17 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
             pubkey.to_string()
         }
     };
-    let initiator_pubkey_display = selected
-        .initiator_pubkey
-        .as_deref()
-        .map(truncate_pubkey)
+    let initiator_pubkey_display = static_h
+        .map(|h| truncate_pubkey(&h.initiator_trade_pubkey))
         .unwrap_or_else(|| "Unknown".to_string());
-    let initiator_role = match selected.is_mine {
+    let initiator_role = match static_h.map(|h| h.is_mine) {
         Some(true) => "Maker",
         Some(false) => "Taker",
         None => "Initiator",
     };
-    let trade_id = selected
-        .trade_index
-        .map(|t| t.to_string())
+    let trade_id = static_h
+        .map(|h| h.trade_index.to_string())
+        .or_else(|| selected.trade_index.map(|t| t.to_string()))
         .unwrap_or_else(|| "Unknown".to_string());
     let payment_method = selected.payment_method.as_deref().unwrap_or("Unknown");
     let premium_text = selected
@@ -252,11 +256,14 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     // signals once available on DM payloads or local `orders` (see dispute UI + `Order::is_full_privacy_order`).
     // Omit that row until then — avoid static "Unknown" placeholders.
 
+    let order_id_display = static_h
+        .map(|h| h.order_id.to_string())
+        .unwrap_or_else(|| selected.order_id.clone());
     let mut header_lines: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("Order ID: ", Style::default().fg(Color::Gray)),
             Span::styled(
-                selected.order_id.clone(),
+                order_id_display,
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
@@ -272,7 +279,7 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
             Span::raw("  "),
             Span::styled("Type: ", Style::default().fg(Color::Gray)),
             Span::styled(
-                order_kind.to_string(),
+                order_kind,
                 Style::default()
                     .fg(PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -135,6 +135,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     let show_buttons = matches!(
         view_state.action,
         Action::HoldInvoicePaymentAccepted
+            | Action::BuyerTookOrder
             | Action::FiatSentOk
             | Action::CooperativeCancelInitiatedByPeer
             | Action::Cancel
@@ -148,30 +149,33 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             ViewingMessageButtonSelection::Three { .. }
         );
 
-    // Hold-invoice: one Line per logical row so newlines render; fixed height avoids a huge Min() gap.
-    let trinary_line_count = if hold_invoice_trinary {
+    // Multiline body: hold-invoice trinary, or `BuyerTookOrder` (CANCEL / NO for cooperative cancel).
+    let multiline_message_body =
+        hold_invoice_trinary || matches!(view_state.action, Action::BuyerTookOrder);
+
+    let content_line_count = if multiline_message_body {
         view_state.message_content.lines().count().max(1) as u16
     } else {
         0
     };
     let max_popup_h = area.height.saturating_sub(4).max(12);
-    let mut message_chunk_height = if hold_invoice_trinary {
+    let mut message_chunk_height = if multiline_message_body {
         // Extra rows for soft-wrapped lines on narrow terminals.
-        trinary_line_count.saturating_add(2).clamp(8, 14)
+        content_line_count.saturating_add(2).clamp(8, 14)
     } else {
         1
     };
 
     // Rows: spacer + title + sep + order + message + spacer + buttons + help  => 10 + message_chunk
     let mut inner_needed = 10u16.saturating_add(message_chunk_height);
-    if hold_invoice_trinary && inner_needed > max_popup_h {
+    if multiline_message_body && inner_needed > max_popup_h {
         let shrink = inner_needed - max_popup_h;
         message_chunk_height = (message_chunk_height.saturating_sub(shrink)).max(6);
         inner_needed = 10u16.saturating_add(message_chunk_height);
     }
 
     let popup_height = if show_buttons {
-        if hold_invoice_trinary {
+        if multiline_message_body {
             inner_needed.min(max_popup_h)
         } else {
             14
@@ -186,7 +190,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     // Clear the popup area to make it fully opaque
     f.render_widget(Clear, popup);
 
-    let constraints = if show_buttons && hold_invoice_trinary {
+    let constraints = if show_buttons && multiline_message_body {
         vec![
             Constraint::Length(1), // spacer
             Constraint::Length(1), // title
@@ -244,7 +248,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
 
     // Message content (multi-line Text so `\n` in the string becomes real line breaks in ratatui)
     let body_style = Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR);
-    let message_paragraph = if hold_invoice_trinary {
+    let message_paragraph = if multiline_message_body {
         let lines: Vec<Line> = view_state
             .message_content
             .lines()
@@ -316,7 +320,12 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
                 ViewingMessageButtonSelection::Two { yes_selected } => yes_selected,
                 ViewingMessageButtonSelection::Three { .. } => true,
             };
-            helpers::render_yes_no_buttons(f, button_area, yes_selected, "✓ YES", "✗ NO");
+            let (yes_label, no_label) = if matches!(view_state.action, Action::BuyerTookOrder) {
+                ("CANCEL", "NO")
+            } else {
+                ("✓ YES", "✗ NO")
+            };
+            helpers::render_yes_no_buttons(f, button_area, yes_selected, yes_label, no_label);
             f.render_widget(
                 Paragraph::new(Line::from(vec![
                     Span::styled("Use ", Style::default()),

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -5,8 +5,8 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
 
 use crate::ui::{
-    helpers, MessageViewState, RatingOrderState, ViewingMessageButtonSelection, BACKGROUND_COLOR,
-    PRIMARY_COLOR,
+    helpers, MessageViewState, RatingOrderState, ThreeState, ViewingMessageButtonSelection,
+    BACKGROUND_COLOR, PRIMARY_COLOR,
 };
 
 pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
@@ -146,7 +146,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     let hold_invoice_trinary = matches!(view_state.action, Action::HoldInvoicePaymentAccepted)
         && matches!(
             view_state.button_selection,
-            ViewingMessageButtonSelection::Three { .. }
+            ViewingMessageButtonSelection::Three(_)
         );
 
     // Multiline body: hold-invoice trinary, or `BuyerTookOrder` (CANCEL / NO for cooperative cancel).
@@ -276,7 +276,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
         let button_area = inner_chunks[6];
         if hold_invoice_trinary {
             let selected = match view_state.button_selection {
-                ViewingMessageButtonSelection::Three { selected } => selected.min(2),
+                ViewingMessageButtonSelection::Three(selected) => selected.index(),
                 ViewingMessageButtonSelection::Two { .. } => 0,
             };
             helpers::render_yes_no_cancel_buttons(
@@ -318,7 +318,9 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
         } else {
             let yes_selected = match view_state.button_selection {
                 ViewingMessageButtonSelection::Two { yes_selected } => yes_selected,
-                ViewingMessageButtonSelection::Three { .. } => true,
+                ViewingMessageButtonSelection::Three(ThreeState::Yes)
+                | ViewingMessageButtonSelection::Three(ThreeState::Cancel) => true,
+                ViewingMessageButtonSelection::Three(ThreeState::No) => false,
             };
             let (yes_label, no_label) = if matches!(view_state.action, Action::BuyerTookOrder) {
                 ("CANCEL", "NO")

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -1,10 +1,13 @@
 use mostro_core::prelude::*;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
 
-use crate::ui::{helpers, MessageViewState, RatingOrderState, BACKGROUND_COLOR, PRIMARY_COLOR};
+use crate::ui::{
+    helpers, MessageViewState, RatingOrderState, ViewingMessageButtonSelection, BACKGROUND_COLOR,
+    PRIMARY_COLOR,
+};
 
 pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
     let paragraph = Paragraph::new(Span::raw("Coming soon")).block(
@@ -128,7 +131,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     let area = f.area();
     let popup_width = area.width.saturating_sub(area.width / 4);
 
-    // YES/NO: same pattern as exit/settings confirms (`helpers::render_yes_no_buttons`).
+    // YES/NO (or YES/NO/CANCEL for hold invoice): same pattern as exit/settings confirms.
     let show_buttons = matches!(
         view_state.action,
         Action::HoldInvoicePaymentAccepted
@@ -139,11 +142,44 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             | Action::Release
     );
 
-    // Adjust popup height based on whether we show buttons
-    let popup_height = if show_buttons {
-        14 // Need space for button blocks with borders
+    let hold_invoice_trinary = matches!(
+        view_state.action,
+        Action::HoldInvoicePaymentAccepted
+    ) && matches!(
+        view_state.button_selection,
+        ViewingMessageButtonSelection::Three { .. }
+    );
+
+    // Hold-invoice: one Line per logical row so newlines render; fixed height avoids a huge Min() gap.
+    let trinary_line_count = if hold_invoice_trinary {
+        view_state.message_content.lines().count().max(1) as u16
     } else {
-        10 // Simpler layout without buttons
+        0
+    };
+    let max_popup_h = area.height.saturating_sub(4).max(12);
+    let mut message_chunk_height = if hold_invoice_trinary {
+        // Extra rows for soft-wrapped lines on narrow terminals.
+        trinary_line_count.saturating_add(2).clamp(8, 14)
+    } else {
+        1
+    };
+
+    // Rows: spacer + title + sep + order + message + spacer + buttons + help  => 10 + message_chunk
+    let mut inner_needed = 10u16.saturating_add(message_chunk_height);
+    if hold_invoice_trinary && inner_needed > max_popup_h {
+        let shrink = inner_needed - max_popup_h;
+        message_chunk_height = (message_chunk_height.saturating_sub(shrink)).max(6);
+        inner_needed = 10u16.saturating_add(message_chunk_height);
+    }
+
+    let popup_height = if show_buttons {
+        if hold_invoice_trinary {
+            inner_needed.min(max_popup_h)
+        } else {
+            14
+        }
+    } else {
+        10
     };
 
     // Center the popup
@@ -152,8 +188,18 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     // Clear the popup area to make it fully opaque
     f.render_widget(Clear, popup);
 
-    // Adjust layout constraints based on whether we show buttons
-    let constraints = if show_buttons {
+    let constraints = if show_buttons && hold_invoice_trinary {
+        vec![
+            Constraint::Length(1), // spacer
+            Constraint::Length(1), // title
+            Constraint::Length(1), // separator
+            Constraint::Length(1), // order id
+            Constraint::Length(message_chunk_height),
+            Constraint::Length(1), // spacer
+            Constraint::Length(3), // buttons
+            Constraint::Length(2), // help text
+        ]
+    } else if show_buttons {
         vec![
             Constraint::Length(1), // spacer
             Constraint::Length(1), // title
@@ -198,50 +244,114 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
         inner_chunks[3],
     );
 
-    // Message content
-    f.render_widget(
+    // Message content (multi-line Text so `\n` in the string becomes real line breaks in ratatui)
+    let body_style = Style::default()
+        .bg(BACKGROUND_COLOR)
+        .fg(PRIMARY_COLOR);
+    let message_paragraph = if hold_invoice_trinary {
+        let lines: Vec<Line> = view_state
+            .message_content
+            .lines()
+            .map(|line| {
+                Line::from(vec![Span::styled(line, body_style)])
+            })
+            .collect();
+        Paragraph::new(Text::from(lines))
+            .alignment(Alignment::Left)
+            .block(
+                Block::default()
+                    .padding(Padding::horizontal(1))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
+            )
+            .wrap(Wrap { trim: true })
+    } else {
         Paragraph::new(Line::from(vec![Span::styled(
-            &view_state.message_content,
-            Style::default().bg(BACKGROUND_COLOR),
+            view_state.message_content.as_str(),
+            body_style,
         )]))
-        .alignment(ratatui::layout::Alignment::Center)
-        .wrap(ratatui::widgets::Wrap { trim: true }),
-        inner_chunks[4],
-    );
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+    };
+    f.render_widget(message_paragraph, inner_chunks[4]);
 
     if show_buttons {
         let button_area = inner_chunks[6];
-        helpers::render_yes_no_buttons(f, button_area, view_state.selected_button, "✓ YES", "✗ NO");
-
-        // Help text for buttons
-        f.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled("Use ", Style::default()),
-                Span::styled(
-                    "Left/Right",
-                    Style::default()
-                        .fg(PRIMARY_COLOR)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(" to select, ", Style::default()),
-                Span::styled(
-                    "Enter",
-                    Style::default()
-                        .fg(PRIMARY_COLOR)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(" to confirm, ", Style::default()),
-                Span::styled(
-                    "Esc",
-                    Style::default()
-                        .fg(PRIMARY_COLOR)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(" to dismiss", Style::default()),
-            ]))
-            .alignment(ratatui::layout::Alignment::Center),
-            inner_chunks[7],
-        );
+        if hold_invoice_trinary {
+            let selected = match view_state.button_selection {
+                ViewingMessageButtonSelection::Three { selected } => selected.min(2),
+                ViewingMessageButtonSelection::Two { .. } => 0,
+            };
+            helpers::render_yes_no_cancel_buttons(
+                f,
+                button_area,
+                selected,
+                "✓ YES",
+                "✗ NO",
+                "CANCEL",
+            );
+            f.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("Use ", Style::default()),
+                    Span::styled(
+                        "Left/Right",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to cycle YES / NO / CANCEL, ", Style::default()),
+                    Span::styled(
+                        "Enter",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to confirm, ", Style::default()),
+                    Span::styled(
+                        "Esc",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to dismiss", Style::default()),
+                ]))
+                .alignment(ratatui::layout::Alignment::Center),
+                inner_chunks[7],
+            );
+        } else {
+            let yes_selected = match view_state.button_selection {
+                ViewingMessageButtonSelection::Two { yes_selected } => yes_selected,
+                ViewingMessageButtonSelection::Three { .. } => true,
+            };
+            helpers::render_yes_no_buttons(f, button_area, yes_selected, "✓ YES", "✗ NO");
+            f.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("Use ", Style::default()),
+                    Span::styled(
+                        "Left/Right",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to select, ", Style::default()),
+                    Span::styled(
+                        "Enter",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to confirm, ", Style::default()),
+                    Span::styled(
+                        "Esc",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to dismiss", Style::default()),
+                ]))
+                .alignment(ratatui::layout::Alignment::Center),
+                inner_chunks[7],
+            );
+        }
     } else {
         // Simple exit text for other actions
         f.render_widget(

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -142,13 +142,11 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             | Action::Release
     );
 
-    let hold_invoice_trinary = matches!(
-        view_state.action,
-        Action::HoldInvoicePaymentAccepted
-    ) && matches!(
-        view_state.button_selection,
-        ViewingMessageButtonSelection::Three { .. }
-    );
+    let hold_invoice_trinary = matches!(view_state.action, Action::HoldInvoicePaymentAccepted)
+        && matches!(
+            view_state.button_selection,
+            ViewingMessageButtonSelection::Three { .. }
+        );
 
     // Hold-invoice: one Line per logical row so newlines render; fixed height avoids a huge Min() gap.
     let trinary_line_count = if hold_invoice_trinary {
@@ -245,16 +243,12 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     );
 
     // Message content (multi-line Text so `\n` in the string becomes real line breaks in ratatui)
-    let body_style = Style::default()
-        .bg(BACKGROUND_COLOR)
-        .fg(PRIMARY_COLOR);
+    let body_style = Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR);
     let message_paragraph = if hold_invoice_trinary {
         let lines: Vec<Line> = view_state
             .message_content
             .lines()
-            .map(|line| {
-                Line::from(vec![Span::styled(line, body_style)])
-            })
+            .map(|line| Line::from(vec![Span::styled(line, body_style)]))
             .collect();
         Paragraph::new(Text::from(lines))
             .alignment(Alignment::Left)

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -251,7 +251,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             .map(|line| Line::from(vec![Span::styled(line, body_style)]))
             .collect();
         Paragraph::new(Text::from(lines))
-            .alignment(Alignment::Left)
+            .alignment(Alignment::Center)
             .block(
                 Block::default()
                     .padding(Padding::horizontal(1))

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -14,6 +14,8 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -60,6 +62,25 @@ static GIFTWRAP_FALLBACK_DECRYPT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static GIFTWRAP_FALLBACK_LAST_ACTIVE_COUNT: AtomicU64 = AtomicU64::new(0);
 /// Last fallback scan: loop duration in milliseconds.
 static GIFTWRAP_FALLBACK_LAST_DURATION_MS: AtomicU64 = AtomicU64::new(0);
+
+fn debug_log_dm(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
 
 pub struct StartupDmHydration {
     pub active_order_trade_indices: HashMap<Uuid, i64>,
@@ -451,6 +472,20 @@ async fn handle_trade_dm_for_order(
 ) {
     let inner_kind = message.get_inner_message_kind();
     let action = inner_kind.action.clone();
+    if matches!(action, Action::NewOrder) {
+        // #region agent log
+        debug_log_dm(
+            "H13",
+            "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:skip_new_order",
+            "Skipping NewOrder DM for Messages tab hydration",
+            serde_json::json!({
+                "order_id": order_id.to_string(),
+                "trade_index": trade_index,
+            }),
+        );
+        // #endregion
+        return;
+    }
 
     let db_order = Order::get_by_id(pool, &order_id.to_string()).await.ok();
     let status_from_db = db_order
@@ -458,6 +493,20 @@ async fn handle_trade_dm_for_order(
         .and_then(|r| r.status.as_ref().and_then(|s| Status::from_str(s).ok()));
 
     let status_candidate = resolved_status_candidate(&action, &inner_kind.payload);
+    // #region agent log
+    debug_log_dm(
+        "H3",
+        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:status_resolution",
+        "Resolved DM status candidate and current DB status",
+        serde_json::json!({
+            "order_id": order_id.to_string(),
+            "action": format!("{:?}", action),
+            "status_from_db": status_from_db.map(|s| format!("{:?}", s)),
+            "status_candidate": status_candidate.map(|s| format!("{:?}", s)),
+            "has_payload": inner_kind.payload.is_some(),
+        }),
+    );
+    // #endregion
 
     // Taker pre-Active cancel returns the order to the book; drop stale local row instead of
     // keeping it as terminal trade state.
@@ -614,6 +663,21 @@ async fn handle_trade_dm_for_order(
     } else {
         baseline_status
     };
+    // #region agent log
+    debug_log_dm(
+        "H5",
+        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:effective_status",
+        "Computed effective status for messages row",
+        serde_json::json!({
+            "order_id": order_id.to_string(),
+            "action": format!("{:?}", action),
+            "baseline_status": baseline_status.map(|s| format!("{:?}", s)),
+            "status_candidate": status_candidate.map(|s| format!("{:?}", s)),
+            "should_accept_candidate": should_accept_candidate,
+            "effective_order_status": effective_order_status.map(|s| format!("{:?}", s)),
+        }),
+    );
+    // #endregion
 
     if let Some(candidate) = status_candidate {
         let oid = small_order_ref_from_payload(&inner_kind.payload)
@@ -687,11 +751,48 @@ async fn handle_trade_dm_for_order(
             return;
         }
     };
-    // Keep one row per order, but ensure the newly accepted message is the one kept.
-    // This avoids dropping same-timestamp/different-action updates during dedup.
-    messages_lock.retain(|m| m.order_id != Some(order_id));
-    messages_lock.push(order_message.clone());
-    messages_lock.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    // Keep one row per order, but do not let older stale replay messages overwrite the
+    // currently selected action row after startup/reconnect hydration.
+    let before_len = messages_lock.len();
+    let should_replace_row = match &existing_message_data {
+        None => true,
+        Some((existing_timestamp, existing_action, _, _, _, _, _, _)) => {
+            // Never let replayed `NewOrder` replace an already-established trade row.
+            // Otherwise Messages can regress to only NewOrder rows, which the UI strips.
+            if matches!(action, Action::NewOrder) && !matches!(existing_action, Action::NewOrder) {
+                false
+            } else if timestamp > *existing_timestamp {
+                true
+            } else if timestamp == *existing_timestamp {
+                action != *existing_action
+            } else {
+                // Older-than-current replay: only replace if it advances accepted status.
+                should_accept_candidate
+            }
+        }
+    };
+    if should_replace_row {
+        messages_lock.retain(|m| m.order_id != Some(order_id));
+        messages_lock.push(order_message.clone());
+        messages_lock.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    }
+    // #region agent log
+    debug_log_dm(
+        "H5",
+        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:messages_replace",
+        "Replaced messages row for order",
+        serde_json::json!({
+            "order_id": order_id.to_string(),
+            "action": format!("{:?}", action),
+                "should_replace_row": should_replace_row,
+            "before_len": before_len,
+            "after_len": messages_lock.len(),
+            "row_status": order_message.order_status.map(|s| format!("{:?}", s)),
+            "row_kind": order_message.order_kind.map(|k| format!("{:?}", k)),
+            "row_is_mine": order_message.is_mine,
+        }),
+    );
+    // #endregion
 
     // Send notification only for actionable/new updates; this avoids follow-up AddInvoice
     // payload variants (without order amount) from retriggering invoice popups with 0 sats.
@@ -713,7 +814,20 @@ enum GiftWrapTerminalPolicy<'a> {
 fn remove_order_from_messages(messages: &Arc<Mutex<Vec<OrderMessage>>>, order_id: Uuid) {
     match messages.lock() {
         Ok(mut guard) => {
+            let before_len = guard.len();
             guard.retain(|m| m.order_id != Some(order_id));
+            // #region agent log
+            debug_log_dm(
+                "H4",
+                "src/util/dm_utils/mod.rs:remove_order_from_messages",
+                "Removed order rows from messages list",
+                serde_json::json!({
+                    "order_id": order_id.to_string(),
+                    "before_len": before_len,
+                    "after_len": guard.len(),
+                }),
+            );
+            // #endregion
         }
         Err(e) => {
             crate::util::request_fatal_restart(format!(
@@ -749,6 +863,7 @@ async fn dispatch_giftwrap_batch(
 
     for (message, timestamp, sender) in parsed_messages {
         let has_terminal_status = trade_message_is_terminal(&message);
+        let action_for_log = format!("{:?}", message.get_inner_message_kind().action);
         log::info!(
             "order id: {} has_terminal_status: {:?}",
             order_id,
@@ -788,6 +903,22 @@ async fn dispatch_giftwrap_batch(
         }
 
         if has_terminal_status {
+            // #region agent log
+            debug_log_dm(
+                "H4",
+                "src/util/dm_utils/mod.rs:dispatch_giftwrap_batch:terminal_detected",
+                "Terminal message detected during giftwrap dispatch",
+                serde_json::json!({
+                    "order_id": order_id.to_string(),
+                    "trade_index": trade_index,
+                    "action": action_for_log,
+                    "terminal_policy": match terminal_policy {
+                        GiftWrapTerminalPolicy::TrackedSubscription(_) => "TrackedSubscription",
+                        GiftWrapTerminalPolicy::UntrackedFallback => "UntrackedFallback",
+                    },
+                }),
+            );
+            // #endregion
             match terminal_policy {
                 GiftWrapTerminalPolicy::TrackedSubscription(subscription_id) => {
                     log::info!(

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -513,13 +513,6 @@ async fn handle_trade_dm_for_order(
         return;
     }
 
-    // Do not surface `new-order` in Messages or toasts (relist, book echo, etc.). Persisted status
-    // above still applies. Publish ack for a newly created order uses `send_new_order` / waiting UI.
-    if matches!(action, Action::NewOrder) {
-        remove_order_from_messages(messages, order_id);
-        return;
-    }
-
     // Lock `messages` only long enough to extract comparison data, then drop it
     // before touching `pending_notifications` to avoid lock-order deadlocks.
     let existing_message_data = {
@@ -803,7 +796,6 @@ async fn dispatch_giftwrap_batch(
                         trade_index,
                         subscription_id
                     );
-                    remove_order_from_messages(messages, order_id);
                     {
                         match active_order_trade_indices.lock() {
                             Ok(mut indices) => {
@@ -825,7 +817,6 @@ async fn dispatch_giftwrap_batch(
                     break;
                 }
                 GiftWrapTerminalPolicy::UntrackedFallback => {
-                    remove_order_from_messages(messages, order_id);
                     {
                         match active_order_trade_indices.lock() {
                             Ok(mut indices) => {

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -30,6 +30,7 @@ use crate::util::filters::filter_giftwrap_to_recipient;
 use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 use crate::util::order_utils::{
     inferred_status_from_trade_action, map_action_to_status, should_apply_status_transition,
+    should_strictly_advance_status,
 };
 use crate::util::types::{determine_message_type, MessageType};
 
@@ -694,7 +695,7 @@ async fn handle_trade_dm_for_order(
     // currently selected action row after startup/reconnect hydration.
     let should_replace_row = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, _)) => {
+        Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status)) => {
             // Never let replayed `NewOrder` replace an already-established trade row.
             // Otherwise Messages can regress to only NewOrder rows, which the UI strips.
             if matches!(action, Action::NewOrder) && !matches!(existing_action, Action::NewOrder) {
@@ -704,8 +705,12 @@ async fn handle_trade_dm_for_order(
             } else if timestamp == *existing_timestamp {
                 action != *existing_action
             } else {
-                // Older-than-current replay: only replace if it advances accepted status.
-                should_accept_candidate
+                // Older-than-current replay: only replace if the payload status **strictly** advances
+                // the status already shown on the row (not merely equal; `should_accept_candidate`
+                // allows equality vs baseline for DB updates).
+                status_candidate.is_some_and(|c| {
+                    should_strictly_advance_status(*existing_order_status, c, effective_order_kind)
+                })
             }
         }
     };

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -763,7 +763,17 @@ async fn dispatch_giftwrap_batch(
     subscription_to_order: &mut HashMap<SubscriptionId, (Uuid, i64)>,
     terminal_policy: GiftWrapTerminalPolicy<'_>,
     notify: bool,
+    dropped_user_history_order_ids: &Arc<Mutex<HashSet<Uuid>>>,
 ) {
+    if let Ok(guard) = dropped_user_history_order_ids.lock() {
+        if guard.contains(&order_id) {
+            log::info!(
+                "[dm_listener] Skipping trade DMs for order_id={} (removed from local history by user)",
+                order_id
+            );
+            return;
+        }
+    }
     let log_each_message = matches!(
         terminal_policy,
         GiftWrapTerminalPolicy::TrackedSubscription(_)
@@ -883,6 +893,7 @@ struct DmListenerStartupReplay<'a> {
     subscribed_pubkeys: &'a mut HashSet<PublicKey>,
     subscription_to_order: &'a mut HashMap<SubscriptionId, (Uuid, i64)>,
     pubkey_to_subscription: &'a HashMap<PublicKey, SubscriptionId>,
+    dropped_user_history_order_ids: &'a Arc<Mutex<HashSet<Uuid>>>,
 }
 
 /// One-shot relay query + replay so restart shows trade DMs. `subscribe` alone often does not
@@ -903,6 +914,7 @@ async fn fetch_and_replay_startup_trade_dms(
         subscribed_pubkeys,
         subscription_to_order,
         pubkey_to_subscription,
+        dropped_user_history_order_ids,
     } = replay;
 
     let lookback_start = Timestamp::now()
@@ -1028,6 +1040,7 @@ async fn fetch_and_replay_startup_trade_dms(
             subscription_to_order,
             GiftWrapTerminalPolicy::TrackedSubscription(&sub_id),
             false,
+            dropped_user_history_order_ids,
         )
         .await;
     }
@@ -1145,6 +1158,7 @@ pub async fn listen_for_order_messages(
     messages: Arc<Mutex<Vec<OrderMessage>>>,
     message_notification_tx: tokio::sync::mpsc::UnboundedSender<MessageNotification>,
     pending_notifications: Arc<Mutex<usize>>,
+    dropped_user_history_order_ids: Arc<Mutex<HashSet<Uuid>>>,
     mut dm_subscription_rx: tokio::sync::mpsc::UnboundedReceiver<OrderDmSubscriptionCmd>,
 ) {
     // Get user key from db (for deriving trade keys)
@@ -1225,6 +1239,7 @@ pub async fn listen_for_order_messages(
             subscribed_pubkeys: &mut subscribed_pubkeys,
             subscription_to_order: &mut subscription_to_order,
             pubkey_to_subscription: &pubkey_to_subscription,
+            dropped_user_history_order_ids: &dropped_user_history_order_ids,
         },
         &startup_active_orders,
         &order_last_seen_dm_ts,
@@ -1491,6 +1506,7 @@ pub async fn listen_for_order_messages(
                             &mut subscription_to_order,
                             GiftWrapTerminalPolicy::TrackedSubscription(&subscription_id),
                             true,
+                            &dropped_user_history_order_ids,
                         )
                         .await;
                     } else if let Some((order_id, trade_index, trade_keys)) =
@@ -1522,6 +1538,7 @@ pub async fn listen_for_order_messages(
                             &mut subscription_to_order,
                             GiftWrapTerminalPolicy::UntrackedFallback,
                             true,
+                            &dropped_user_history_order_ids,
                         )
                         .await;
                     }

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -14,8 +14,6 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -62,25 +60,6 @@ static GIFTWRAP_FALLBACK_DECRYPT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static GIFTWRAP_FALLBACK_LAST_ACTIVE_COUNT: AtomicU64 = AtomicU64::new(0);
 /// Last fallback scan: loop duration in milliseconds.
 static GIFTWRAP_FALLBACK_LAST_DURATION_MS: AtomicU64 = AtomicU64::new(0);
-
-fn debug_log_dm(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
 
 pub struct StartupDmHydration {
     pub active_order_trade_indices: HashMap<Uuid, i64>,
@@ -473,17 +452,6 @@ async fn handle_trade_dm_for_order(
     let inner_kind = message.get_inner_message_kind();
     let action = inner_kind.action.clone();
     if matches!(action, Action::NewOrder) {
-        // #region agent log
-        debug_log_dm(
-            "H13",
-            "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:skip_new_order",
-            "Skipping NewOrder DM for Messages tab hydration",
-            serde_json::json!({
-                "order_id": order_id.to_string(),
-                "trade_index": trade_index,
-            }),
-        );
-        // #endregion
         return;
     }
 
@@ -493,20 +461,6 @@ async fn handle_trade_dm_for_order(
         .and_then(|r| r.status.as_ref().and_then(|s| Status::from_str(s).ok()));
 
     let status_candidate = resolved_status_candidate(&action, &inner_kind.payload);
-    // #region agent log
-    debug_log_dm(
-        "H3",
-        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:status_resolution",
-        "Resolved DM status candidate and current DB status",
-        serde_json::json!({
-            "order_id": order_id.to_string(),
-            "action": format!("{:?}", action),
-            "status_from_db": status_from_db.map(|s| format!("{:?}", s)),
-            "status_candidate": status_candidate.map(|s| format!("{:?}", s)),
-            "has_payload": inner_kind.payload.is_some(),
-        }),
-    );
-    // #endregion
 
     // Taker pre-Active cancel returns the order to the book; drop stale local row instead of
     // keeping it as terminal trade state.
@@ -663,21 +617,6 @@ async fn handle_trade_dm_for_order(
     } else {
         baseline_status
     };
-    // #region agent log
-    debug_log_dm(
-        "H5",
-        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:effective_status",
-        "Computed effective status for messages row",
-        serde_json::json!({
-            "order_id": order_id.to_string(),
-            "action": format!("{:?}", action),
-            "baseline_status": baseline_status.map(|s| format!("{:?}", s)),
-            "status_candidate": status_candidate.map(|s| format!("{:?}", s)),
-            "should_accept_candidate": should_accept_candidate,
-            "effective_order_status": effective_order_status.map(|s| format!("{:?}", s)),
-        }),
-    );
-    // #endregion
 
     if let Some(candidate) = status_candidate {
         let oid = small_order_ref_from_payload(&inner_kind.payload)
@@ -753,7 +692,6 @@ async fn handle_trade_dm_for_order(
     };
     // Keep one row per order, but do not let older stale replay messages overwrite the
     // currently selected action row after startup/reconnect hydration.
-    let before_len = messages_lock.len();
     let should_replace_row = match &existing_message_data {
         None => true,
         Some((existing_timestamp, existing_action, _, _, _, _, _, _)) => {
@@ -776,23 +714,6 @@ async fn handle_trade_dm_for_order(
         messages_lock.push(order_message.clone());
         messages_lock.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
     }
-    // #region agent log
-    debug_log_dm(
-        "H5",
-        "src/util/dm_utils/mod.rs:handle_trade_dm_for_order:messages_replace",
-        "Replaced messages row for order",
-        serde_json::json!({
-            "order_id": order_id.to_string(),
-            "action": format!("{:?}", action),
-                "should_replace_row": should_replace_row,
-            "before_len": before_len,
-            "after_len": messages_lock.len(),
-            "row_status": order_message.order_status.map(|s| format!("{:?}", s)),
-            "row_kind": order_message.order_kind.map(|k| format!("{:?}", k)),
-            "row_is_mine": order_message.is_mine,
-        }),
-    );
-    // #endregion
 
     // Send notification only for actionable/new updates; this avoids follow-up AddInvoice
     // payload variants (without order amount) from retriggering invoice popups with 0 sats.
@@ -814,20 +735,7 @@ enum GiftWrapTerminalPolicy<'a> {
 fn remove_order_from_messages(messages: &Arc<Mutex<Vec<OrderMessage>>>, order_id: Uuid) {
     match messages.lock() {
         Ok(mut guard) => {
-            let before_len = guard.len();
             guard.retain(|m| m.order_id != Some(order_id));
-            // #region agent log
-            debug_log_dm(
-                "H4",
-                "src/util/dm_utils/mod.rs:remove_order_from_messages",
-                "Removed order rows from messages list",
-                serde_json::json!({
-                    "order_id": order_id.to_string(),
-                    "before_len": before_len,
-                    "after_len": guard.len(),
-                }),
-            );
-            // #endregion
         }
         Err(e) => {
             crate::util::request_fatal_restart(format!(
@@ -863,7 +771,6 @@ async fn dispatch_giftwrap_batch(
 
     for (message, timestamp, sender) in parsed_messages {
         let has_terminal_status = trade_message_is_terminal(&message);
-        let action_for_log = format!("{:?}", message.get_inner_message_kind().action);
         log::info!(
             "order id: {} has_terminal_status: {:?}",
             order_id,
@@ -903,22 +810,6 @@ async fn dispatch_giftwrap_batch(
         }
 
         if has_terminal_status {
-            // #region agent log
-            debug_log_dm(
-                "H4",
-                "src/util/dm_utils/mod.rs:dispatch_giftwrap_batch:terminal_detected",
-                "Terminal message detected during giftwrap dispatch",
-                serde_json::json!({
-                    "order_id": order_id.to_string(),
-                    "trade_index": trade_index,
-                    "action": action_for_log,
-                    "terminal_policy": match terminal_policy {
-                        GiftWrapTerminalPolicy::TrackedSubscription(_) => "TrackedSubscription",
-                        GiftWrapTerminalPolicy::UntrackedFallback => "UntrackedFallback",
-                    },
-                }),
-            );
-            // #endregion
             match terminal_policy {
                 GiftWrapTerminalPolicy::TrackedSubscription(subscription_id) => {
                     log::info!(

--- a/src/util/dm_utils/notifications_ch_mng.rs
+++ b/src/util/dm_utils/notifications_ch_mng.rs
@@ -1,6 +1,8 @@
 // Notifications channel manager - handles message notifications from async tasks
 use crate::ui::orders::invoice_popup_allowed_for_order_status;
-use crate::ui::{AppState, InvoiceInputState, MessageNotification, UiMode};
+use crate::ui::{
+    AppState, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification, UiMode,
+};
 use mostro_core::prelude::Action;
 
 /// Check if the popup should be shown for a given notification
@@ -81,6 +83,7 @@ pub fn handle_message_notification(notification: MessageNotification, app: &mut 
                 just_pasted: false,
                 copied_to_clipboard: false,
                 scroll_y: 0,
+                action_selection: InvoiceNotificationActionSelection::Primary,
             };
             let action = notification.action.clone();
             app.mode = UiMode::NewMessageNotification(notification, action, invoice_state);

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -1,7 +1,8 @@
 // Order channel manager - handles order result messages from async tasks
 use crate::ui::orders::{strip_new_order_messages_and_clamp_selected, OrderSuccess};
 use crate::ui::{
-    AppState, InvoiceInputState, MessageNotification, OperationResult, UiMode, UserMode,
+    AppState, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification,
+    OperationResult, UiMode, UserMode,
 };
 use mostro_core::prelude::Action;
 use uuid::Uuid;
@@ -127,6 +128,7 @@ pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) 
             just_pasted: false,
             copied_to_clipboard: false,
             scroll_y: 0,
+            action_selection: InvoiceNotificationActionSelection::Primary,
         };
         // Reuse pay invoice popup for buy orders when taking an order
         app.mode = UiMode::NewMessageNotification(notification, Action::PayInvoice, invoice_state);

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -4,28 +4,7 @@ use crate::ui::{
     AppState, InvoiceInputState, MessageNotification, OperationResult, UiMode, UserMode,
 };
 use mostro_core::prelude::Action;
-use std::fs::OpenOptions;
-use std::io::Write;
 use uuid::Uuid;
-
-fn debug_log_order_result(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
-    let payload = serde_json::json!({
-        "sessionId": "715880",
-        "runId": "pre-fix",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": chrono::Utc::now().timestamp_millis()
-    });
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("debug-715880.log")
-    {
-        let _ = writeln!(file, "{payload}");
-    }
-}
 
 fn remove_closed_trade_from_messages_tab(app: &mut AppState, order_id: Uuid) {
     match app.messages.lock() {
@@ -87,17 +66,6 @@ fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) 
 /// Handle order result from the order result channel
 pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) {
     if let OperationResult::TradeClosed { order_id, message } = result {
-        // #region agent log
-        debug_log_order_result(
-            "H9",
-            "src/util/dm_utils/order_ch_mng.rs:handle_operation_result:trade_closed",
-            "TradeClosed branch removing order from messages tab",
-            serde_json::json!({
-                "order_id": order_id.to_string(),
-                "message": message,
-            }),
-        );
-        // #endregion
         remove_closed_trade_from_messages_tab(app, order_id);
         result = OperationResult::Info(message);
     }

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -33,10 +33,48 @@ fn remove_closed_trade_from_messages_tab(app: &mut AppState, order_id: Uuid) {
     }
 }
 
+fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) {
+    let id_set: std::collections::HashSet<Uuid> = order_ids.iter().copied().collect();
+    match app.messages.lock() {
+        Ok(mut messages) => {
+            messages.retain(|m| m.order_id.map(|id| !id_set.contains(&id)).unwrap_or(true));
+            strip_new_order_messages_and_clamp_selected(
+                &mut messages,
+                &mut app.selected_message_idx,
+            );
+        }
+        Err(e) => {
+            crate::util::request_fatal_restart(format!(
+                "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
+            ));
+        }
+    }
+    match app.active_order_trade_indices.lock() {
+        Ok(mut indices) => {
+            for order_id in order_ids {
+                indices.remove(order_id);
+            }
+        }
+        Err(e) => {
+            crate::util::request_fatal_restart(format!(
+                "Mostrix encountered an internal error (poisoned active order indices lock: {e}). Please restart the app."
+            ));
+        }
+    }
+}
+
 /// Handle order result from the order result channel
 pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) {
     if let OperationResult::TradeClosed { order_id, message } = result {
         remove_closed_trade_from_messages_tab(app, order_id);
+        result = OperationResult::Info(message);
+    }
+    if let OperationResult::OrderHistoryDeleted {
+        deleted_order_ids,
+        message,
+    } = result
+    {
+        remove_many_orders_from_messages_tab(app, &deleted_order_ids);
         result = OperationResult::Info(message);
     }
 

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -1,4 +1,5 @@
 // Order channel manager - handles order result messages from async tasks
+use crate::ui::helpers::build_active_order_chat_list;
 use crate::ui::orders::{strip_new_order_messages_and_clamp_selected, OrderSuccess};
 use crate::ui::{
     AppState, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification,
@@ -32,6 +33,7 @@ fn remove_closed_trade_from_messages_tab(app: &mut AppState, order_id: Uuid) {
             ));
         }
     }
+    app.order_chat_static.remove(&order_id);
 }
 
 fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) {
@@ -43,6 +45,12 @@ fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) 
                 &mut messages,
                 &mut app.selected_message_idx,
             );
+            let n = build_active_order_chat_list(&messages).len();
+            if n == 0 {
+                app.selected_order_chat_idx = 0;
+            } else if app.selected_order_chat_idx >= n {
+                app.selected_order_chat_idx = n - 1;
+            }
         }
         Err(e) => {
             crate::util::request_fatal_restart(format!(
@@ -62,6 +70,15 @@ fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) 
             ));
         }
     }
+    for order_id in order_ids {
+        let key = order_id.to_string();
+        app.order_chats.remove(&key);
+        app.order_chat_last_seen.remove(&key);
+        app.order_chat_static.remove(order_id);
+        if let Ok(mut dropped) = app.dropped_user_history_order_ids.lock() {
+            dropped.insert(*order_id);
+        }
+    }
 }
 
 /// Handle order result from the order result channel
@@ -79,12 +96,26 @@ pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) 
         result = OperationResult::Info(message);
     }
 
+    match &result {
+        OperationResult::Success(os) => {
+            if let Some(h) = &os.static_header {
+                app.order_chat_static.insert(h.order_id, h.clone());
+            }
+        }
+        OperationResult::PaymentRequestRequired { static_header, .. } => {
+            app.order_chat_static
+                .insert(static_header.order_id, static_header.clone());
+        }
+        _ => {}
+    }
+
     // Handle PaymentRequestRequired - show invoice popup for buy orders
     if let OperationResult::PaymentRequestRequired {
         order,
         invoice,
         sat_amount,
         trade_index,
+        static_header: _,
     } = &result
     {
         // Track trade_index

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -4,7 +4,28 @@ use crate::ui::{
     AppState, InvoiceInputState, MessageNotification, OperationResult, UiMode, UserMode,
 };
 use mostro_core::prelude::Action;
+use std::fs::OpenOptions;
+use std::io::Write;
 use uuid::Uuid;
+
+fn debug_log_order_result(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    let payload = serde_json::json!({
+        "sessionId": "715880",
+        "runId": "pre-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": chrono::Utc::now().timestamp_millis()
+    });
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug-715880.log")
+    {
+        let _ = writeln!(file, "{payload}");
+    }
+}
 
 fn remove_closed_trade_from_messages_tab(app: &mut AppState, order_id: Uuid) {
     match app.messages.lock() {
@@ -66,6 +87,17 @@ fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) 
 /// Handle order result from the order result channel
 pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) {
     if let OperationResult::TradeClosed { order_id, message } = result {
+        // #region agent log
+        debug_log_order_result(
+            "H9",
+            "src/util/dm_utils/order_ch_mng.rs:handle_operation_result:trade_closed",
+            "TradeClosed branch removing order from messages tab",
+            serde_json::json!({
+                "order_id": order_id.to_string(),
+                "message": message,
+            }),
+        );
+        // #endregion
         remove_closed_trade_from_messages_tab(app, order_id);
         result = OperationResult::Info(message);
     }

--- a/src/util/order_utils/execute_send_msg.rs
+++ b/src/util/order_utils/execute_send_msg.rs
@@ -134,7 +134,9 @@ pub async fn execute_send_msg(
             )),
         },
         Action::Cancel => match inner_message.action {
-            Action::Canceled | Action::CooperativeCancelAccepted | Action::CooperativeCancelInitiatedByYou => Ok(()),
+            Action::Canceled
+            | Action::CooperativeCancelAccepted
+            | Action::CooperativeCancelInitiatedByYou => Ok(()),
             _ => Err(anyhow::anyhow!(
                 "Unexpected action in response: {:?}",
                 inner_message.action

--- a/src/util/order_utils/execute_send_msg.rs
+++ b/src/util/order_utils/execute_send_msg.rs
@@ -134,7 +134,7 @@ pub async fn execute_send_msg(
             )),
         },
         Action::Cancel => match inner_message.action {
-            Action::Canceled | Action::CooperativeCancelAccepted => Ok(()),
+            Action::Canceled | Action::CooperativeCancelAccepted | Action::CooperativeCancelInitiatedByYou => Ok(()),
             _ => Err(anyhow::anyhow!(
                 "Unexpected action in response: {:?}",
                 inner_message.action

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use uuid::Uuid;
 
-use crate::ui::state::{OperationResult, OrderSuccess, TakeOrderState};
+use crate::ui::state::{OperationResult, OrderChatStaticHeader, OrderSuccess, TakeOrderState};
 use crate::util::dm_utils::FETCH_EVENTS_TIMEOUT;
 use crate::util::filters::create_filter;
 use crate::util::types::{get_cant_do_description, Event, ListKind};
@@ -455,8 +455,31 @@ pub async fn fetch_order_fiat_from_relay(
     Ok(if fiat.is_empty() { None } else { Some(fiat) })
 }
 
+/// Build My Trades static header for one trade (maker or taker).
+pub(super) fn build_order_chat_static_header(
+    order: &SmallOrder,
+    trade_index: i64,
+    trade_keys: &Keys,
+    is_mine: bool,
+) -> Option<OrderChatStaticHeader> {
+    let order_id = order.id?;
+    Some(OrderChatStaticHeader {
+        order_id,
+        kind: order.kind,
+        created_at: order.created_at,
+        trade_index,
+        initiator_trade_pubkey: trade_keys.public_key().to_string(),
+        is_mine,
+    })
+}
+
 /// Helper function to create OperationResult::Success from an order
-pub(super) fn create_order_result_success(order: &SmallOrder, trade_index: i64) -> OperationResult {
+pub(super) fn create_order_result_success(
+    order: &SmallOrder,
+    trade_index: i64,
+    trade_keys: &Keys,
+    is_mine: bool,
+) -> OperationResult {
     OperationResult::Success(OrderSuccess {
         order_id: order.id,
         kind: order.kind,
@@ -469,6 +492,7 @@ pub(super) fn create_order_result_success(order: &SmallOrder, trade_index: i64) 
         premium: order.premium,
         status: order.status,
         trade_index: Some(trade_index),
+        static_header: build_order_chat_static_header(order, trade_index, trade_keys, is_mine),
     })
 }
 

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -165,6 +165,23 @@ pub fn should_apply_status_transition(
     }
 }
 
+/// Like [`should_apply_status_transition`], but never treats **equal** status as an advance.
+///
+/// Use when an **older** Nostr `timestamp` must not replace the Messages row unless the payload
+/// status is strictly newer than what the current row already shows.
+pub fn should_strictly_advance_status(
+    current: Option<Status>,
+    candidate: Status,
+    kind: Option<mostro_core::order::Kind>,
+) -> bool {
+    if let Some(cur) = current {
+        if cur == candidate {
+            return false;
+        }
+    }
+    should_apply_status_transition(current, candidate, kind)
+}
+
 /// Validates the range amount input against min/max limits.
 pub fn validate_range_amount(take_state: &mut TakeOrderState) {
     if take_state.amount_input.is_empty() {
@@ -540,7 +557,7 @@ pub(super) fn handle_mostro_response(
 
 #[cfg(test)]
 mod tests {
-    use super::should_apply_status_transition;
+    use super::{should_apply_status_transition, should_strictly_advance_status};
     use mostro_core::prelude::Status;
 
     #[test]
@@ -571,5 +588,20 @@ mod tests {
             Some(mostro_core::order::Kind::Buy),
         );
         assert!(!allow);
+    }
+
+    #[test]
+    fn apply_allows_equal_status_but_strict_does_not() {
+        let kind = Some(mostro_core::order::Kind::Buy);
+        assert!(should_apply_status_transition(
+            Some(Status::WaitingPayment),
+            Status::WaitingPayment,
+            kind,
+        ));
+        assert!(!should_strictly_advance_status(
+            Some(Status::WaitingPayment),
+            Status::WaitingPayment,
+            kind,
+        ));
     }
 }

--- a/src/util/order_utils/mod.rs
+++ b/src/util/order_utils/mod.rs
@@ -27,7 +27,7 @@ pub use helper::{
     dispute_from_tags, fetch_events_list, get_disputes, get_orders,
     inferred_status_from_trade_action, map_action_to_status, order_from_tags,
     parse_disputes_events, parse_orders_events, should_apply_status_transition,
-    validate_range_amount,
+    should_strictly_advance_status, validate_range_amount,
 };
 pub use send_new_order::send_new_order;
 pub use take_order::take_order;

--- a/src/util/order_utils/send_new_order.rs
+++ b/src/util/order_utils/send_new_order.rs
@@ -185,7 +185,12 @@ pub async fn send_new_order(
                                     }
                                 }
 
-                                Ok(create_order_result_success(order, next_idx))
+                                Ok(create_order_result_success(
+                                    order,
+                                    next_idx,
+                                    &trade_keys,
+                                    true,
+                                ))
                             } else {
                                 log::error!(
                                     "Mostro replied with Action::NewOrder but payload is missing/invalid. request_id={:?} trade_index={} payload={:?}",
@@ -231,7 +236,12 @@ pub async fn send_new_order(
                         }
                     }
 
-                    Ok(create_order_result_success(order, next_idx))
+                    Ok(create_order_result_success(
+                        order,
+                        next_idx,
+                        &trade_keys,
+                        true,
+                    ))
                 } else {
                     log::error!(
                         "Mostro replied with Action::{:?} but payload is missing/invalid. request_id={:?} trade_index={} payload={:?}",

--- a/src/util/order_utils/take_order.rs
+++ b/src/util/order_utils/take_order.rs
@@ -262,7 +262,12 @@ pub async fn take_order(
                                 &trade_keys,
                                 false,
                             )
-                            .expect("take order_to_save with id: static header for PayInvoice");
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "failed to build static header for order id {:?}",
+                                    order_to_save.id
+                                )
+                            })?;
                             Ok(OperationResult::PaymentRequestRequired {
                                 order: order_to_save.clone(),
                                 invoice: invoice_string.clone(),

--- a/src/util/order_utils/take_order.rs
+++ b/src/util/order_utils/take_order.rs
@@ -8,7 +8,9 @@ use crate::ui::OperationResult;
 use crate::util::db_utils::save_order;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
 use crate::util::mostro_info::MostroInstanceInfo;
-use crate::util::order_utils::helper::{create_order_result_success, handle_mostro_response};
+use crate::util::order_utils::helper::{
+    build_order_chat_static_header, create_order_result_success, handle_mostro_response,
+};
 use crate::util::OrderDmSubscriptionCmd;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -190,7 +192,12 @@ pub async fn take_order(
                                     trade_index: next_idx,
                                 });
                             }
-                            Ok(create_order_result_success(&normalized_order, next_idx))
+                            Ok(create_order_result_success(
+                                &normalized_order,
+                                next_idx,
+                                &trade_keys,
+                                false,
+                            ))
                         }
                         Some(Payload::PaymentRequest(opt_order, invoice_string, opt_amount)) => {
                             // For buy orders, we receive PaymentRequest with invoice for seller to pay
@@ -249,11 +256,19 @@ pub async fn take_order(
                             );
 
                             // Return PaymentRequestRequired to trigger invoice popup
+                            let static_header = build_order_chat_static_header(
+                                &order_to_save,
+                                next_idx,
+                                &trade_keys,
+                                false,
+                            )
+                            .expect("take order_to_save with id: static header for PayInvoice");
                             Ok(OperationResult::PaymentRequestRequired {
                                 order: order_to_save.clone(),
                                 invoice: invoice_string.clone(),
                                 sat_amount: *opt_amount,
                                 trade_index: next_idx,
+                                static_header,
                             })
                         }
                         _ => {

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -73,6 +73,7 @@ pub fn get_cant_do_description(reason: &CantDoReason) -> String {
         CantDoReason::TooManyRequests => {
             "Too many requests - please wait and try again".to_string()
         }
+        CantDoReason::NotAuthorized => "Not authorized to perform this action".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

When Mostro reports **Hold invoice payment accepted**, the Messages tab confirmation is now a **three-option** flow: **YES** (send `FiatSent`), **NO** (dismiss), or **CANCEL** (send cooperative `Cancel`, same idea as My Trades Shift+C). This lets users either continue the trade or start a cooperative cancel without leaving Messages.

## Changes

- **State**: `MessageViewState` uses `ViewingMessageButtonSelection` — `Two { yes_selected }` for existing YES/NO popups, `Three { selected }` for hold-invoice (0/1/2).
- **Copy**: `VIEW_MESSAGE_HOLD_INVOICE_PREVIEW` in `constants.rs`; `order_message_to_notification` uses it for `HoldInvoicePaymentAccepted`.
- **UI**: `render_yes_no_cancel_buttons`; hold-invoice popup uses multi-line `Text` (real line breaks), left-aligned body with padding, and height derived from line count so the frame stays compact.
- **Input**: Left/Right cycles the three choices; Enter dispatches per selection; explicit success text when sending cooperative cancel from this popup.
- **Protocol**: `execute_send_msg` treats `CooperativeCancelInitiatedByYou` as a valid response after sending `Cancel`.

## Motivation

At hold-invoice-accepted, users may need to **cooperatively cancel** instead of marking fiat sent; previously cancel was only convenient from My Trades.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three-button confirmations (YES/NO/CANCEL) for hold-invoice flows and a prompt for buyer-took-order; single/bulk local order-history delete with short success popup and cleanup.
  * Invoice/payment popups: Left/Right action selection (Primary vs Cancel), keyboard/mouse paste fallbacks, and startup preload of order-history plus a stable “My Trades” static header.

* **Bug Fixes / UX**
  * Improved navigation/selection cycling, safer default selections, and protections against replayed or locally-deleted history overwrites.

* **Documentation**
  * Updated TUI, message-flow, and DB docs for new popups, paste fallbacks, and history sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->