### PR TITLE
feat(ln): verify LNURL-pay before saving ln_address and AddInvoice - Phase 2

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -21,6 +21,8 @@ This document outlines the coding standards and best practices for the Mostrix p
   - Protocol logic in `src/util/order_utils/`
   - Database operations in `src/util/db_utils.rs`
 
+- **Async UI feedback channels**: When spawning tasks from the key handler, use a **dedicated** `tokio::sync::mpsc` channel when the domain is not order/dispute traffic (for example, **`ln_address_result_tx`** / **`LnAddressVerifyResult`** for Lightning address LNURL verification) instead of overloading **`order_result_tx`**, which already carries creates, takes, disputes, history cleanup, and attachment flows. The main loop can still map a small domain-specific enum into **`OperationResult`** for a single popup renderer.
+
 ### 6. Import Usage Rule
 
 **Always import from the crate root at the top of the file; never use full crate paths in the body of the code.**

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -472,6 +472,7 @@ For invoice-related trade actions, the Messages Enter path uses `UiMode::NewMess
 - Paste/copy details:
   - AddInvoice supports bracketed paste plus key/mouse fallbacks where terminals do not emit `Event::Paste`.
   - PayInvoice keeps copy (`C`) + scroll behavior while supporting cancel selection.
+- **Lightning address as invoice**: If the input is a Lightning address (`user@domain.com`), Mostrix still sends `AddInvoice` with a `PaymentRequest` payload, but first verifies the LNURL metadata endpoint returns `tag: payRequest` (`util::ln_address::ln_address_pay_request_reachable`) so unreachable addresses fail before hitting Mostro.
 
 ### Rating the counterparty (`RateUser`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 ## Contributing & tooling
 
 - **Coding Standards**: [CODING_STANDARDS.md](CODING_STANDARDS.md) — Style, re-exports, tests, clippy
-- **Settings analysis**: [SETTINGS_ANALYSIS.md](SETTINGS_ANALYSIS.md) — Deeper notes on `settings.toml` / options (reference)
+- **Settings analysis**: [SETTINGS_ANALYSIS.md](SETTINGS_ANALYSIS.md) — Deeper notes on `settings.toml` / options (includes buyer `ln_address`, LNURL verify-on-save)
 
 ## Tips
 

--- a/docs/SETTINGS_ANALYSIS.md
+++ b/docs/SETTINGS_ANALYSIS.md
@@ -30,7 +30,7 @@ Proof-of-work for **published Nostr events** is **not** configured in the Settin
 - **Field**: `Settings.ln_address` (`String`, default empty). Persisted in `settings.toml`; template always includes `ln_address = ""`.
 - **UI**: Only listed under **User** Settings (not Admin). **Set** opens `AddLnAddress` → `ConfirmLnAddress`; **Clear** uses `ConfirmClearLnAddress` (no network).
 - **Format check**: `validate_ln_address_format` in `src/ui/key_handler/settings.rs` (`LightningAddress::from_str`).
-- **Reachability before save**: On confirm, `spawn_verify_and_save_ln_address_task` GETs the LNURL-pay metadata URL and requires JSON `tag: "payRequest"` (`ln_address_pay_request_reachable` in `src/util/ln_address.rs`). Failure surfaces as `OperationResult::Error`; disk is not updated.
+- **Reachability before save**: On confirm, `spawn_verify_and_save_ln_address_task` GETs the LNURL-pay metadata URL and requires JSON `tag: "payRequest"` (`ln_address_pay_request_reachable` in `src/util/ln_address.rs`). Results are sent on **`ln_address_result_tx`** as **`LnAddressVerifyResult`** (`src/ui/orders.rs`); the main loop (`src/main.rs`) receives them on **`ln_address_result_rx`**, maps success to `OperationResult::Info` and failure to `OperationResult::Error`, then calls **`handle_operation_result`** so the user still sees the same operation-result popup. Disk is not updated on failure.
 - **AddInvoice path**: When the pasted/submitted invoice parses as a Lightning address, `execute_add_invoice` runs the same reachability check before sending the Mostro DM (`src/util/order_utils/execute_add_invoice.rs`).
 
 ### 4. Validation Enhancements

--- a/docs/SETTINGS_ANALYSIS.md
+++ b/docs/SETTINGS_ANALYSIS.md
@@ -25,6 +25,14 @@ This document provides a comprehensive analysis of the Settings tab features imp
 
 Proof-of-work for **published Nostr events** is **not** configured in the Settings tab or in `settings.toml`. It comes from the Mostro instance status event (kind 38385, tag `pow`) and is applied in code paths described in **[POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md)**. Older `settings.toml` files may still list `pow`; that key is ignored when loading `Settings`.
 
+### Buyer Lightning address (`ln_address`, User mode)
+
+- **Field**: `Settings.ln_address` (`String`, default empty). Persisted in `settings.toml`; template always includes `ln_address = ""`.
+- **UI**: Only listed under **User** Settings (not Admin). **Set** opens `AddLnAddress` → `ConfirmLnAddress`; **Clear** uses `ConfirmClearLnAddress` (no network).
+- **Format check**: `validate_ln_address_format` in `src/ui/key_handler/settings.rs` (`LightningAddress::from_str`).
+- **Reachability before save**: On confirm, `spawn_verify_and_save_ln_address_task` GETs the LNURL-pay metadata URL and requires JSON `tag: "payRequest"` (`ln_address_pay_request_reachable` in `src/util/ln_address.rs`). Failure surfaces as `OperationResult::Error`; disk is not updated.
+- **AddInvoice path**: When the pasted/submitted invoice parses as a Lightning address, `execute_add_invoice` runs the same reachability check before sending the Mostro DM (`src/util/order_utils/execute_add_invoice.rs`).
+
 ### 4. Validation Enhancements
 - **Mostro Pubkey Validation**: Changed from `npub` format to hex format validation
 - **Relay Validation**: Added validation to ensure relay URLs start with `wss://`

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -97,6 +97,8 @@ pub struct Settings {
     pub currencies_filter: Vec<String>,
     #[serde(default = "default_user_mode")]
     pub user_mode: String, // "user" or "admin", default "user"
+    #[serde(default)]
+    pub ln_address: String, // Lightning address for buyer receive; empty = unset
 }
 ```
 
@@ -110,6 +112,7 @@ pub struct Settings {
   - When empty, all currencies published by the Mostro instance are shown.  
   - When non-empty (e.g. `["USD"]`, `["USD", "EUR"]`), only orders whose fiat code is in this list are displayed.
 - **`user_mode`**: Either "user" or "admin". Controls the UI and available actions.
+- **`ln_address`**: Optional **Lightning address** (`user@domain.com`) used when the local user acts as **buyer** (receive via LNURL-pay). The embedded template includes `ln_address = ""`. Older `settings.toml` files without this key still load (`#[serde(default)]` yields an empty string). **Saving from the Settings tab** runs an async check that the LNURL metadata URL returns JSON with `tag: "payRequest"` before writing disk (`spawn_verify_and_save_ln_address_task` in `src/ui/key_handler/async_tasks.rs`, helper in `src/util/ln_address.rs`). **Clear** removes the value without a network call.
 
 Proof-of-work for published events is taken from the Mostro instance status event (kind 38385, tag `pow`), not from `settings.toml`.
 

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -112,7 +112,7 @@ pub struct Settings {
   - When empty, all currencies published by the Mostro instance are shown.  
   - When non-empty (e.g. `["USD"]`, `["USD", "EUR"]`), only orders whose fiat code is in this list are displayed.
 - **`user_mode`**: Either "user" or "admin". Controls the UI and available actions.
-- **`ln_address`**: Optional **Lightning address** (`user@domain.com`) used when the local user acts as **buyer** (receive via LNURL-pay). The embedded template includes `ln_address = ""`. Older `settings.toml` files without this key still load (`#[serde(default)]` yields an empty string). **Saving from the Settings tab** runs an async check that the LNURL metadata URL returns JSON with `tag: "payRequest"` before writing disk (`spawn_verify_and_save_ln_address_task` in `src/ui/key_handler/async_tasks.rs`, helper in `src/util/ln_address.rs`). **Clear** removes the value without a network call.
+- **`ln_address`**: Optional **Lightning address** (`user@domain.com`) used when the local user acts as **buyer** (receive via LNURL-pay). The embedded template includes `ln_address = ""`. Older `settings.toml` files without this key still load (`#[serde(default)]` yields an empty string). **Saving from the Settings tab** runs an async check that the LNURL metadata URL returns JSON with `tag: "payRequest"` before writing disk (`spawn_verify_and_save_ln_address_task` in `src/ui/key_handler/async_tasks.rs`, helper in `src/util/ln_address.rs`). The spawned task reports on **`ln_address_result_tx`** (`LnAddressVerifyResult`), not on `order_result_tx`, so settings verification does not share the order/dispute result queue. **Clear** removes the value without a network call.
 
 Proof-of-work for published events is taken from the Mostro instance status event (kind 38385, tag `pow`), not from `settings.toml`.
 
@@ -181,31 +181,27 @@ In addition to the background scheduler, Mostrix restores admin chat state durin
 
 ## Main Event Loop
 
-The TUI runs in a `tokio::select!` loop that handles:
-1. **Order Results**: Results from asynchronous order-related operations.
-2. **Message Notifications**: New direct messages from counterparties or Mostro.
-3. **Network Status Events**: Offline/online transitions and reconnect workflow.
-4. **User Input**: Keyboard and paste events processed via `key_handler.rs`.
-5. **UI Refresh**: Periodic ticks to ensure the UI stays up-to-date.
+The TUI runs in a `tokio::select!` loop that handles (among others):
 
-**Source**: `src/main.rs:184`
-```184:279:src/main.rs
-    loop {
-        tokio::select! {
-            result = order_result_rx.recv() => {
-                // ... handle order results ...
-            }
-            notification = message_notification_rx.recv() => {
-                // ... handle notifications ...
-            }
-            maybe_event = events.next() => {
-                // ... handle keyboard/paste events ...
-            }
-            _ = refresh_interval.tick() => {
-                // Refresh the UI
-            }
-        }
-        // ... UI drawing ...
-        terminal.draw(|f| ui_draw(f, &app, &orders, Some(&status_line)))?;
+1. **Fatal errors**: `fatal_error_rx` — aborts background work and shows an error popup.
+2. **Network status**: `network_status_rx` — offline overlay vs reconnect + runtime reload.
+3. **Order / dispute / attachment / observer async results**: `order_result_rx` — `OperationResult`; includes dispute-list refresh side effects for certain `Info` messages and My Trades DB resync for `OrderHistoryDeleted`.
+4. **Lightning address verify-and-save (settings)**: `ln_address_result_rx` — `LnAddressVerifyResult`; mapped to `OperationResult::Info` / `Error` and passed to **`handle_operation_result`** so UI behavior matches other operation-result popups without mixing traffic into `order_result_rx`.
+5. **Key rotation / seed words / message notifications / admin & user chat fetches / Mostro instance info / user input / periodic ticks**: see `src/main.rs` (`create_app_channels` in `src/ui/key_handler/async_tasks.rs` lists all paired senders and receivers).
+
+**Source**: `src/main.rs` (outer `loop` + `tokio::select!` + `terminal.draw`).
+
+```text
+// Simplified shape (not exhaustive — see src/main.rs for full select!)
+loop {
+    tokio::select! {
+        // fatal_error_rx, network_status_rx, ...
+        result = order_result_rx.recv() => { /* handle_operation_result + side effects */ }
+        ln_address_verify = ln_address_result_rx.recv() => { /* map LnAddressVerifyResult → OperationResult */ }
+        // key_rotation_rx, seed_words_rx, message_notification_rx, ...
+        maybe_event = events.next() => { /* handle_key_event, paste, mouse */ }
+        _ = refresh_interval.tick() => { /* keep UI alive */ }
     }
+    terminal.draw(|f| ui_draw(f, &app, &orders, Some(&status_line)))?;
+}
 ```

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -76,7 +76,7 @@ Focused on trading and order management.
 - **Orders**: View the global order book.
 - **My Trades**: Manage active trades.
 - **Messages**: Direct messages for trade coordination.
-- **Settings**: Local configuration, including key rotation via **Generate New Keys** and mnemonic backup prompts.
+- **Settings**: Local configuration, including key rotation via **Generate New Keys** and mnemonic backup prompts. **User mode only**: **Set Lightning Address (buyer)** / **Clear Lightning Address** — optional `user@domain.com` stored in `settings.toml`; confirm-save fetches LNURL metadata (`payRequest`) before persisting (see `src/util/ln_address.rs`, `spawn_verify_and_save_ln_address_task`).
 - **Create New Order**: Form for publishing new orders.
 
 ### Admin Role
@@ -138,7 +138,7 @@ Popups are implemented by rendering additional widgets on top of the main layout
 The primary shared popup is the **operation result** modal, used for:
 
 - Order creation / take-order flows
-- Settings validation errors (invalid pubkey, relay, currency, etc.)
+- Settings validation errors (invalid pubkey, relay, currency, Lightning address format, LNURL verification failure, etc.)
 - Admin actions (add solver, finalize disputes)
 - Blossom attachment downloads and Observer-mode shared-key errors
 

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -195,7 +195,7 @@ Users can switch between roles (User/Admin) and tabs using arrow keys.
 
 The `handle_key_event` function dispatches keys based on the current `UiMode`.
 
-**Example**: Handling the `Enter` key (dispatched from `key_handler/mod.rs` to `enter_handlers::handle_enter_key`, which uses `order_result_tx` for operation-result feedback).
+**Example**: Handling the `Enter` key (dispatched from `key_handler/mod.rs` to `enter_handlers::handle_enter_key`). Async feedback uses purpose-specific channels from **`EnterKeyContext`**: **`order_result_tx`** for orders, takes, disputes, bulk history cleanup, attachments, etc., and **`ln_address_result_tx`** for **Lightning address verify-and-save** only (`LnAddressVerifyResult` → main loop maps to `OperationResult` for the shared popup).
 
 ### Specialized Input
 

--- a/docs/buy order flow.md
+++ b/docs/buy order flow.md
@@ -75,7 +75,7 @@ Same status vocabulary applies; **order** of states must match [ORDER.md](https:
 
 ### Invoice popups (paste vs pay)
 
-- **AddInvoice** (paste Lightning invoice): open only when the **buyer** must submit an invoice and status/action indicates that step for the **local** user.
+- **AddInvoice** (paste **BOLT11** or **Lightning address**): open only when the **buyer** must submit an invoice and status/action indicates that step for the **local** user. For addresses, Mostrix checks the LNURL endpoint before publishing the DM. An optional saved buyer address lives in **`settings.toml`** (`ln_address`) and is editable from **User → Settings** only.
 - **PayInvoice** (pay hold invoice): open only when the **seller** must pay and that matches the **local** user in the current phase.
 - If Enter is pressed but the phase does **not** match, **do not** open the invoice modal; show a short informational message or no-op.
 

--- a/docs/sell order flow.md
+++ b/docs/sell order flow.md
@@ -34,7 +34,7 @@ Typical `Status` values follow the same global order machine as other trades (`w
 
 Phases (labels from `SELL_ORDER_FLOW_STEPS_TAKER`):
 
-1. **Add invoice** — buyer submits Lightning invoice when required.
+1. **Add invoice** — buyer submits a **BOLT11** payment request or a **Lightning address** (`user@domain.com`) when required; Mostrix verifies LNURL-pay metadata (`payRequest`) before sending `AddInvoice` for addresses. Optional default address: **User → Settings → Set Lightning Address** (`settings.toml` field `ln_address`).
 2. **Wait for seller** — seller pays hold / completes prerequisites.
 3. **Chat with buyer** — messaging phase (label uses “Buyer” from book side).
 4. **Send fiat** — buyer sends fiat.

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use crate::ui::key_handler::{
     spawn_refresh_mostro_info_task, AppChannels, RuntimeReconnectContext,
 };
 use crate::ui::network_status::spawn_network_status_monitor;
-use crate::ui::{MostroInfoFetchResult, OperationResult};
+use crate::ui::{LnAddressVerifyResult, MostroInfoFetchResult, OperationResult};
 use crate::util::{
     any_relay_reachable, catch_unwind_request_fatal_restart, connect_client_safely,
     handle_message_notification, handle_operation_result, hydrate_startup_active_order_dm_state,
@@ -195,6 +195,8 @@ async fn main() -> Result<(), anyhow::Error> {
         mut network_status_rx,
         fatal_error_tx,
         mut fatal_error_rx,
+        ln_address_result_tx,
+        mut ln_address_result_rx,
     } = create_app_channels();
 
     // Set fatal error tx for the app channels
@@ -433,6 +435,17 @@ async fn main() -> Result<(), anyhow::Error> {
                     }
                 }
             }
