### PR TITLE
feat: add add-solver permission selector and payload support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod db;
 pub mod models;
 pub mod settings;
+pub mod shared;
 pub mod ui;
 pub mod util;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,19 @@ fn apply_pasted_text_to_active_input(app: &mut AppState, pasted_text: &str) {
     }
 
     // Handle paste for admin key input popups
-    if let UiMode::AdminMode(AdminMode::AddSolver(ref mut key_state))
-    | UiMode::AdminMode(AdminMode::SetupAdminKey(ref mut key_state)) = app.mode
-    {
+    if let UiMode::AdminMode(AdminMode::AddSolver(ref mut add_solver_state)) = app.mode {
+        if add_solver_state.key_input.focused {
+            let filtered_text: String = pasted_text
+                .chars()
+                .filter(|c| !c.is_control() || *c == '\t')
+                .collect();
+            add_solver_state
+                .key_input
+                .key_input
+                .push_str(&filtered_text);
+            add_solver_state.key_input.just_pasted = true;
+        }
+    } else if let UiMode::AdminMode(AdminMode::SetupAdminKey(ref mut key_state)) = app.mode {
         if key_state.focused {
             let filtered_text: String = pasted_text
                 .chars()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 pub mod db;
 pub mod models;
 pub mod settings;
+pub mod shared;
 pub mod ui;
 pub mod util;
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,0 +1,1 @@
+pub mod permissions;

--- a/src/shared/permissions.rs
+++ b/src/shared/permissions.rs
@@ -1,0 +1,21 @@
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SolverPermission {
+    Read,
+    ReadWrite,
+}
+
+impl SolverPermission {
+    pub const fn toggle(self) -> Self {
+        match self {
+            Self::Read => Self::ReadWrite,
+            Self::ReadWrite => Self::Read,
+        }
+    }
+
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::ReadWrite => "read-write",
+        }
+    }
+}

--- a/src/ui/admin_state.rs
+++ b/src/ui/admin_state.rs
@@ -1,26 +1,5 @@
+use crate::shared::permissions::SolverPermission;
 use crate::ui::KeyInputState;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SolverPermission {
-    Read,
-    ReadWrite,
-}
-
-impl SolverPermission {
-    pub const fn toggle(self) -> Self {
-        match self {
-            Self::Read => Self::ReadWrite,
-            Self::ReadWrite => Self::Read,
-        }
-    }
-
-    pub const fn as_label(self) -> &'static str {
-        match self {
-            Self::Read => "read",
-            Self::ReadWrite => "read-write",
-        }
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct AddSolverState {

--- a/src/ui/admin_state.rs
+++ b/src/ui/admin_state.rs
@@ -1,11 +1,43 @@
 use crate::ui::KeyInputState;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SolverPermission {
+    Read,
+    ReadWrite,
+}
+
+impl SolverPermission {
+    pub const fn toggle(self) -> Self {
+        match self {
+            Self::Read => Self::ReadWrite,
+            Self::ReadWrite => Self::Read,
+        }
+    }
+
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::ReadWrite => "read-write",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AddSolverState {
+    pub key_input: KeyInputState,
+    pub permission: SolverPermission,
+}
+
 #[derive(Clone, Debug)]
 pub enum AdminMode {
     Normal,
-    AddSolver(KeyInputState),
-    ConfirmAddSolver(String, bool), // (solver_pubkey, selected_button: true=Yes, false=No)
-    WaitingAddSolver,               // Waiting for Mostro response after admin-add-solver
+    AddSolver(AddSolverState),
+    ConfirmAddSolver {
+        solver_pubkey: String,
+        permission: SolverPermission,
+        selected_button: bool, // true=Yes, false=No
+    },
+    WaitingAddSolver, // Waiting for Mostro response after admin-add-solver
     SetupAdminKey(KeyInputState),
     ConfirmAdminKey(String, bool), // (key_string, selected_button: true=Yes, false=No)
     ConfirmTakeDispute(uuid::Uuid, bool), // (dispute_id, selected_button: true=Yes, false=No)

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -7,6 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
+use crate::shared::permissions::SolverPermission;
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::*;
 use crate::util::fatal::request_fatal_restart;

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -457,10 +457,10 @@ fn render_add_solver_popup(f: &mut ratatui::Frame, add_solver_state: &AddSolverS
         chunks[1],
     );
 
-    let input_display = if add_solver_state.key_input.key_input.is_empty() {
-        "npub... / hex...".to_string()
+    let input_display: &str = if add_solver_state.key_input.key_input.is_empty() {
+        "npub... / hex..."
     } else {
-        add_solver_state.key_input.key_input.clone()
+        add_solver_state.key_input.key_input.as_str()
     };
 
     f.render_widget(

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -1,7 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use mostro_core::prelude::*;
+use ratatui::layout::Alignment;
 use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::*;
@@ -291,15 +295,8 @@ pub fn ui_draw(
     }
 
     // Admin key input popup overlay
-    if let UiMode::AdminMode(AdminMode::AddSolver(key_state)) = &app.mode {
-        key_input_popup::render_key_input_popup(
-            f,
-            "Add Solver",
-            "Enter solver public key (npub... or hex):",
-            "npub... / hex...",
-            key_state,
-            false,
-        );
+    if let UiMode::AdminMode(AdminMode::AddSolver(add_solver_state)) = &app.mode {
+        render_add_solver_popup(f, add_solver_state);
     }
     if let UiMode::AdminMode(AdminMode::SetupAdminKey(key_state)) = &app.mode {
         key_input_popup::render_key_input_popup(
@@ -326,15 +323,21 @@ pub fn ui_draw(
             )),
         );
     }
-    if let UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, selected_button)) =
-        &app.mode
+    if let UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+        solver_pubkey,
+        permission,
+        selected_button,
+    }) = &app.mode
     {
         admin_key_confirm::render_admin_key_confirm_with_message(
             f,
             "Add Solver",
             solver_pubkey,
             *selected_button,
-            Some("Are you sure you want to add this pubkey as dispute solver?"),
+            Some(&format!(
+                "Add this pubkey as dispute solver with '{}' permission?",
+                permission.as_label()
+            )),
         );
     }
     if let UiMode::AdminMode(AdminMode::ConfirmAdminKey(key_string, selected_button)) = &app.mode {
@@ -414,4 +417,120 @@ pub fn ui_draw(
     if let Some(message) = app.offline_overlay_message.as_deref() {
         offline_overlay::render_offline_overlay(f, message);
     }
+}
+
+fn render_add_solver_popup(f: &mut ratatui::Frame, add_solver_state: &AddSolverState) {
+    let area = f.area();
+    let popup = crate::ui::helpers::create_centered_popup(area, 84, 13);
+    f.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title("Add Solver")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    f.render_widget(block, popup);
+
+    let chunks = Layout::new(
+        Direction::Vertical,
+        [
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ],
+    )
+    .split(popup);
+
+    f.render_widget(
+        Paragraph::new("Enter solver pubkey (npub... or hex):")
+            .style(
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    let input_display = if add_solver_state.key_input.key_input.is_empty() {
+        "npub... / hex...".to_string()
+    } else {
+        add_solver_state.key_input.key_input.clone()
+    };
+
+    f.render_widget(
+        Paragraph::new(input_display)
+            .style(
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .bg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .wrap(Wrap { trim: true })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .style(Style::default().fg(PRIMARY_COLOR)),
+            ),
+        chunks[2],
+    );
+
+    let is_read_selected = add_solver_state.permission == SolverPermission::Read;
+    let read_style = if is_read_selected {
+        Style::default()
+            .fg(Color::Black)
+            .bg(PRIMARY_COLOR)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Gray)
+    };
+    let read_write_style = if is_read_selected {
+        Style::default().fg(Color::Gray)
+    } else {
+        Style::default()
+            .fg(Color::Black)
+            .bg(PRIMARY_COLOR)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    let permission_line = Line::from(vec![
+        Span::styled("Permission: ", Style::default().fg(Color::White)),
+        Span::styled(" [ Read ] ", read_style),
+        Span::styled("   ", Style::default()),
+        Span::styled(" [ Read-Write ] ", read_write_style),
+    ]);
+    f.render_widget(
+        Paragraph::new(permission_line).alignment(Alignment::Center),
+        chunks[4],
+    );
+
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "(Left/Right to switch)",
+            Style::default().fg(Color::DarkGray),
+        )))
+        .alignment(Alignment::Center),
+        chunks[5],
+    );
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Press ", Style::default()),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" to continue", Style::default()),
+        ]))
+        .alignment(Alignment::Center),
+        chunks[6],
+    );
+
+    crate::ui::helpers::render_help_text(f, chunks[7], "Press ", "Esc", " to cancel");
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -238,7 +238,7 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
         ),
         (
             "Add Dispute Solver",
-            "Enter solver npub and choose read or read-write permission before confirming.",
+            "Enter solver npub, use Left/Right to choose read or read-write, then confirm",
         ),
         (
             "Change Admin Key",

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -238,7 +238,7 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
         ),
         (
             "Add Dispute Solver",
-            "Enter a solver npub to register with Mostro for dispute routing.",
+            "Enter solver npub and choose read or read-write permission before confirming.",
         ),
         (
             "Change Admin Key",

--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -89,7 +89,6 @@ pub(crate) fn execute_add_solver_action(
     };
     app.mode = UiMode::AdminMode(AdminMode::WaitingAddSolver);
 
-    let solver_pubkey_clone = solver_pubkey.clone();
     let client_clone = ctx.client.clone();
     let result_tx = ctx.order_result_tx.clone();
 
@@ -106,7 +105,7 @@ pub(crate) fn execute_add_solver_action(
     let mostro_info = ctx.mostro_info.clone();
     tokio::spawn(async move {
         match execute_admin_add_solver(
-            &solver_pubkey_clone,
+            &solver_pubkey,
             permission,
             &admin_keys,
             &client_clone,

--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -1,5 +1,5 @@
 use crate::ui::key_handler::EnterKeyContext;
-use crate::ui::{AdminMode, AppState, UiMode};
+use crate::ui::{AddSolverState, AdminMode, AppState, SolverPermission, UiMode};
 use crate::util::fatal::request_fatal_restart;
 use crate::util::order_utils::{execute_admin_add_solver, execute_finalize_dispute};
 use uuid::Uuid;
@@ -77,6 +77,7 @@ pub(crate) fn execute_take_dispute_action(
 pub(crate) fn execute_add_solver_action(
     app: &mut AppState,
     solver_pubkey: String,
+    permission: SolverPermission,
     ctx: &EnterKeyContext<'_>,
 ) {
     let Some(admin_keys) = ctx.admin_chat_keys.cloned() else {
@@ -105,6 +106,7 @@ pub(crate) fn execute_add_solver_action(
     tokio::spawn(async move {
         match execute_admin_add_solver(
             &solver_pubkey_clone,
+            permission,
             &admin_keys,
             &client_clone,
             current_mostro_pubkey,
@@ -198,14 +200,21 @@ pub(crate) fn handle_enter_admin_mode(
     ctx: &crate::ui::key_handler::EnterKeyContext<'_>,
 ) {
     match mode {
-        UiMode::AdminMode(AdminMode::AddSolver(key_state)) => {
+        UiMode::AdminMode(AdminMode::AddSolver(add_solver_state)) => {
             // Validate npub before proceeding to confirmation
-            match validate_npub(&key_state.key_input) {
+            match validate_npub(&add_solver_state.key_input.key_input) {
                 Ok(_) => {
-                    app.mode =
-                        handle_input_to_confirmation(&key_state.key_input, default_mode, |input| {
-                            UiMode::AdminMode(AdminMode::ConfirmAddSolver(input, true))
-                        });
+                    app.mode = handle_input_to_confirmation(
+                        &add_solver_state.key_input.key_input,
+                        default_mode,
+                        |input| {
+                            UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+                                solver_pubkey: input,
+                                permission: add_solver_state.permission,
+                                selected_button: true,
+                            })
+                        },
+                    );
                 }
                 Err(e) => {
                     // Show error popup
@@ -213,14 +222,20 @@ pub(crate) fn handle_enter_admin_mode(
                 }
             }
         }
-        UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, selected_button)) => {
+        UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+            solver_pubkey,
+            permission,
+            selected_button,
+        }) => {
             if selected_button {
                 // YES selected - send AddSolver message
-                execute_add_solver_action(app, solver_pubkey, ctx);
+                execute_add_solver_action(app, solver_pubkey, permission, ctx);
             } else {
                 // NO selected - go back to input
-                app.mode =
-                    UiMode::AdminMode(AdminMode::AddSolver(create_key_input_state(&solver_pubkey)));
+                app.mode = UiMode::AdminMode(AdminMode::AddSolver(AddSolverState {
+                    key_input: create_key_input_state(&solver_pubkey),
+                    permission,
+                }));
             }
         }
         UiMode::AdminMode(AdminMode::SetupAdminKey(key_state)) => {

--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -1,5 +1,6 @@
+use crate::shared::permissions::SolverPermission;
 use crate::ui::key_handler::EnterKeyContext;
-use crate::ui::{AddSolverState, AdminMode, AppState, SolverPermission, UiMode};
+use crate::ui::{AddSolverState, AdminMode, AppState, UiMode};
 use crate::util::fatal::request_fatal_restart;
 use crate::util::order_utils::{execute_admin_add_solver, execute_finalize_dispute};
 use uuid::Uuid;

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -210,10 +210,18 @@ pub fn handle_confirm_key(
             // Return false to break the main loop
             false
         }
-        UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, _)) => {
+        UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+            solver_pubkey,
+            permission,
+            ..
+        }) => {
             // Delegate to the same handler used for Enter to keep logic DRY
             // (synthesize a mode with YES selected)
-            let mode = UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, true));
+            let mode = UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+                solver_pubkey,
+                permission,
+                selected_button: true,
+            });
             handle_enter_admin_mode(app, mode, default_mode, ctx);
             true
         }
@@ -283,9 +291,17 @@ pub fn handle_cancel_key(app: &mut AppState) {
         UiMode::ConfirmDeleteHistoryOrder(_, _) | UiMode::ConfirmBulkDeleteHistory(_)
     ) {
         app.mode = default_mode;
-    } else if let UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, _)) = &app.mode {
+    } else if let UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+        solver_pubkey,
+        permission,
+        ..
+    }) = &app.mode
+    {
         app.mode = handle_confirmation_esc(solver_pubkey, |input| {
-            UiMode::AdminMode(AdminMode::AddSolver(create_key_input_state(input)))
+            UiMode::AdminMode(AdminMode::AddSolver(crate::ui::AddSolverState {
+                key_input: create_key_input_state(input),
+                permission: *permission,
+            }))
         });
     } else if let UiMode::AdminMode(AdminMode::ConfirmAdminKey(key_string, _)) = &app.mode {
         app.mode = handle_confirmation_esc(key_string, |input| {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1,4 +1,6 @@
 use crate::models::{Order, ORDER_HISTORY_BULK_DELETE_STATUSES};
+use crate::shared::permissions::SolverPermission;
+use crate::ui::admin_state::AddSolverState;
 use crate::ui::helpers::{build_active_order_chat_list, save_order_chat_message};
 use crate::ui::key_handler::chat_helpers::{
     handle_enter_finalize_popup, message_counter, FinalizeDisputePopupButton,
@@ -1074,9 +1076,9 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             }
             6 if app.user_role == UserRole::Admin => {
                 // Add Solver (Admin only)
-                app.mode = UiMode::AdminMode(AdminMode::AddSolver(crate::ui::AddSolverState {
+                app.mode = UiMode::AdminMode(AdminMode::AddSolver(AddSolverState {
                     key_input: key_state,
-                    permission: crate::ui::SolverPermission::ReadWrite,
+                    permission: SolverPermission::ReadWrite,
                 }));
             }
             7 if app.user_role == UserRole::Admin => {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -460,7 +460,7 @@ pub fn handle_enter_key(app: &mut AppState, ctx: &super::EnterKeyContext<'_>) ->
             true
         }
         UiMode::AdminMode(AdminMode::AddSolver(_))
-        | UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, _))
+        | UiMode::AdminMode(AdminMode::ConfirmAddSolver { .. })
         | UiMode::AdminMode(AdminMode::SetupAdminKey(_))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, _)) => {
             handle_enter_admin_mode(app, current_mode, default_mode, ctx);
@@ -1074,7 +1074,10 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             }
             6 if app.user_role == UserRole::Admin => {
                 // Add Solver (Admin only)
-                app.mode = UiMode::AdminMode(AdminMode::AddSolver(key_state));
+                app.mode = UiMode::AdminMode(AdminMode::AddSolver(crate::ui::AddSolverState {
+                    key_input: key_state,
+                    permission: crate::ui::SolverPermission::ReadWrite,
+                }));
             }
             7 if app.user_role == UserRole::Admin => {
                 // Setup Admin Key (Admin only)

--- a/src/ui/key_handler/esc_handlers.rs
+++ b/src/ui/key_handler/esc_handlers.rs
@@ -90,10 +90,17 @@ pub fn handle_esc_key(app: &mut AppState) -> bool {
             app.mode = default_mode.clone();
             true
         }
-        UiMode::AdminMode(AdminMode::ConfirmAddSolver(solver_pubkey, _)) => {
+        UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+            solver_pubkey,
+            permission,
+            ..
+        }) => {
             // Cancel confirmation, go back to input
             app.mode = handle_confirmation_esc(solver_pubkey, |input| {
-                UiMode::AdminMode(AdminMode::AddSolver(create_key_input_state(input)))
+                UiMode::AdminMode(AdminMode::AddSolver(crate::ui::AddSolverState {
+                    key_input: create_key_input_state(input),
+                    permission: *permission,
+                }))
             });
             true
         }

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -696,7 +696,7 @@ pub fn handle_key_event(
             UiMode::AddMostroPubkey(ref mut ks) => Some(ks),
             UiMode::AddRelay(ref mut ks) => Some(ks),
             UiMode::AddCurrency(ref mut ks) => Some(ks),
-            UiMode::AdminMode(AdminMode::AddSolver(ref mut ks)) => Some(ks),
+            UiMode::AdminMode(AdminMode::AddSolver(ref mut state)) => Some(&mut state.key_input),
             UiMode::AdminMode(AdminMode::SetupAdminKey(ref mut ks)) => Some(ks),
             _ => None,
         };
@@ -908,7 +908,14 @@ pub fn handle_key_event(
         KeyCode::Left | KeyCode::Right => {
             // Handle Left/Right for button selection in confirmation popups
             match &mut app.mode {
-                UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
+                UiMode::AdminMode(AdminMode::AddSolver(ref mut state)) => {
+                    state.permission = state.permission.toggle();
+                    return Some(true);
+                }
+                UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+                    ref mut selected_button,
+                    ..
+                })
                 | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
                 | UiMode::AdminMode(AdminMode::ConfirmTakeDispute(_, ref mut selected_button))
                 | UiMode::ConfirmMostroPubkey(_, ref mut selected_button)

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -69,7 +69,10 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
                 selection.cycle_three_prev();
             }
         },
-        UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
+        UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+            ref mut selected_button,
+            ..
+        })
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmFinalizeDispute {
             ref mut selected_button,
@@ -137,7 +140,10 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
                 selection.cycle_three_next();
             }
         },
-        UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, ref mut selected_button))
+        UiMode::AdminMode(AdminMode::ConfirmAddSolver {
+            ref mut selected_button,
+            ..
+        })
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, ref mut selected_button))
         | UiMode::AdminMode(AdminMode::ConfirmFinalizeDispute {
             ref mut selected_button,
@@ -281,7 +287,7 @@ fn handle_up_key(
         | UiMode::ViewingMessage(_)
         | UiMode::RatingOrder(_)
         | UiMode::AdminMode(AdminMode::AddSolver(_))
-        | UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, _))
+        | UiMode::AdminMode(AdminMode::ConfirmAddSolver { .. })
         | UiMode::AdminMode(AdminMode::SetupAdminKey(_))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, _))
         | UiMode::AdminMode(AdminMode::ConfirmTakeDispute(_, _))
