### PR TITLE
Step 3 - refactor(dm): parse inbound GiftWrap with mostro_core unwrap_message

### DIFF
--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -276,29 +276,14 @@ pub async fn parse_dm_events(
         }
 
         let (created_at, message, sender) = match dm.kind {
-            nostr_sdk::Kind::GiftWrap => {
-                let unwrapped_gift = match nip59::extract_rumor(pubkey, dm).await {
-                    Ok(u) => u,
-                    Err(e) => {
-                        log::warn!("Could not decrypt gift wrap (event {}): {}", dm.id, e);
-                        continue;
-                    }
-                };
-                let (message, _): (Message, Option<String>) =
-                    match serde_json::from_str(&unwrapped_gift.rumor.content) {
-                        Ok(msg) => msg,
-                        Err(e) => {
-                            log::warn!("Could not parse message content (event {}): {}", dm.id, e);
-                            continue;
-                        }
-                    };
-
-                (
-                    unwrapped_gift.rumor.created_at,
-                    message,
-                    unwrapped_gift.sender,
-                )
-            }
+            nostr_sdk::Kind::GiftWrap => match unwrap_message(dm, pubkey).await {
+                Ok(None) => continue,
+                Err(e) => {
+                    log::warn!("Could not unwrap gift wrap (event {}): {}", dm.id, e);
+                    continue;
+                }
+                Ok(Some(u)) => (u.created_at, u.message, u.sender),
+            },
             nostr_sdk::Kind::PrivateDirectMessage => {
                 let ck = if let Ok(ck) = ConversationKey::derive(pubkey.secret_key(), &dm.pubkey) {
                     ck
@@ -354,30 +339,14 @@ pub async fn parse_dm_events(
 
 /// Parse one GiftWrap [`Event`] with the trade key (`since: None`). Shared by relay notifications and startup replay.
 ///
-/// When `pre_unwrapped` is set (e.g. after a successful `nip59::extract_rumor`), skips a second decrypt.
+/// When `pre_unwrapped` is set (e.g. after a successful `unwrap_message`), skips a second unwrap.
 async fn parse_dm_events_single(
     event: &Event,
     trade_keys: &Keys,
-    pre_unwrapped: Option<nip59::UnwrappedGift>,
+    pre_unwrapped: Option<UnwrappedMessage>,
 ) -> Vec<(Message, i64, PublicKey)> {
-    if let Some(unwrapped_gift) = pre_unwrapped {
-        let (message, _): (Message, Option<String>) =
-            match serde_json::from_str(&unwrapped_gift.rumor.content) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    log::warn!(
-                        "Could not parse message content (event {}): {}",
-                        event.id,
-                        e
-                    );
-                    return Vec::new();
-                }
-            };
-        return vec![(
-            message,
-            unwrapped_gift.rumor.created_at.as_secs() as i64,
-            unwrapped_gift.sender,
-        )];
+    if let Some(u) = pre_unwrapped {
+        return vec![(u.message, u.created_at.as_secs() as i64, u.sender)];
     }
     let mut batch = Events::default();
     batch.insert(event.clone());
@@ -1002,8 +971,17 @@ async fn fetch_and_replay_startup_trade_dms(
 
         let mut best: Option<(i64, EventId, (Message, i64, PublicKey))> = None;
         for event in &event_list {
-            let Ok(unwrapped) = nip59::extract_rumor(&trade_keys, event).await else {
-                continue;
+            let unwrapped = match unwrap_message(event, &trade_keys).await {
+                Ok(Some(u)) => u,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::warn!(
+                        "Startup DM replay: unwrap_message failed (event {}): {}",
+                        event.id,
+                        e
+                    );
+                    continue;
+                }
             };
             let parsed_messages = parse_dm_events_single(event, &trade_keys, Some(unwrapped)).await;
             if parsed_messages.is_empty() {
@@ -1118,7 +1096,7 @@ async fn resolve_order_for_event(
     event: &Event,
     user: &User,
     active_order_trade_indices: &Arc<Mutex<HashMap<Uuid, i64>>>,
-) -> Option<(Uuid, i64, Keys, nip59::UnwrappedGift)> {
+) -> Option<(Uuid, i64, Keys, UnwrappedMessage)> {
     GIFTWRAP_FALLBACK_DECRYPT_TOTAL.fetch_add(1, Ordering::Relaxed);
     let started = Instant::now();
 
@@ -1142,11 +1120,19 @@ async fn resolve_order_for_event(
             Ok(k) => k,
             Err(_) => continue,
         };
-        if let Ok(unwrapped) = nip59::extract_rumor(&trade_keys, event).await {
-            let duration_ms = started.elapsed().as_millis() as u64;
-            GIFTWRAP_FALLBACK_LAST_DURATION_MS.store(duration_ms, Ordering::Relaxed);
-            log_giftwrap_fallback_decrypt_stats(active_count, decrypt_attempts, duration_ms, true);
-            return Some((order_id, trade_index, trade_keys, unwrapped));
+        match unwrap_message(event, &trade_keys).await {
+            Ok(Some(unwrapped)) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                GIFTWRAP_FALLBACK_LAST_DURATION_MS.store(duration_ms, Ordering::Relaxed);
+                log_giftwrap_fallback_decrypt_stats(
+                    active_count,
+                    decrypt_attempts,
+                    duration_ms,
+                    true,
+                );
+                return Some((order_id, trade_index, trade_keys, unwrapped));
+            }
+            Ok(None) | Err(_) => continue,
         }
     }
 
@@ -1166,8 +1152,8 @@ async fn resolve_order_for_event(
 ///   2) tracked-order path: parse and dispatch updates to the order/UI pipeline
 /// - reuse decryptability checks across both paths for the same incoming GiftWrap
 ///   and trade pubkey (`HashMap<PublicKey, bool>` scoped to one notification; the
-///   unknown-subscription fallback reuses the `UnwrappedGift` from `resolve_order_for_event`
-///   so it does not decrypt twice there)
+///   unknown-subscription fallback reuses the `UnwrappedMessage` from `resolve_order_for_event`
+///   so it does not unwrap twice there)
 ///
 /// Lifecycle notes:
 /// - bootstrap subscriptions for already-active orders at startup
@@ -1429,7 +1415,7 @@ pub async fn listen_for_order_messages(
                     // 2) tracked order subscriptions (UI/order state pipeline).
                     // Shared cache for this single incoming GiftWrap: decryptability is keyed only
                     // by trade pubkey; `event.id` is fixed for the whole handler block.
-                    // This avoids duplicate `extract_rumor` calls between waiter and tracked paths.
+                    // This avoids duplicate `unwrap_message` calls between waiter and tracked paths.
                     let mut rumor_cache: HashMap<PublicKey, bool> = HashMap::new();
 
                     if !pending_waiters.is_empty() {
@@ -1447,7 +1433,10 @@ pub async fn listen_for_order_messages(
                             let can_decrypt = if let Some(boolean) = rumor_cache.get(&key) {
                                 *boolean
                             } else {
-                                let ok = nip59::extract_rumor(&waiter.trade_keys, &event).await.is_ok();
+                                let ok = matches!(
+                                    unwrap_message(&event, &waiter.trade_keys).await,
+                                    Ok(Some(_))
+                                );
                                 rumor_cache.insert(key, ok);
                                 ok
                             };
@@ -1490,7 +1479,10 @@ pub async fn listen_for_order_messages(
                         let can_decrypt = if let Some(boolean) = rumor_cache.get(&key) {
                             *boolean
                         } else {
-                            let ok = nip59::extract_rumor(&trade_keys, &event).await.is_ok();
+                            let ok = matches!(
+                                unwrap_message(&event, &trade_keys).await,
+                                Ok(Some(_))
+                            );
                             rumor_cache.insert(key, ok);
                             ok
                         };


### PR DESCRIPTION
Replace nostr-sdk nip59::extract_rumor for inbound trade DMs with mostro_core::unwrap_message (Ok(None) for wrong recipient). Reuse UnwrappedMessage in parse_dm_events_single / resolve_order_for_event / startup replay / listener probes; simplify rumor_cache keys to PublicKey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized message processing and decryption performance
  * Improved startup synchronization efficiency
  * Enhanced message selection logic for reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->