### PR TITLE
Step  for new mostro-core gift wrap: send GiftWrap via mostro-core nip59

### DIFF
--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -1,8 +1,7 @@
 // Helper functions for direct message operations
-use anyhow::{Error, Result};
+use anyhow::Result;
 use base64::engine::general_purpose;
 use base64::Engine;
-use mostro_core::prelude::*;
 use nip44::v2::encrypt_to_bytes;
 use nip44::v2::ConversationKey;
 use nostr_sdk::prelude::*;
@@ -11,44 +10,6 @@ use uuid::Uuid;
 
 use crate::ui::{AdminChatLastSeen, AppState, ChatParty};
 use crate::util::filters::filter_giftwrap_to_recipient;
-use crate::util::types::create_expiration_tags;
-
-/// Builds the published NIP-59 **Gift Wrap** (kind 1059) from a signed **Seal** event.
-///
-/// Rust-nostr’s `EventBuilder::gift_wrap` seals and wraps but does not apply NIP-13 PoW to the
-/// outer Gift Wrap; Mostro may require that difficulty on the relay-visible event. This helper
-/// mirrors the SDK’s seal→wrap steps: reject non-seal inputs, encrypt the seal JSON to `receiver`
-/// with NIP-44 using an **ephemeral** key pair, attach `p` and optional tags, set
-/// [`nip59::RANGE_RANDOM_TIMESTAMP_TWEAK`]-style `created_at`, mine with [`EventBuilder::pow`],
-/// then sign the wrap with the ephemeral keys.
-fn gift_wrap_from_seal_with_pow(
-    receiver: &PublicKey,
-    seal: &Event,
-    extra_tags: impl IntoIterator<Item = Tag>,
-    pow: u8,
-) -> Result<Event> {
-    if seal.kind != nostr_sdk::Kind::Seal {
-        return Err(anyhow::anyhow!("Invalid kind"));
-    }
-
-    let ephem = Keys::generate();
-    let content = nip44::encrypt(
-        ephem.secret_key(),
-        receiver,
-        seal.as_json(),
-        nip44::Version::default(),
-    )?;
-
-    let mut tags: Vec<Tag> = extra_tags.into_iter().collect();
-    tags.push(Tag::public_key(*receiver));
-
-    EventBuilder::new(nostr_sdk::Kind::GiftWrap, content)
-        .tags(tags)
-        .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
-        .pow(pow)
-        .sign_with_keys(&ephem)
-        .map_err(|e| anyhow::anyhow!("Failed to sign gift wrap: {e}"))
-}
 
 /// Subscription behavior for GiftWrap filters.
 pub(crate) enum GiftWrapSubscriptionMode {
@@ -85,51 +46,6 @@ pub(crate) async fn create_private_dm_event(
             .tag(Tag::public_key(*receiver_pubkey))
             .sign_with_keys(trade_keys)?,
     )
-}
-
-/// Create a gift wrap event (private or signed)
-pub(crate) async fn create_gift_wrap_event(
-    trade_keys: &Keys,
-    identity_keys: Option<&Keys>,
-    receiver_pubkey: &PublicKey,
-    payload: String,
-    pow: u8,
-    expiration: Option<Timestamp>,
-    signed: bool,
-) -> Result<nostr_sdk::Event> {
-    let message = Message::from_json(&payload)
-        .map_err(|e| anyhow::anyhow!("Failed to deserialize message: {e}"))?;
-
-    let content = if signed {
-        let _identity_keys = identity_keys
-            .ok_or_else(|| Error::msg("identity_keys required for signed messages"))?;
-        let sig = Message::sign(payload, trade_keys);
-        serde_json::to_string(&(message, sig))
-            .map_err(|e| anyhow::anyhow!("Failed to serialize message: {e}"))?
-    } else {
-        let content: (Message, Option<Signature>) = (message, None);
-        serde_json::to_string(&content)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize message: {e}"))?
-    };
-
-    let rumor = EventBuilder::text_note(content)
-        .pow(pow)
-        .build(trade_keys.public_key());
-
-    let tags = create_expiration_tags(expiration);
-
-    let signer_keys = if signed {
-        identity_keys.ok_or_else(|| Error::msg("identity_keys required for signed messages"))?
-    } else {
-        trade_keys
-    };
-
-    let seal: Event = EventBuilder::seal(signer_keys, receiver_pubkey, rumor)
-        .await?
-        .sign(signer_keys)
-        .await?;
-
-    gift_wrap_from_seal_with_pow(receiver_pubkey, &seal, tags, pow)
 }
 
 /// Subscribe GiftWrap for a trade pubkey and remember the returned subscription id.

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -189,7 +189,7 @@ pub async fn send_dm(
         MessageType::PrivateDirectMessage => {
             dm_helpers::create_private_dm_event(trade_keys, receiver_pubkey, payload, pow).await?
         }
-        MessageType::PrivateGiftWrap => {
+        MessageType::SignedGiftWrap | MessageType::PrivateGiftWrap => {
             let message = Message::from_json(&payload)
                 .map_err(|e| anyhow::anyhow!("Failed to deserialize message: {e}"))?;
             let identity_keys = identity_keys.unwrap_or(trade_keys);
@@ -201,24 +201,7 @@ pub async fn send_dm(
                 WrapOptions {
                     pow,
                     expiration,
-                    signed: false,
-                },
-            )
-            .await?
-        }
-        MessageType::SignedGiftWrap => {
-            let message = Message::from_json(&payload)
-                .map_err(|e| anyhow::anyhow!("Failed to deserialize message: {e}"))?;
-            let identity_keys = identity_keys.unwrap_or(trade_keys);
-            wrap_message(
-                &message,
-                identity_keys,
-                trade_keys,
-                *receiver_pubkey,
-                WrapOptions {
-                    pow,
-                    expiration,
-                    signed: true,
+                    signed: matches!(message_type, MessageType::SignedGiftWrap),
                 },
             )
             .await?
@@ -370,10 +353,32 @@ pub async fn parse_dm_events(
 }
 
 /// Parse one GiftWrap [`Event`] with the trade key (`since: None`). Shared by relay notifications and startup replay.
+///
+/// When `pre_unwrapped` is set (e.g. after a successful `nip59::extract_rumor`), skips a second decrypt.
 async fn parse_dm_events_single(
     event: &Event,
     trade_keys: &Keys,
+    pre_unwrapped: Option<nip59::UnwrappedGift>,
 ) -> Vec<(Message, i64, PublicKey)> {
+    if let Some(unwrapped_gift) = pre_unwrapped {
+        let (message, _): (Message, Option<String>) =
+            match serde_json::from_str(&unwrapped_gift.rumor.content) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    log::warn!(
+                        "Could not parse message content (event {}): {}",
+                        event.id,
+                        e
+                    );
+                    return Vec::new();
+                }
+            };
+        return vec![(
+            message,
+            unwrapped_gift.rumor.created_at.as_secs() as i64,
+            unwrapped_gift.sender,
+        )];
+    }
     let mut batch = Events::default();
     batch.insert(event.clone());
     parse_dm_events(batch, trade_keys, None).await
@@ -997,10 +1002,10 @@ async fn fetch_and_replay_startup_trade_dms(
 
         let mut best: Option<(i64, EventId, (Message, i64, PublicKey))> = None;
         for event in &event_list {
-            if nip59::extract_rumor(&trade_keys, event).await.is_err() {
+            let Ok(unwrapped) = nip59::extract_rumor(&trade_keys, event).await else {
                 continue;
-            }
-            let parsed_messages = parse_dm_events_single(event, &trade_keys).await;
+            };
+            let parsed_messages = parse_dm_events_single(event, &trade_keys, Some(unwrapped)).await;
             if parsed_messages.is_empty() {
                 continue;
             }
@@ -1113,7 +1118,7 @@ async fn resolve_order_for_event(
     event: &Event,
     user: &User,
     active_order_trade_indices: &Arc<Mutex<HashMap<Uuid, i64>>>,
-) -> Option<(Uuid, i64, Keys)> {
+) -> Option<(Uuid, i64, Keys, nip59::UnwrappedGift)> {
     GIFTWRAP_FALLBACK_DECRYPT_TOTAL.fetch_add(1, Ordering::Relaxed);
     let started = Instant::now();
 
@@ -1137,11 +1142,11 @@ async fn resolve_order_for_event(
             Ok(k) => k,
             Err(_) => continue,
         };
-        if nip59::extract_rumor(&trade_keys, event).await.is_ok() {
+        if let Ok(unwrapped) = nip59::extract_rumor(&trade_keys, event).await {
             let duration_ms = started.elapsed().as_millis() as u64;
             GIFTWRAP_FALLBACK_LAST_DURATION_MS.store(duration_ms, Ordering::Relaxed);
             log_giftwrap_fallback_decrypt_stats(active_count, decrypt_attempts, duration_ms, true);
-            return Some((order_id, trade_index, trade_keys));
+            return Some((order_id, trade_index, trade_keys, unwrapped));
         }
     }
 
@@ -1159,8 +1164,10 @@ async fn resolve_order_for_event(
 /// - route each incoming GiftWrap through two complementary paths:
 ///   1) waiter path: satisfy in-flight `wait_for_dm` calls
 ///   2) tracked-order path: parse and dispatch updates to the order/UI pipeline
-/// - reuse per-event decryptability checks across both paths to avoid duplicate
-///   `nip59::extract_rumor` work for the same `(event_id, trade_pubkey)`
+/// - reuse decryptability checks across both paths for the same incoming GiftWrap
+///   and trade pubkey (`HashMap<PublicKey, bool>` scoped to one notification; the
+///   unknown-subscription fallback reuses the `UnwrappedGift` from `resolve_order_for_event`
+///   so it does not decrypt twice there)
 ///
 /// Lifecycle notes:
 /// - bootstrap subscriptions for already-active orders at startup
@@ -1420,13 +1427,10 @@ pub async fn listen_for_order_messages(
                     // One GiftWrap event can be consumed by:
                     // 1) request/response waiters (`wait_for_dm`) and
                     // 2) tracked order subscriptions (UI/order state pipeline).
-                    // Keep a shared per-event cache so we only test decryptability once per
-                    // (event_id, trade_pubkey), then reuse the result in both paths.
-                    // This avoids duplicate `extract_rumor` calls while preserving behavior.
-                    let event_id = event.id;
-                    // Cache decryptability for this event across both waiter and tracked paths.
-                    // Keep it event-scoped to avoid unbounded growth over runtime.
-                    let mut rumor_cache: HashMap<(EventId, PublicKey), bool> = HashMap::new();
+                    // Shared cache for this single incoming GiftWrap: decryptability is keyed only
+                    // by trade pubkey; `event.id` is fixed for the whole handler block.
+                    // This avoids duplicate `extract_rumor` calls between waiter and tracked paths.
+                    let mut rumor_cache: HashMap<PublicKey, bool> = HashMap::new();
 
                     if !pending_waiters.is_empty() {
                         let mut still_pending: Vec<PendingDmWaiter> =
@@ -1439,8 +1443,7 @@ pub async fn listen_for_order_messages(
                             if waiter.response_tx.is_closed() {
                                 continue;
                             }
-                            // Cache key: this event + this waiter's trade pubkey.
-                            let key = (event_id, waiter.trade_keys.public_key());
+                            let key = waiter.trade_keys.public_key();
                             let can_decrypt = if let Some(boolean) = rumor_cache.get(&key) {
                                 *boolean
                             } else {
@@ -1483,7 +1486,7 @@ pub async fn listen_for_order_messages(
                         };
                         // Reuse per-event decryptability result if waiter path already checked
                         // this same trade pubkey.
-                        let key = (event_id, trade_keys.public_key());
+                        let key = trade_keys.public_key();
                         let can_decrypt = if let Some(boolean) = rumor_cache.get(&key) {
                             *boolean
                         } else {
@@ -1496,7 +1499,8 @@ pub async fn listen_for_order_messages(
                             continue;
                         }
 
-                        let parsed_messages = parse_dm_events_single(&event, &trade_keys).await;
+                        let parsed_messages =
+                            parse_dm_events_single(&event, &trade_keys, None).await;
                         if parsed_messages.is_empty() {
                             continue;
                         }
@@ -1526,10 +1530,15 @@ pub async fn listen_for_order_messages(
                             &dropped_user_history_order_ids,
                         )
                         .await;
-                    } else if let Some((order_id, trade_index, trade_keys)) =
+                    } else if let Some((order_id, trade_index, trade_keys, unwrapped)) =
                         resolve_order_for_event(&event, &user, &active_order_trade_indices).await
                     {
-                        let parsed_messages = parse_dm_events_single(&event, &trade_keys).await;
+                        let parsed_messages = parse_dm_events_single(
+                            &event,
+                            &trade_keys,
+                            Some(unwrapped),
+                        )
+                        .await;
                         if parsed_messages.is_empty() {
                             continue;
                         }

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -190,26 +190,36 @@ pub async fn send_dm(
             dm_helpers::create_private_dm_event(trade_keys, receiver_pubkey, payload, pow).await?
         }
         MessageType::PrivateGiftWrap => {
-            dm_helpers::create_gift_wrap_event(
-                trade_keys,
+            let message = Message::from_json(&payload)
+                .map_err(|e| anyhow::anyhow!("Failed to deserialize message: {e}"))?;
+            let identity_keys = identity_keys.unwrap_or(trade_keys);
+            wrap_message(
+                &message,
                 identity_keys,
-                receiver_pubkey,
-                payload,
-                pow,
-                expiration,
-                false,
+                trade_keys,
+                *receiver_pubkey,
+                WrapOptions {
+                    pow,
+                    expiration,
+                    signed: false,
+                },
             )
             .await?
         }
         MessageType::SignedGiftWrap => {
-            dm_helpers::create_gift_wrap_event(
-                trade_keys,
+            let message = Message::from_json(&payload)
+                .map_err(|e| anyhow::anyhow!("Failed to deserialize message: {e}"))?;
+            let identity_keys = identity_keys.unwrap_or(trade_keys);
+            wrap_message(
+                &message,
                 identity_keys,
-                receiver_pubkey,
-                payload,
-                pow,
-                expiration,
-                true,
+                trade_keys,
+                *receiver_pubkey,
+                WrapOptions {
+                    pow,
+                    expiration,
+                    signed: true,
+                },
             )
             .await?
         }

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -77,14 +77,6 @@ pub fn get_cant_do_description(reason: &CantDoReason) -> String {
     }
 }
 
-pub(super) fn create_expiration_tags(expiration: Option<Timestamp>) -> Tags {
-    let mut tags: Vec<Tag> = Vec::with_capacity(1 + usize::from(expiration.is_some()));
-    if let Some(timestamp) = expiration {
-        tags.push(Tag::expiration(timestamp));
-    }
-    Tags::from_list(tags)
-}
-
 pub(super) fn determine_message_type(to_user: bool, private: bool) -> MessageType {
     match (to_user, private) {
         (true, _) => MessageType::PrivateDirectMessage,


### PR DESCRIPTION
### Summary
Use mostro-core `wrap_message` in `send_dm` and remove the now-unused local NIP-59 GiftWrap builders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal direct message handling logic for improved efficiency.
  * Optimized gift-wrapped message processing with caching to reduce redundant operations.
  * Consolidated helper functions and simplified internal utilities for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->