+            ln_address_verify = ln_address_result_rx.recv() => {
+                if let Some(ln_res) = ln_address_verify {
+                    let op = match ln_res {
+                        LnAddressVerifyResult::Verified { message } => {
+                            OperationResult::Info(message)
+                        }
+                        LnAddressVerifyResult::Err(e) => OperationResult::Error(e),
+                    };
+                    handle_operation_result(op, &mut app);
+                }
+            }
             key_rotation_result = key_rotation_rx.recv() => {
                 if let Some(res) = key_rotation_result {
                     match res {
@@ -571,6 +584,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         mostro_pubkey,
                         &current_mostro_pubkey,
                         &order_result_tx,
+                        &ln_address_result_tx,
                         &key_rotation_tx,
                         &seed_words_tx,
                         &mostro_info_tx,

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -264,7 +264,7 @@ pub fn ui_draw(
             "⚡ Confirm Lightning Address",
             addr,
             *selected_button,
-            Some("Save this address to settings.toml for buyer receive flow?"),
+            Some("Verify LNURL endpoint and save this address to settings.toml?"),
         );
     }
     if let UiMode::ConfirmClearLnAddress(selected_button) = &app.mode {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -265,7 +265,7 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
         ),
         (
             "Set Lightning Address (buyer)",
-            "User mode only. Save a Lightning address (user@domain.com) to settings for receiving when you buy.",
+            "User mode only. Confirms save after fetching LNURL metadata (payRequest). On failure, settings are not updated.",
         ),
         (
             "Clear Lightning Address",

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -5,8 +5,8 @@ use crate::ui::helpers::hydrate_app_admin_keys_from_privkey;
 use crate::ui::key_handler::EnterKeyContext;
 use crate::ui::FormState;
 use crate::ui::{
-    AdminChatUpdate, AppState, ChatAttachment, MessageNotification, MostroInfoFetchResult,
-    NetworkStatus, OperationResult, OrderChatUpdate, TakeOrderState, UiMode,
+    AdminChatUpdate, AppState, ChatAttachment, LnAddressVerifyResult, MessageNotification,
+    MostroInfoFetchResult, NetworkStatus, OperationResult, OrderChatUpdate, TakeOrderState, UiMode,
 };
 use crate::util::fatal::request_fatal_restart;
 use crate::util::fetch_mostro_instance_info;
@@ -655,6 +655,8 @@ pub struct AppChannels {
     pub network_status_rx: UnboundedReceiver<NetworkStatus>,
     pub fatal_error_tx: UnboundedSender<String>,
     pub fatal_error_rx: UnboundedReceiver<String>,
+    pub ln_address_result_tx: UnboundedSender<LnAddressVerifyResult>,
+    pub ln_address_result_rx: UnboundedReceiver<LnAddressVerifyResult>,
 }
 
 pub fn create_app_channels() -> AppChannels {
@@ -679,6 +681,8 @@ pub fn create_app_channels() -> AppChannels {
     let (network_status_tx, network_status_rx) =
         tokio::sync::mpsc::unbounded_channel::<NetworkStatus>();
     let (fatal_error_tx, fatal_error_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let (ln_address_result_tx, ln_address_result_rx) =
+        tokio::sync::mpsc::unbounded_channel::<LnAddressVerifyResult>();
 
     AppChannels {
         order_result_tx,
@@ -703,6 +707,8 @@ pub fn create_app_channels() -> AppChannels {
         network_status_rx,
         fatal_error_tx,
         fatal_error_rx,
+        ln_address_result_tx,
+        ln_address_result_rx,
     }
 }
 
@@ -748,12 +754,12 @@ pub fn spawn_send_new_order_task(ctx: &EnterKeyContext<'_>, form: FormState) {
 /// Verify LNURL-pay metadata (`tag: payRequest`), then persist trimmed address to `settings.toml`.
 pub fn spawn_verify_and_save_ln_address_task(
     address: String,
-    result_tx: UnboundedSender<OperationResult>,
+    result_tx: UnboundedSender<LnAddressVerifyResult>,
 ) {
     tokio::spawn(async move {
         let trimmed = address.trim().to_string();
         if trimmed.is_empty() {
-            let _ = result_tx.send(OperationResult::Error(
+            let _ = result_tx.send(LnAddressVerifyResult::Err(
                 "Lightning address cannot be empty".to_string(),
             ));
             return;
@@ -766,12 +772,13 @@ pub fn spawn_verify_and_save_ln_address_task(
                     match crate::settings::save_settings(&s) {
                         Ok(()) => {
                             log::info!("Lightning address saved after LNURL verification");
-                            let _ = result_tx.send(OperationResult::Info(
-                                "Lightning address saved (LNURL endpoint verified).".to_string(),
-                            ));
+                            let _ = result_tx.send(LnAddressVerifyResult::Verified {
+                                message: "Lightning address saved (LNURL endpoint verified)."
+                                    .to_string(),
+                            });
                         }
                         Err(e) => {
-                            let _ = result_tx.send(OperationResult::Error(format!(
+                            let _ = result_tx.send(LnAddressVerifyResult::Err(format!(
                                 "Address verified but failed to save settings: {}",
                                 e
                             )));
@@ -779,14 +786,14 @@ pub fn spawn_verify_and_save_ln_address_task(
                     }
                 }
                 Err(e) => {
-                    let _ = result_tx.send(OperationResult::Error(format!(
+                    let _ = result_tx.send(LnAddressVerifyResult::Err(format!(
                         "Failed to load settings: {}",
                         e
                     )));
                 }
             },
             Err(e) => {
-                let _ = result_tx.send(OperationResult::Error(format!(
+                let _ = result_tx.send(LnAddressVerifyResult::Err(format!(
                     "Could not verify Lightning address: {}",
                     e
                 )));

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -745,6 +745,56 @@ pub fn spawn_send_new_order_task(ctx: &EnterKeyContext<'_>, form: FormState) {
     });
 }
 
+/// Verify LNURL-pay metadata (`tag: payRequest`), then persist trimmed address to `settings.toml`.
+pub fn spawn_verify_and_save_ln_address_task(
+    address: String,
+    result_tx: UnboundedSender<OperationResult>,
+) {
+    tokio::spawn(async move {
+        let trimmed = address.trim().to_string();
+        if trimmed.is_empty() {
+            let _ = result_tx.send(OperationResult::Error(
+                "Lightning address cannot be empty".to_string(),
+            ));
+            return;
+        }
+
+        match crate::util::ln_address::ln_address_pay_request_reachable(&trimmed).await {
+            Ok(()) => match load_settings_from_disk() {
+                Ok(mut s) => {
+                    s.ln_address = trimmed.clone();
+                    match crate::settings::save_settings(&s) {
+                        Ok(()) => {
+                            log::info!("Lightning address saved after LNURL verification");
+                            let _ = result_tx.send(OperationResult::Info(
+                                "Lightning address saved (LNURL endpoint verified).".to_string(),
+                            ));
+                        }
+                        Err(e) => {
+                            let _ = result_tx.send(OperationResult::Error(format!(
+                                "Address verified but failed to save settings: {}",
+                                e
+                            )));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = result_tx.send(OperationResult::Error(format!(
+                        "Failed to load settings: {}",
+                        e
+                    )));
+                }
+            },
+            Err(e) => {
+                let _ = result_tx.send(OperationResult::Error(format!(
+                    "Could not verify Lightning address: {}",
+                    e
+                )));
+            }
+        }
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_take_order_task(
     pool: SqlitePool,

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -174,7 +174,7 @@ pub fn handle_confirm_key(
             true
         }
         UiMode::ConfirmLnAddress(addr, _) => {
-            spawn_verify_and_save_ln_address_task(addr.clone(), ctx.order_result_tx.clone());
+            spawn_verify_and_save_ln_address_task(addr.clone(), ctx.ln_address_result_tx.clone());
             app.mode = UiMode::OperationResult(OperationResult::Info(
                 "Verifying Lightning address...".to_string(),
             ));

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -5,13 +5,14 @@ use crate::ui::{AdminMode, AppState, UiMode, UserMode, UserRole};
 use crate::ui::key_handler::admin_handlers::{
     execute_take_dispute_action, handle_enter_admin_mode,
 };
-use crate::ui::key_handler::async_tasks::{spawn_add_relay_task, spawn_refresh_mostro_info_task};
+use crate::ui::key_handler::async_tasks::{
+    spawn_add_relay_task, spawn_refresh_mostro_info_task, spawn_verify_and_save_ln_address_task,
+};
 use crate::ui::key_handler::user_handlers::execute_take_order_action;
 
 use crate::ui::key_handler::settings::{
     clear_currency_filters, clear_ln_address_from_settings, save_currency_to_settings,
-    save_ln_address_to_settings, save_mostro_pubkey_to_settings, save_relay_to_settings,
-    try_save_admin_key_to_settings,
+    save_mostro_pubkey_to_settings, save_relay_to_settings, try_save_admin_key_to_settings,
 };
 use nostr_sdk::prelude::PublicKey;
 use std::str::FromStr;
@@ -173,17 +174,10 @@ pub fn handle_confirm_key(
             true
         }
         UiMode::ConfirmLnAddress(addr, _) => {
-            let default_mode = match app.user_role {
-                UserRole::User => UiMode::UserMode(UserMode::Normal),
-                UserRole::Admin => UiMode::AdminMode(AdminMode::Normal),
-            };
-            app.mode = handle_confirmation_enter(
-                true,
-                &addr,
-                default_mode,
-                save_ln_address_to_settings,
-                |input| UiMode::AddLnAddress(create_key_input_state(input)),
-            );
+            spawn_verify_and_save_ln_address_task(addr.clone(), ctx.order_result_tx.clone());
+            app.mode = UiMode::OperationResult(OperationResult::Info(
+                "Verifying Lightning address...".to_string(),
+            ));
             true
         }
         UiMode::ConfirmCurrency(currency_string, _) => {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -772,7 +772,7 @@ fn handle_enter_settings_mode(
         UiMode::ConfirmLnAddress(addr, selected_button) => {
             if selected_button {
                 let addr_clone = addr.clone();
-                spawn_verify_and_save_ln_address_task(addr_clone, ctx.order_result_tx.clone());
+                spawn_verify_and_save_ln_address_task(addr_clone, ctx.ln_address_result_tx.clone());
                 app.mode = UiMode::OperationResult(OperationResult::Info(
                     "Verifying Lightning address...".to_string(),
                 ));

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -20,7 +20,7 @@ use crate::ui::{
 use crate::ui::key_handler::async_tasks::{
     spawn_key_rotation_task, spawn_load_seed_words_task,
     spawn_refresh_mostro_info_from_settings_task, spawn_refresh_mostro_info_task,
-    spawn_send_new_order_task,
+    spawn_send_new_order_task, spawn_verify_and_save_ln_address_task,
 };
 use crate::ui::key_handler::user_handlers::{
     handle_enter_creating_order, handle_enter_taking_order,
@@ -38,8 +38,8 @@ use crate::ui::key_handler::confirmation::{
 };
 use crate::ui::key_handler::settings::{
     clear_currency_filters, clear_ln_address_from_settings, handle_mode_switch,
-    save_currency_to_settings, save_ln_address_to_settings, save_mostro_pubkey_to_settings,
-    save_relay_to_settings, validate_ln_address_format,
+    save_currency_to_settings, save_mostro_pubkey_to_settings, save_relay_to_settings,
+    validate_ln_address_format,
 };
 
 fn invoice_popup_action_for_message_action(action: &Action) -> Option<Action> {
@@ -770,13 +770,15 @@ fn handle_enter_settings_mode(
             }
         },
         UiMode::ConfirmLnAddress(addr, selected_button) => {
-            app.mode = handle_confirmation_enter(
-                selected_button,
-                addr.as_str(),
-                default_mode,
-                save_ln_address_to_settings,
-                |input| UiMode::AddLnAddress(create_key_input_state(input)),
-            );
+            if selected_button {
+                let addr_clone = addr.clone();
+                spawn_verify_and_save_ln_address_task(addr_clone, ctx.order_result_tx.clone());
+                app.mode = UiMode::OperationResult(OperationResult::Info(
+                    "Verifying Lightning address...".to_string(),
+                ));
+            } else {
+                app.mode = UiMode::AddLnAddress(create_key_input_state(addr.as_str()));
+            }
         }
         UiMode::ConfirmClearLnAddress(selected_button) => {
             if selected_button {

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -19,8 +19,8 @@ use crate::ui::key_handler::chat_helpers::{
 use crate::ui::{
     helpers::{get_visible_attachment_messages, is_dispute_finalized},
     AdminMode, AdminTab, AppState, ChatAttachment, ChatSender, DisputeFilter,
-    InvoiceNotificationActionSelection, MostroInfoFetchResult, OperationResult, Tab,
-    TakeOrderState, UiMode, UserMode, UserTab, ViewingMessageButtonSelection,
+    InvoiceNotificationActionSelection, LnAddressVerifyResult, MostroInfoFetchResult,
+    OperationResult, Tab, TakeOrderState, UiMode, UserMode, UserTab, ViewingMessageButtonSelection,
 };
 use crate::util::MostroInstanceInfo;
 use crate::util::OrderDmSubscriptionCmd;
@@ -42,6 +42,7 @@ pub struct EnterKeyContext<'a> {
     pub mostro_pubkey: PublicKey,
     pub current_mostro_pubkey: &'a Arc<Mutex<PublicKey>>,
     pub order_result_tx: &'a UnboundedSender<OperationResult>,
+    pub ln_address_result_tx: &'a UnboundedSender<LnAddressVerifyResult>,
     pub key_rotation_tx: &'a UnboundedSender<Result<Zeroizing<String>, String>>,
     pub seed_words_tx: &'a UnboundedSender<Result<Zeroizing<String>, String>>,
     pub mostro_info_tx: &'a UnboundedSender<MostroInfoFetchResult>,
@@ -365,6 +366,7 @@ pub fn handle_key_event(
     mostro_pubkey: PublicKey,
     current_mostro_pubkey: &Arc<Mutex<PublicKey>>,
     order_result_tx: &UnboundedSender<OperationResult>,
+    ln_address_result_tx: &UnboundedSender<LnAddressVerifyResult>,
     key_rotation_tx: &UnboundedSender<Result<Zeroizing<String>, String>>,
     seed_words_tx: &UnboundedSender<Result<Zeroizing<String>, String>>,
     mostro_info_tx: &UnboundedSender<MostroInfoFetchResult>,
@@ -1064,6 +1066,7 @@ pub fn handle_key_event(
                 mostro_pubkey,
                 current_mostro_pubkey,
                 order_result_tx,
+                ln_address_result_tx,
                 key_rotation_tx,
                 seed_words_tx,
                 mostro_info_tx,

--- a/src/ui/key_handler/settings.rs
+++ b/src/ui/key_handler/settings.rs
@@ -44,7 +44,8 @@ pub fn save_mostro_pubkey_to_settings(key_string: &str) {
     );
 }
 
-/// Validate Lightning address shape (`user@domain.com`) for settings UI (reachability is PR3).
+/// Validate Lightning address shape (`user@domain.com`) before opening the confirm dialog.
+/// Saving runs an async LNURL metadata check (`tag: payRequest`) before writing disk.
 pub fn validate_ln_address_format(addr: &str) -> Result<(), String> {
     let t = addr.trim();
     if t.is_empty() {
@@ -53,16 +54,6 @@ pub fn validate_ln_address_format(addr: &str) -> Result<(), String> {
     LightningAddress::from_str(t)
         .map(|_| ())
         .map_err(|_| "Invalid Lightning address (expected user@domain.com)".to_string())
-}
-
-/// Persist trimmed Lightning address for buyer receive flow.
-pub fn save_ln_address_to_settings(addr: &str) {
-    let trimmed = addr.trim().to_string();
-    save_settings_with(
-        |s| s.ln_address = trimmed.clone(),
-        "Failed to save Lightning address",
-        "Lightning address saved to settings file",
-    );
 }
 
 pub fn clear_ln_address_from_settings() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -40,9 +40,9 @@ pub use state::{
     apply_kind_color, order_message_to_notification, AdminChatLastSeen, AdminChatUpdate, AdminTab,
     AppState, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender, DisputeChatMessage,
     DisputeFilter, FormState, InvoiceInputState, InvoiceNotificationActionSelection, KeyInputState,
-    MessageNotification, MessageViewState, MostroInfoFetchResult, OperationResult,
-    OrderChatLastSeen, OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab,
-    TakeOrderState, ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
-    ViewingMessageButtonSelection,
+    LnAddressVerifyResult, MessageNotification, MessageViewState, MostroInfoFetchResult,
+    OperationResult, OrderChatLastSeen, OrderChatStaticHeader, OrderChatUpdate, OrderMessage,
+    RatingOrderState, Tab, TakeOrderState, ThreeState, UiMode, UserChatSender,
+    UserOrderChatMessage, UserRole, UserTab, ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -70,6 +70,13 @@ pub enum OperationResult {
     },
 }
 
+/// Result of async Lightning address LNURL verification and save (settings flow; not order/dispute).
+#[derive(Clone, Debug)]
+pub enum LnAddressVerifyResult {
+    Verified { message: String },
+    Err(String),
+}
+
 /// Result of an async Mostro instance info fetch (sent from key handlers to main loop).
 #[derive(Clone, Debug)]
 pub enum MostroInfoFetchResult {

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -9,7 +9,7 @@ pub use crate::ui::chat::{
 pub use crate::ui::navigation::{AdminTab, Tab, UserRole, UserTab};
 pub use crate::ui::orders::{
     apply_kind_color, order_message_to_notification, FormState, InvoiceInputState,
-    InvoiceNotificationActionSelection, KeyInputState, MessageNotification, MessageViewState,
-    MostroInfoFetchResult, OperationResult, OrderChatStaticHeader, OrderMessage, OrderSuccess,
-    RatingOrderState, TakeOrderState, ThreeState, ViewingMessageButtonSelection,
+    InvoiceNotificationActionSelection, KeyInputState, LnAddressVerifyResult, MessageNotification,
+    MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatStaticHeader, OrderMessage,
+    OrderSuccess, RatingOrderState, TakeOrderState, ThreeState, ViewingMessageButtonSelection,
 };

--- a/src/util/ln_address.rs
+++ b/src/util/ln_address.rs
@@ -1,0 +1,66 @@
+//! LNURL-pay metadata checks for Lightning addresses (and raw `lnurl1…` URLs).
+
+use anyhow::Context;
+use lnurl::lightning_address::LightningAddress;
+use lnurl::lnurl::LnUrl;
+use serde_json::Value;
+use std::str::FromStr;
+
+const LNURL_HTTP_TIMEOUT_SECS: u64 = 12;
+
+/// Resolve the HTTP URL that returns LNURL-pay metadata JSON (`tag: payRequest`).
+fn resolve_lnurlp_metadata_url(address: &str) -> Result<String, anyhow::Error> {
+    let trimmed = address.trim();
+    if trimmed.to_lowercase().starts_with("lnurl") {
+        let lnurl =
+            LnUrl::decode(trimmed.to_string()).map_err(|_| anyhow::anyhow!("Invalid LNURL"))?;
+        Ok(lnurl.url)
+    } else {
+        let la = LightningAddress::from_str(trimmed)
+            .map_err(|_| anyhow::anyhow!("Invalid Lightning address format"))?;
+        Ok(la.lnurlp_url())
+    }
+}
+
+/// GET the LNURL-pay metadata URL and ensure JSON declares `tag: "payRequest"` (same idea as Mostro `ln_exists`).
+pub async fn ln_address_pay_request_reachable(address: &str) -> Result<(), anyhow::Error> {
+    let url = resolve_lnurlp_metadata_url(address)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(LNURL_HTTP_TIMEOUT_SECS))
+        .user_agent(concat!("mostrix/", env!("CARGO_PKG_VERSION")))
+        .redirect(reqwest::redirect::Policy::limited(8))
+        .build()
+        .context("build HTTP client")?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {}", url))?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("LNURL metadata HTTP {}", response.status());
+    }
+
+    let body = response.text().await.context("read LNURL metadata body")?;
+
+    let value: Value = serde_json::from_str(&body).context("LNURL metadata is not valid JSON")?;
+
+    match value.get("tag").and_then(|t| t.as_str()) {
+        Some("payRequest") => Ok(()),
+        Some(other) => anyhow::bail!("unexpected LNURL tag {:?} (expected payRequest)", other),
+        None => anyhow::bail!("LNURL metadata missing tag"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_well_known_lnurlp_from_lightning_address() {
+        let url = resolve_lnurlp_metadata_url("user@example.com").unwrap();
+        assert_eq!(url, "https://example.com/.well-known/lnurlp/user");
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,7 @@ pub mod db_utils;
 pub mod dm_utils;
 pub mod fatal;
 pub mod filters;
+pub mod ln_address;
 pub mod mostro_info;
 pub mod network;
 pub mod order_utils;

--- a/src/util/order_utils/execute_add_invoice.rs
+++ b/src/util/order_utils/execute_add_invoice.rs
@@ -42,9 +42,16 @@ pub async fn execute_add_invoice(
     let order_trade_keys = Keys::parse(&trade_keys)?;
 
     // Check invoice string
-    let ln_addr = LightningAddress::from_str(invoice);
+    let ln_addr = LightningAddress::from_str(invoice.trim());
     let payload = if ln_addr.is_ok() {
-        Some(Payload::PaymentRequest(None, invoice.to_string(), None))
+        crate::util::ln_address::ln_address_pay_request_reachable(invoice.trim())
+            .await
+            .map_err(|e| anyhow::anyhow!("Lightning address not verified: {}", e))?;
+        Some(Payload::PaymentRequest(
+            None,
+            invoice.trim().to_string(),
+            None,
+        ))
     } else {
         match is_valid_invoice(invoice) {
             Ok(i) => Some(Payload::PaymentRequest(None, i.to_string(), None)),


### PR DESCRIPTION
- Add util/ln_address.rs: resolve lnurlp URL, GET metadata, require tag payRequest
- spawn_verify_and_save_ln_address_task: async verify then persist settings
- Settings confirm and y-shortcut: show verifying toast, save only after success
- execute_add_invoice: same check for Lightning address input before DM
- Remove unused sync save_ln_address_to_settings
- Docs: STARTUP_AND_CONFIG, TUI, SETTINGS_ANALYSIS, MESSAGE_FLOW, buy/sell flows, docs README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lightning address support: save an optional address in settings and reuse it across orders.
  * Added LNURL verification: all Lightning addresses are automatically validated before saving or use.
  * Expanded invoice input: buyers can submit either BOLT11 invoices or Lightning addresses.

* **Documentation**
  * Updated guides with Lightning address setup and LNURL verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->