### PR TITLE
Step 1 for new mostro-core gift wrap: aligned nostr-sdk and mostro-core to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.8.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08956454941d9577a2cde63ae6ee5d8bac4ffeee8398d02aa844ad4b3638723a"
+checksum = "9a0129503ada548a422fae83599dafbe1d58d425b492a3b5e0fa5a8d9ba70d17"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -2144,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.43.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
+checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
  "base64",
  "bech32",
@@ -2156,6 +2156,7 @@ dependencies = [
  "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.17",
+ "hex",
  "instant",
  "scrypt",
  "secp256k1",
@@ -2167,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-database"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
+checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
  "lru",
  "nostr",
@@ -2177,14 +2178,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "nostr-relay-pool"
-version = "0.43.1"
+name = "nostr-gossip"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
+checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
+dependencies = [
+ "nostr",
+]
+
+[[package]]
+name = "nostr-relay-pool"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1073ccfbaea5549fb914a9d52c68dab2aecda61535e5143dd73e95445a804b"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
+ "hex",
  "lru",
  "negentropy",
  "nostr",
@@ -2195,15 +2206,17 @@ dependencies = [
 
 [[package]]
 name = "nostr-sdk"
-version = "0.43.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
+checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
 dependencies = [
  "async-utility",
  "nostr",
  "nostr-database",
+ "nostr-gossip",
  "nostr-relay-pool",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = "0.8.0"
-nostr-sdk = { version = "0.43.0", features = ["nip06", "nip44", "nip59"] }
+mostro-core = "0.10.1"
+nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.5", features = ["sqlite", "runtime-tokio-rustls"] }
 tokio = { version = "1.50.0", features = ["full"] }

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -171,7 +171,7 @@ pub async fn unwrap_giftwrap_with_shared_key(
 
     Ok((
         inner_event.content,
-        inner_event.created_at.as_u64() as i64,
+        inner_event.created_at.as_secs() as i64,
         inner_event.pubkey,
     ))
 }
@@ -182,7 +182,7 @@ pub async fn fetch_gift_wraps_for_shared_key(
     client: &Client,
     shared_keys: &Keys,
 ) -> Result<Vec<(String, i64, PublicKey)>> {
-    let now = Timestamp::now().as_u64();
+    let now = Timestamp::now().as_secs();
     let seven_days_secs: u64 = 7 * 24 * 60 * 60;
     let wide_since = now.saturating_sub(seven_days_secs);
 

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -157,7 +157,7 @@ pub(crate) async fn ensure_order_giftwrap_subscription(
     let filter = match options.mode {
         GiftWrapSubscriptionMode::StartupCatchUp => filter_giftwrap_to_recipient(pubkey).limit(1),
         GiftWrapSubscriptionMode::StartupSince(ts) => {
-            let ts = u64::try_from(ts).unwrap_or(Timestamp::now().as_u64());
+            let ts = u64::try_from(ts).unwrap_or(Timestamp::now().as_secs());
             let since_ts = ts.saturating_sub(super::STARTUP_GIFTWRAP_ENVELOPE_SKEW_SECS);
             filter_giftwrap_to_recipient(pubkey).since(Timestamp::from(since_ts))
         }

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -349,11 +349,11 @@ pub async fn parse_dm_events(
                 .unwrap()
                 .timestamp();
 
-            if (created_at.as_u64() as i64) < since_time {
+            if (created_at.as_secs() as i64) < since_time {
                 continue;
             }
         }
-        direct_messages.push((message, created_at.as_u64() as i64, sender));
+        direct_messages.push((message, created_at.as_secs() as i64, sender));
     }
     direct_messages.sort_by(|a, b| a.1.cmp(&b.1));
     direct_messages
@@ -925,7 +925,7 @@ async fn fetch_and_replay_startup_trade_dms(
     } = replay;
 
     let lookback_start = Timestamp::now()
-        .as_u64()
+        .as_secs()
         .saturating_sub(STARTUP_TRADE_DM_LOOKBACK_SECS);
 
     for (order_id, trade_index) in startup_active_orders {

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -12,7 +12,7 @@ const INSTANCE_INFO_STALE_SECS: u64 = 604_800;
 
 /// Human-readable age string for a timestamp (e.g. "2 hours ago", "5 days ago").
 pub fn format_instance_info_age(ts: &Timestamp) -> String {
-    let age_secs = Timestamp::now().as_u64().saturating_sub(ts.as_u64());
+    let age_secs = Timestamp::now().as_secs().saturating_sub(ts.as_secs());
     if age_secs < 60 {
         "just now".to_string()
     } else if age_secs < 3600 {
@@ -61,7 +61,7 @@ impl MostroInstanceInfo {
     pub fn is_stale(&self) -> bool {
         self.last_updated
             .map(|t| {
-                let age_seconds = Timestamp::now().as_u64().saturating_sub(t.as_u64());
+                let age_seconds = Timestamp::now().as_secs().saturating_sub(t.as_secs());
                 age_seconds > INSTANCE_INFO_STALE_SECS
             })
             .unwrap_or(true)

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -273,7 +273,7 @@ pub fn parse_disputes_events(events: Events) -> Vec<Dispute> {
         };
 
         // Get created_at field from Nostr event
-        dispute.created_at = event.created_at.as_u64() as i64;
+        dispute.created_at = event.created_at.as_secs() as i64;
 
         latest_by_id
             .entry(dispute.id)
@@ -323,7 +323,7 @@ pub fn parse_orders_events(
             continue;
         }
         // Set created at
-        order.created_at = Some(event.created_at.as_u64() as i64);
+        order.created_at = Some(event.created_at.as_secs() as i64);
         // Update latest order by id
         latest_by_id
             .entry(order_id)


### PR DESCRIPTION
### Summary:
-Bump mostro-core to 0.10.1 and align nostr-sdk to 0.44.1
-Mechanical Timestamp::as_u64 → Timestamp::as_secs fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated `mostro-core` from version 0.8.0 to 0.10.1 for enhanced core functionality and improved stability.
* Updated `nostr-sdk` from version 0.43.0 to 0.44.1 to ensure compatibility with latest protocol standards and implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->