@@ -450,7 +456,7 @@ fn handle_down_key(
         | UiMode::ViewingMessage(_)
         | UiMode::RatingOrder(_)
         | UiMode::AdminMode(AdminMode::AddSolver(_))
-        | UiMode::AdminMode(AdminMode::ConfirmAddSolver(_, _))
+        | UiMode::AdminMode(AdminMode::ConfirmAddSolver { .. })
         | UiMode::AdminMode(AdminMode::SetupAdminKey(_))
         | UiMode::AdminMode(AdminMode::ConfirmAdminKey(_, _))
         | UiMode::AdminMode(AdminMode::ConfirmTakeDispute(_, _))

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,7 +33,7 @@ pub mod tabs;
 pub mod user_state;
 pub mod waiting;
 
-pub use admin_state::AdminMode;
+pub use admin_state::{AddSolverState, AdminMode, SolverPermission};
 pub use draw::ui_draw;
 pub use network_status::NetworkStatus;
 pub use state::{

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,7 +33,7 @@ pub mod tabs;
 pub mod user_state;
 pub mod waiting;
 
-pub use admin_state::{AddSolverState, AdminMode, SolverPermission};
+pub use admin_state::{AddSolverState, AdminMode};
 pub use draw::ui_draw;
 pub use network_status::NetworkStatus;
 pub use state::{

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,4 +1,5 @@
-pub use crate::ui::admin_state::{AddSolverState, SolverPermission};
+pub use crate::shared::permissions::SolverPermission;
+pub use crate::ui::admin_state::AddSolverState;
 pub use crate::ui::app_state::{AppState, UiMode};
 pub use crate::ui::chat::{
     AdminChatLastSeen, AdminChatUpdate, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,3 +1,4 @@
+pub use crate::ui::admin_state::{AddSolverState, SolverPermission};
 pub use crate::ui::app_state::{AppState, UiMode};
 pub use crate::ui::chat::{
     AdminChatLastSeen, AdminChatUpdate, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,

--- a/src/util/order_utils/execute_admin_add_solver.rs
+++ b/src/util/order_utils/execute_admin_add_solver.rs
@@ -4,8 +4,8 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
+use crate::shared::permissions::SolverPermission;
 use crate::ui::key_handler::hex_pubkey_to_npub;
-use crate::ui::SolverPermission;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
 use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::handle_mostro_response;

--- a/src/util/order_utils/execute_admin_add_solver.rs
+++ b/src/util/order_utils/execute_admin_add_solver.rs
@@ -5,6 +5,7 @@ use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
 use crate::ui::key_handler::hex_pubkey_to_npub;
+use crate::ui::SolverPermission;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
 use crate::util::mostro_info::MostroInstanceInfo;
 use crate::util::order_utils::helper::handle_mostro_response;
@@ -27,10 +28,19 @@ fn normalize_solver_pubkey(pubkey: &str) -> String {
     trimmed.to_string()
 }
 
+fn build_solver_payload_text(pubkey: &str, permission: SolverPermission) -> String {
+    let normalized_pubkey = normalize_solver_pubkey(pubkey);
+    match permission {
+        SolverPermission::Read => format!("{normalized_pubkey}:read"),
+        SolverPermission::ReadWrite => normalized_pubkey,
+    }
+}
+
 /// Add a new solver to the Mostro network
 /// Requires admin privileges (admin_privkey must be configured)
 pub async fn execute_admin_add_solver(
     solver_pubkey: &str,
+    permission: SolverPermission,
     admin_keys: &Keys,
     client: &Client,
     mostro_pubkey: PublicKey,
@@ -38,8 +48,7 @@ pub async fn execute_admin_add_solver(
 ) -> Result<()> {
     let request_id = Uuid::new_v4().as_u128() as u64;
 
-    // Normalize solver pubkey to bech32 (hex input → npub conversion)
-    let normalized_pubkey = normalize_solver_pubkey(solver_pubkey);
+    let payload_text = build_solver_payload_text(solver_pubkey, permission);
 
     // Create AddSolver message
     let add_solver_message = Message::new_dispute(
@@ -47,7 +56,7 @@ pub async fn execute_admin_add_solver(
         Some(request_id),
         None,
         Action::AdminAddSolver,
-        Some(Payload::TextMessage(normalized_pubkey)),
+        Some(Payload::TextMessage(payload_text)),
     )
     .as_json()
     .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
@@ -84,4 +93,23 @@ pub async fn execute_admin_add_solver(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_solver_payload_uses_read_suffix_for_read_permission() {
+        let npub = "npub1qqq884wtp2jn96lqhqlnarl4kk3rmvrc9z2nmrvqujx3m4l2ea5qd5d0fq";
+        let payload = build_solver_payload_text(npub, SolverPermission::Read);
+        assert_eq!(payload, format!("{npub}:read"));
+    }
+
+    #[test]
+    fn add_solver_payload_keeps_default_format_for_read_write_permission() {
+        let npub = "npub1qqq884wtp2jn96lqhqlnarl4kk3rmvrc9z2nmrvqujx3m4l2ea5qd5d0fq";
+        let payload = build_solver_payload_text(npub, SolverPermission::ReadWrite);
+        assert_eq!(payload, npub);
+    }
 }


### PR DESCRIPTION
Improve the admin add-solver flow by introducing a read/read-write permission selector in the popup and carrying that choice through confirmation and submission. Format admin-add-solver payloads according to protocol expectations, preserve state on cancel paths, and refresh help text and tests for the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission selection (Read or Read-Write) when adding dispute solvers
  * Confirmation now shows the chosen permission label

* **Improvements**
  * Redesigned Add Solver popup into a dedicated permission-aware UI with in-popup help
  * Left/Right keys toggle permission during setup; cancelling preserves the selected permission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->