### PR TITLE
feat: relay snapshot DB reconcile for stale order status

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -179,7 +179,10 @@ pub use dm_utils::{
     set_dm_router_cmd_tx, wait_for_dm, OrderDmSubscriptionCmd, StartupDmHydration,
     FETCH_EVENTS_TIMEOUT,
 };
-pub use filters::{create_filter, create_seven_days_filter, filter_giftwrap_to_recipient};
+pub use filters::{
+    create_filter, create_mostro_list_fetch_filter, filter_giftwrap_to_recipient,
+    MOSTRO_LIST_FETCH_EVENT_LIMIT,
+};
 pub use order_utils::{fetch_events_list, get_orders, send_new_order, take_order};
 pub use types::{get_cant_do_description, Event, ListKind};
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,9 @@ use crate::util::{
     handle_message_notification, handle_operation_result, hydrate_startup_active_order_dm_state,
     install_background_panic_hook, listen_for_order_messages,
     order_utils::{
-        run_relay_order_db_reconcile_once, spawn_admin_chat_fetch, spawn_user_order_chat_fetch,
-        start_fetch_scheduler, validate_range_amount, FetchSchedulerResult,
+        run_relay_order_db_reconcile_once, run_targeted_relay_order_db_reconcile_tick,
+        spawn_admin_chat_fetch, spawn_user_order_chat_fetch, start_fetch_scheduler,
+        validate_range_amount, FetchSchedulerResult,
     },
     set_dm_router_cmd_tx, set_fatal_error_tx, spawn_save_attachment, StartupDmHydration,
 };
@@ -309,6 +310,17 @@ async fn main() -> Result<(), anyhow::Error> {
     if relays_reachable {
         if let Err(e) = run_relay_order_db_reconcile_once(&client, &pool, mostro_pubkey).await {
             log::warn!("Startup relay order DB reconcile failed: {}", e);
+        }
+        let startup_targeted_cursor = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        if let Err(e) = run_targeted_relay_order_db_reconcile_tick(
+            &client,
+            &pool,
+            mostro_pubkey,
+            &startup_targeted_cursor,
+        )
+        .await
+        {
+            log::warn!("Startup targeted relay order DB reconcile failed: {}", e);
         }
     }
     load_user_order_chats_at_startup(&client, &pool, &mut app).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use crate::util::{
     handle_message_notification, handle_operation_result, hydrate_startup_active_order_dm_state,
     install_background_panic_hook, listen_for_order_messages,
     order_utils::{
-        spawn_admin_chat_fetch, spawn_user_order_chat_fetch, start_fetch_scheduler,
-        validate_range_amount, FetchSchedulerResult,
+        run_relay_order_db_reconcile_once, spawn_admin_chat_fetch, spawn_user_order_chat_fetch,
+        start_fetch_scheduler, validate_range_amount, FetchSchedulerResult,
     },
     set_dm_router_cmd_tx, set_fatal_error_tx, spawn_save_attachment, StartupDmHydration,
 };
@@ -245,7 +245,12 @@ async fn main() -> Result<(), anyhow::Error> {
         disputes,
         mut order_task,
         mut dispute_task,
-    } = start_fetch_scheduler(client.clone(), Arc::clone(&current_mostro_pubkey), settings);
+    } = start_fetch_scheduler(
+        client.clone(),
+        Arc::clone(&current_mostro_pubkey),
+        settings,
+        pool.clone(),
+    );
 
     // Event handling: keyboard input and periodic UI refresh.
     let mut events = EventStream::new();
@@ -301,6 +306,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Load admin disputes at startup (only when role is admin)
     load_admin_disputes_at_startup(&pool, &mut app).await;
+    if relays_reachable {
+        if let Err(e) = run_relay_order_db_reconcile_once(&client, &pool, mostro_pubkey).await {
+            log::warn!("Startup relay order DB reconcile failed: {}", e);
+        }
+    }
     load_user_order_chats_at_startup(&client, &pool, &mut app).await;
 
     // Spawn background task to listen for messages on active orders

--- a/src/models.rs
+++ b/src/models.rs
@@ -557,6 +557,27 @@ impl Order {
         Ok(rows)
     }
 
+    /// Order UUIDs (as strings) that may still need a relay terminal status, for targeted reconcile.
+    ///
+    /// Rows must have persisted trade keys. Status is compared case-insensitively against
+    /// [`TERMINAL_ORDER_HISTORY_STATUSES`] (includes `success`, unlike [`TERMINAL_DM_STATUSES`]).
+    pub async fn list_ids_for_targeted_relay_reconcile(pool: &SqlitePool) -> Result<Vec<String>> {
+        let mut qb: QueryBuilder<'_, Sqlite> = QueryBuilder::new(
+            "SELECT id FROM orders WHERE trade_keys IS NOT NULL AND trade_keys != '' \
+             AND id IS NOT NULL AND id != '' \
+             AND (status IS NULL OR lower(status) NOT IN (",
+        );
+        {
+            let mut separated = qb.separated(", ");
+            for s in TERMINAL_ORDER_HISTORY_STATUSES {
+                separated.push_bind(*s);
+            }
+        }
+        qb.push(")) ORDER BY id");
+        let rows = qb.build_query_scalar::<String>().fetch_all(pool).await?;
+        Ok(rows)
+    }
+
     /// Fetches all locally-known user trade rows (maker + taker history) with persisted trade keys.
     pub async fn get_user_history_orders(pool: &SqlitePool) -> Result<Vec<Order>> {
         let rows = sqlx::query_as::<_, Order>(

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -218,6 +218,7 @@ pub async fn apply_pending_key_reload(
                         Arc::clone(&orders),
                         Arc::clone(&disputes),
                         &latest_settings,
+                        pool.clone(),
                     );
                     *order_fetch_task = o;
                     *dispute_fetch_task = d;
@@ -381,6 +382,7 @@ pub async fn apply_pending_fetch_scheduler_reload(
         Arc::clone(&orders),
         Arc::clone(&disputes),
         &latest,
+        pool.clone(),
     );
     *order_fetch_task = o;
     *dispute_fetch_task = d;
@@ -553,6 +555,7 @@ pub async fn reload_runtime_session_after_reconnect(
         Arc::clone(&ctx.orders),
         Arc::clone(&ctx.disputes),
         ctx.settings,
+        ctx.pool.clone(),
     );
     *ctx.order_fetch_task = o;
     *ctx.dispute_fetch_task = d;

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -11,11 +11,17 @@ pub fn filter_giftwrap_to_recipient(pubkey: PublicKey) -> Filter {
     Filter::new().pubkey(pubkey).kind(nostr_sdk::Kind::GiftWrap)
 }
 
-/// Create a filter for events from the last 7 days
-pub fn create_seven_days_filter(kind: u16, pubkey: PublicKey) -> Result<Filter> {
+/// Relay fetch cap for Mostro-published [`Kind::Custom`] order/dispute list snapshots.
+pub const MOSTRO_LIST_FETCH_EVENT_LIMIT: usize = 500;
+
+/// Build a fetch filter for Mostro list snapshots: events authored by `pubkey`, a given custom
+/// `kind`, and at most [`MOSTRO_LIST_FETCH_EVENT_LIMIT`] results.
+///
+/// There is **no** `since` time window; relay ordering decides which events fall inside the limit.
+pub fn create_mostro_list_fetch_filter(kind: u16, pubkey: PublicKey) -> Result<Filter> {
     Ok(Filter::new()
         .author(pubkey)
-        .limit(50)
+        .limit(MOSTRO_LIST_FETCH_EVENT_LIMIT)
         .kind(nostr_sdk::Kind::Custom(kind)))
 }
 
@@ -26,8 +32,8 @@ pub fn create_filter(
     _since: Option<&i64>,
 ) -> Result<Filter> {
     match list_kind {
-        ListKind::Orders => create_seven_days_filter(NOSTR_ORDER_EVENT_KIND, pubkey),
-        ListKind::Disputes => create_seven_days_filter(NOSTR_DISPUTE_EVENT_KIND, pubkey),
+        ListKind::Orders => create_mostro_list_fetch_filter(NOSTR_ORDER_EVENT_KIND, pubkey),
+        ListKind::Disputes => create_mostro_list_fetch_filter(NOSTR_DISPUTE_EVENT_KIND, pubkey),
         _ => Err(anyhow::anyhow!("Unsupported ListKind for mostrix")),
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -27,7 +27,10 @@ pub use fatal::{
     catch_unwind_request_fatal_restart, fatal_requested, install_background_panic_hook,
     request_fatal_restart, set_fatal_error_tx,
 };
-pub use filters::{create_filter, create_seven_days_filter, filter_giftwrap_to_recipient};
+pub use filters::{
+    create_filter, create_mostro_list_fetch_filter, filter_giftwrap_to_recipient,
+    MOSTRO_LIST_FETCH_EVENT_LIMIT,
+};
 pub use mostro_info::{
     fetch_mostro_instance_info, fetch_mostro_instance_info_from_settings, format_instance_info_age,
     mostro_info_from_tags, nostr_pow_from_instance, MostroInstanceInfo, MOSTRO_INSTANCE_INFO_KIND,

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -23,6 +23,7 @@ use super::helper::{
 };
 use super::relay_order_db_reconcile::{
     reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,
+    run_targeted_relay_order_db_reconcile_tick,
 };
 
 /// Result of starting the fetch scheduler
@@ -210,6 +211,7 @@ pub fn spawn_fetch_scheduler_loops(
                 Instant::now(),
                 Duration::from_secs(RECONCILIATION_INTERVAL_SECS),
             );
+            let targeted_reconcile_cursor = Arc::new(Mutex::new(0usize));
             loop {
                 tokio::select! {
                     _ = refresh_interval.tick() => {
@@ -271,6 +273,20 @@ pub fn spawn_fetch_scheduler_loops(
                                 "[orders_reconcile] failed to fetch order events: {}",
                                 e
                             ),
+                        }
+
+                        if let Err(e) = run_targeted_relay_order_db_reconcile_tick(
+                            &client_for_orders,
+                            &pool_for_orders,
+                            mostro_pubkey_for_orders,
+                            &targeted_reconcile_cursor,
+                        )
+                        .await
+                        {
+                            log::warn!(
+                                "[orders_reconcile_targeted] relay DB status reconcile failed: {}",
+                                e
+                            );
                         }
                     }
                     notification = notifications.recv() => {

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -15,8 +15,15 @@ use crate::ui::{
 };
 use crate::util::catch_unwind_request_fatal_restart;
 use crate::util::chat_utils::{fetch_admin_chat_updates, fetch_user_order_chat_updates};
+use sqlx::SqlitePool;
 
-use super::{get_disputes, get_orders};
+use super::get_disputes;
+use super::helper::{
+    aggregate_latest_orders_by_id, fetch_mostro_order_events, pending_orders_for_book,
+};
+use super::relay_order_db_reconcile::{
+    reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,
+};
 
 /// Result of starting the fetch scheduler
 /// Contains shared state for orders and disputes that are periodically updated
@@ -120,6 +127,7 @@ fn apply_live_dispute_update(disputes: &Arc<Mutex<Vec<Dispute>>>, dispute: Dispu
 ///
 /// * `client` - Nostr client for fetching events
 /// * `mostro_pubkey` - Public key of the Mostro daemon
+/// * `pool` - SQLite pool used to align local order rows with relay terminal statuses
 ///
 /// # Returns
 ///
@@ -128,6 +136,7 @@ pub fn start_fetch_scheduler(
     client: Client,
     current_mostro_pubkey: Arc<Mutex<PublicKey>>,
     settings: &Settings,
+    pool: SqlitePool,
 ) -> FetchSchedulerResult {
     let orders: Arc<Mutex<Vec<SmallOrder>>> = Arc::new(Mutex::new(Vec::new()));
     let disputes: Arc<Mutex<Vec<Dispute>>> = Arc::new(Mutex::new(Vec::new()));
@@ -138,6 +147,7 @@ pub fn start_fetch_scheduler(
         Arc::clone(&orders),
         Arc::clone(&disputes),
         settings,
+        pool,
     );
 
     FetchSchedulerResult {
@@ -158,10 +168,12 @@ pub fn spawn_fetch_scheduler_loops(
     orders: Arc<Mutex<Vec<SmallOrder>>>,
     disputes: Arc<Mutex<Vec<Dispute>>>,
     settings: &Settings,
+    pool: SqlitePool,
 ) -> (JoinHandle<()>, JoinHandle<()>) {
     // Spawn task to periodically fetch orders
     let orders_clone = Arc::clone(&orders);
     let client_for_orders = client.clone();
+    let pool_for_orders = pool.clone();
     let current_mostro_pubkey_for_orders = Arc::clone(&current_mostro_pubkey);
     let reloaded_settings = settings.clone();
     let order_task = tokio::spawn(async move {
@@ -218,29 +230,47 @@ pub fn spawn_fetch_scheduler_loops(
                             }
                         };
 
-                        if let Ok(fetched_orders) = get_orders(
+                        match fetch_mostro_order_events(
                             &client_for_orders,
                             mostro_pubkey_for_orders,
-                            Some(Status::Pending),
-                            Some(currencies),
                         )
                         .await
                         {
-                            let mut orders_lock = match orders_clone.lock() {
-                                Ok(g) => g,
-                                Err(e) => {
-                                    crate::util::request_fatal_restart(format!(
-                                        "Mostrix encountered an internal error while reconciling orders (poisoned orders lock: {e}). Please restart the app."
-                                    ));
-                                    return;
+                            Ok(events) => {
+                                let latest_map = aggregate_latest_orders_by_id(&events);
+                                if let Err(e) = reconcile_terminal_order_statuses_from_relay(
+                                    &pool_for_orders,
+                                    &latest_map,
+                                )
+                                .await
+                                {
+                                    log::warn!(
+                                        "[orders_reconcile] relay DB status reconcile failed: {}",
+                                        e
+                                    );
                                 }
-                            };
-                            orders_lock.clear();
-                            orders_lock.extend(fetched_orders);
-                            log::debug!(
-                                "[orders_reconcile] refreshed pending orders count={}",
-                                orders_lock.len()
-                            );
+                                let fetched_orders =
+                                    pending_orders_for_book(&latest_map, Some(currencies));
+                                let mut orders_lock = match orders_clone.lock() {
+                                    Ok(g) => g,
+                                    Err(e) => {
+                                        crate::util::request_fatal_restart(format!(
+                                            "Mostrix encountered an internal error while reconciling orders (poisoned orders lock: {e}). Please restart the app."
+                                        ));
+                                        return;
+                                    }
+                                };
+                                orders_lock.clear();
+                                orders_lock.extend(fetched_orders);
+                                log::debug!(
+                                    "[orders_reconcile] refreshed pending orders count={}",
+                                    orders_lock.len()
+                                );
+                            }
+                            Err(e) => log::warn!(
+                                "[orders_reconcile] failed to fetch order events: {}",
+                                e
+                            ),
                         }
                     }
                     notification = notifications.recv() => {
@@ -253,13 +283,13 @@ pub fn spawn_fetch_scheduler_loops(
                         }
                         let mut one = Events::default();
                         one.insert(event);
+                        let latest_live = aggregate_latest_orders_by_id(&one);
+                        for relay_order in latest_live.values() {
+                            reconcile_one_order_if_terminal(&pool_for_orders, relay_order).await;
+                        }
                         let currencies = reloaded_settings.currencies_filter.clone();
-                        let mut parsed = super::parse_orders_events(
-                            one,
-                            Some(currencies),
-                            None,
-                            None,
-                        );
+                        let mut parsed =
+                            super::parse_orders_events(one, Some(currencies), None, None);
                         log::debug!(
                             "[orders_live] received order event, parsed_candidates={}",
                             parsed.len()

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -121,7 +121,7 @@ fn status_phase_rank_for_actor(
     }
 }
 
-fn is_terminal_trade_status(status: Status) -> bool {
+pub(crate) fn is_terminal_trade_status(status: Status) -> bool {
     matches!(
         status,
         Status::Canceled
@@ -291,17 +291,13 @@ pub fn parse_disputes_events(events: Events) -> Vec<Dispute> {
     disputes_list
 }
 
-/// Parse orders from events
-pub fn parse_orders_events(
-    events: Events,
-    currencies: Option<Vec<String>>,
-    status: Option<Status>,
-    kind: Option<mostro_core::order::Kind>,
-) -> Vec<SmallOrder> {
+/// Latest [`SmallOrder`] per order id from Mostro nostr order events (newest event wins).
+///
+/// Does not apply currency, status, or kind filters — use [`parse_orders_events`] for that.
+pub fn aggregate_latest_orders_by_id(events: &Events) -> HashMap<Uuid, SmallOrder> {
     let mut latest_by_id: HashMap<Uuid, SmallOrder> = HashMap::new();
 
     for event in events.iter() {
-        // Get order from tags
         let mut order = match order_from_tags(event.tags.clone()) {
             Ok(o) => o,
             Err(e) => {
@@ -309,7 +305,6 @@ pub fn parse_orders_events(
                 continue;
             }
         };
-        // Get order id
         let order_id = match order.id {
             Some(id) => id,
             None => {
@@ -317,14 +312,11 @@ pub fn parse_orders_events(
                 continue;
             }
         };
-        // Check if order kind is none
         if order.kind.is_none() {
             log::info!("Order kind is none");
             continue;
         }
-        // Set created at
         order.created_at = Some(event.created_at.as_secs() as i64);
-        // Update latest order by id
         latest_by_id
             .entry(order_id)
             .and_modify(|existing| {
@@ -336,6 +328,18 @@ pub fn parse_orders_events(
             })
             .or_insert(order);
     }
+
+    latest_by_id
+}
+
+/// Parse orders from events
+pub fn parse_orders_events(
+    events: Events,
+    currencies: Option<Vec<String>>,
+    status: Option<Status>,
+    kind: Option<mostro_core::order::Kind>,
+) -> Vec<SmallOrder> {
+    let latest_by_id = aggregate_latest_orders_by_id(&events);
 
     let mut requested: Vec<SmallOrder> = latest_by_id
         .into_values()
@@ -359,6 +363,41 @@ pub fn parse_orders_events(
     requested
 }
 
+/// Fetch raw Mostro order-kind events from relays (same filter as [`fetch_events_list`] for orders).
+///
+/// Relay queries are capped (see [`crate::util::filters::MOSTRO_LIST_FETCH_EVENT_LIMIT`]); very old
+/// order updates may not be included in the snapshot.
+pub async fn fetch_mostro_order_events(
+    client: &Client,
+    mostro_pubkey: PublicKey,
+) -> Result<Events> {
+    let filters = create_filter(ListKind::Orders, mostro_pubkey, None)?;
+    Ok(client.fetch_events(filters, FETCH_EVENTS_TIMEOUT).await?)
+}
+
+/// Pending listings for the public order book from an aggregated relay snapshot.
+///
+/// Applies the same currency rules as [`parse_orders_events`] when `status` is pending-only:
+/// empty `currencies` list means no filter; `None` means no filter.
+pub fn pending_orders_for_book(
+    latest: &HashMap<Uuid, SmallOrder>,
+    currencies: Option<Vec<String>>,
+) -> Vec<SmallOrder> {
+    let mut requested: Vec<SmallOrder> = latest
+        .values()
+        .filter(|o| {
+            o.status == Some(Status::Pending)
+                && currencies
+                    .as_ref()
+                    .map(|currencies| currencies.is_empty() || currencies.contains(&o.fiat_code))
+                    .unwrap_or(true)
+        })
+        .cloned()
+        .collect();
+    requested.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    requested
+}
+
 /// Fetch events list using the same logic as mostro-cli (adapted for mostrix)
 pub async fn fetch_events_list(
     list_kind: ListKind,
@@ -371,8 +410,7 @@ pub async fn fetch_events_list(
 ) -> Result<Vec<Event>> {
     match list_kind {
         ListKind::Orders => {
-            let filters = create_filter(list_kind, mostro_pubkey, None)?;
-            let fetched_events = client.fetch_events(filters, FETCH_EVENTS_TIMEOUT).await?;
+            let fetched_events = fetch_mostro_order_events(client, mostro_pubkey).await?;
             let orders = parse_orders_events(fetched_events, currencies, status, kind);
             Ok(orders.into_iter().map(Event::SmallOrder).collect())
         }
@@ -394,29 +432,13 @@ pub async fn get_orders(
     status: Option<Status>,
     currencies: Option<Vec<String>>,
 ) -> Result<Vec<SmallOrder>> {
-    let fetched_events = fetch_events_list(
-        ListKind::Orders,
-        status,
+    let fetched_events = fetch_mostro_order_events(client, mostro_pubkey).await?;
+    Ok(parse_orders_events(
+        fetched_events,
         currencies,
+        status,
         None,
-        client,
-        mostro_pubkey,
-        None,
-    )
-    .await?;
-
-    let orders: Vec<SmallOrder> = fetched_events
-        .into_iter()
-        .filter_map(|event| {
-            if let Event::SmallOrder(order) = event {
-                Some(order)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    Ok(orders)
+    ))
 }
 
 /// Fetch disputes from the Mostro network

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -469,6 +469,30 @@ pub async fn get_disputes(client: &Client, mostro_pubkey: PublicKey) -> Result<V
     Ok(disputes)
 }
 
+/// Fetch the latest [`SmallOrder`] for one order id from relays (author + custom order kind + `d` tag).
+///
+/// Uses `limit(10)` and picks the event with the greatest [`Event::created_at`] so relays that return
+/// multiple revisions for the same identifier still resolve to the newest snapshot.
+pub async fn fetch_small_order_by_id_from_relay(
+    client: &Client,
+    mostro_pubkey: PublicKey,
+    order_id: Uuid,
+) -> Result<Option<SmallOrder>> {
+    let filter = Filter::new()
+        .author(mostro_pubkey)
+        .kind(nostr_sdk::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
+        .identifier(order_id.to_string())
+        .limit(10);
+    let events = client
+        .fetch_events(filter, FETCH_EVENTS_TIMEOUT)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to fetch order from relay by id: {}", e))?;
+    let Some(best) = events.iter().max_by_key(|e| e.created_at) else {
+        return Ok(None);
+    };
+    Ok(Some(order_from_tags(best.tags.clone())?))
+}
+
 /// Fetch a single order's fiat code from the relay by order id (identifier "d" tag).
 /// Used when the order is not in the local DB (e.g. admin taking a dispute for an order they did not create).
 pub async fn fetch_order_fiat_from_relay(
@@ -476,22 +500,15 @@ pub async fn fetch_order_fiat_from_relay(
     mostro_pubkey: PublicKey,
     order_id: Uuid,
 ) -> Result<Option<String>> {
-    let filter = Filter::new()
-        .author(mostro_pubkey)
-        .kind(nostr_sdk::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
-        .identifier(order_id.to_string())
-        .limit(1);
-    let events = client
-        .fetch_events(filter, FETCH_EVENTS_TIMEOUT)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch order from relay: {}", e))?;
-    let event = match events.iter().next() {
-        Some(ev) => ev,
-        None => return Ok(None),
-    };
-    let order = order_from_tags(event.tags.clone())?;
-    let fiat = order.fiat_code;
-    Ok(if fiat.is_empty() { None } else { Some(fiat) })
+    let order = fetch_small_order_by_id_from_relay(client, mostro_pubkey, order_id).await?;
+    Ok(order.and_then(|o| {
+        let fiat = o.fiat_code;
+        if fiat.is_empty() {
+            None
+        } else {
+            Some(fiat)
+        }
+    }))
 }
 
 /// Build My Trades static header for one trade (maker or taker).
@@ -579,8 +596,44 @@ pub(super) fn handle_mostro_response(
 
 #[cfg(test)]
 mod tests {
-    use super::{should_apply_status_transition, should_strictly_advance_status};
+    use super::{
+        is_terminal_trade_status, should_apply_status_transition, should_strictly_advance_status,
+    };
+    use crate::models::TERMINAL_ORDER_HISTORY_STATUSES;
     use mostro_core::prelude::Status;
+    use std::str::FromStr;
+
+    #[test]
+    fn terminal_order_history_statuses_match_is_terminal_trade_status() {
+        let terminal_variants = [
+            Status::Success,
+            Status::Canceled,
+            Status::CanceledByAdmin,
+            Status::SettledByAdmin,
+            Status::CompletedByAdmin,
+            Status::Expired,
+            Status::CooperativelyCanceled,
+        ];
+        for s in terminal_variants {
+            assert!(
+                is_terminal_trade_status(s),
+                "test variant list must stay aligned with is_terminal_trade_status"
+            );
+            let display = s.to_string();
+            assert!(
+                TERMINAL_ORDER_HISTORY_STATUSES.contains(&display.as_str()),
+                "Status::to_string() for {s:?} must appear in TERMINAL_ORDER_HISTORY_STATUSES for targeted reconcile SQL"
+            );
+        }
+        for &kebab in TERMINAL_ORDER_HISTORY_STATUSES {
+            let parsed =
+                Status::from_str(kebab).expect("TERMINAL_ORDER_HISTORY_STATUSES must parse");
+            assert!(
+                is_terminal_trade_status(parsed),
+                "{kebab} in TERMINAL_ORDER_HISTORY_STATUSES must be terminal for relay reconcile"
+            );
+        }
+    }
 
     #[test]
     fn buy_maker_blocks_waiting_payment_downgrade() {

--- a/src/util/order_utils/mod.rs
+++ b/src/util/order_utils/mod.rs
@@ -8,6 +8,7 @@ mod execute_send_msg;
 mod execute_take_dispute;
 mod fetch_scheduler;
 mod helper;
+mod relay_order_db_reconcile;
 mod send_new_order;
 mod take_order;
 
@@ -24,10 +25,14 @@ pub use fetch_scheduler::{
     start_fetch_scheduler, FetchSchedulerResult,
 };
 pub use helper::{
-    dispute_from_tags, fetch_events_list, get_disputes, get_orders,
-    inferred_status_from_trade_action, map_action_to_status, order_from_tags,
-    parse_disputes_events, parse_orders_events, should_apply_status_transition,
-    should_strictly_advance_status, validate_range_amount,
+    aggregate_latest_orders_by_id, dispute_from_tags, fetch_events_list, fetch_mostro_order_events,
+    get_disputes, get_orders, inferred_status_from_trade_action, map_action_to_status,
+    order_from_tags, parse_disputes_events, parse_orders_events, pending_orders_for_book,
+    should_apply_status_transition, should_strictly_advance_status, validate_range_amount,
+};
+pub use relay_order_db_reconcile::{
+    reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,
+    run_relay_order_db_reconcile_once,
 };
 pub use send_new_order::send_new_order;
 pub use take_order::take_order;

--- a/src/util/order_utils/mod.rs
+++ b/src/util/order_utils/mod.rs
@@ -32,7 +32,8 @@ pub use helper::{
 };
 pub use relay_order_db_reconcile::{
     reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,
-    run_relay_order_db_reconcile_once,
+    run_relay_order_db_reconcile_once, run_targeted_relay_order_db_reconcile_tick,
+    TARGETED_RELAY_RECONCILE_MAX_PER_TICK,
 };
 pub use send_new_order::send_new_order;
 pub use take_order::take_order;

--- a/src/util/order_utils/relay_order_db_reconcile.rs
+++ b/src/util/order_utils/relay_order_db_reconcile.rs
@@ -6,14 +6,18 @@ use nostr_sdk::prelude::*;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 use crate::models::Order;
 
 use super::helper::{
-    aggregate_latest_orders_by_id, fetch_mostro_order_events, is_terminal_trade_status,
-    should_apply_status_transition,
+    aggregate_latest_orders_by_id, fetch_mostro_order_events, fetch_small_order_by_id_from_relay,
+    is_terminal_trade_status, should_apply_status_transition,
 };
+
+/// Max per-order relay fetches each scheduler tick (round-robin over local non-terminal rows).
+pub const TARGETED_RELAY_RECONCILE_MAX_PER_TICK: usize = 5;
 
 /// Fetch latest order snapshots from relays and apply [`reconcile_one_order_if_terminal`] for each entry.
 pub async fn reconcile_terminal_order_statuses_from_relay(
@@ -35,6 +39,68 @@ pub async fn run_relay_order_db_reconcile_once(
     let events = fetch_mostro_order_events(client, mostro_pubkey).await?;
     let latest = aggregate_latest_orders_by_id(&events);
     reconcile_terminal_order_statuses_from_relay(pool, &latest).await
+}
+
+/// Per-order relay fetch for local non-terminal rows; advances `cursor` for round-robin fairness.
+///
+/// Locks `cursor` only for short sync sections so the future stays [`Send`] across relay awaits.
+pub async fn run_targeted_relay_order_db_reconcile_tick(
+    client: &Client,
+    pool: &SqlitePool,
+    mostro_pubkey: PublicKey,
+    cursor: &Arc<Mutex<usize>>,
+) -> Result<()> {
+    let ids = Order::list_ids_for_targeted_relay_reconcile(pool).await?;
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let len = ids.len();
+    let (start, take) = {
+        let c = cursor
+            .lock()
+            .map_err(|_| anyhow::anyhow!("targeted reconcile cursor mutex poisoned"))?;
+        let start = *c % len;
+        let take = TARGETED_RELAY_RECONCILE_MAX_PER_TICK.min(len);
+        (start, take)
+    };
+    for i in 0..take {
+        let id_str = &ids[(start + i) % len];
+        let order_id = match Uuid::parse_str(id_str) {
+            Ok(u) => u,
+            Err(_) => {
+                log::debug!(
+                    "[orders_reconcile_targeted] skip invalid order id in DB: {}",
+                    id_str
+                );
+                continue;
+            }
+        };
+        match fetch_small_order_by_id_from_relay(client, mostro_pubkey, order_id).await {
+            Ok(Some(relay_order)) => {
+                reconcile_one_order_if_terminal(pool, &relay_order).await;
+            }
+            Ok(None) => {
+                log::debug!(
+                    "[orders_reconcile_targeted] no relay event for order_id={}",
+                    order_id
+                );
+            }
+            Err(e) => {
+                log::debug!(
+                    "[orders_reconcile_targeted] fetch failed order_id={}: {}",
+                    order_id,
+                    e
+                );
+            }
+        }
+    }
+    {
+        let mut c = cursor
+            .lock()
+            .map_err(|_| anyhow::anyhow!("targeted reconcile cursor mutex poisoned"))?;
+        *c = (start + take) % len;
+    }
+    Ok(())
 }
 
 /// If `relay_order` carries a terminal status and the local row exists, update SQLite when allowed.
@@ -225,5 +291,105 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn list_ids_for_targeted_reconcile_includes_only_open_trades_with_keys() {
+        let pool = test_pool().await;
+        sqlx::query(
+            r#"
+            CREATE TABLE orders (
+                id TEXT PRIMARY KEY,
+                kind TEXT,
+                status TEXT,
+                amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL,
+                min_amount INTEGER,
+                max_amount INTEGER,
+                fiat_amount INTEGER NOT NULL,
+                payment_method TEXT NOT NULL,
+                premium INTEGER NOT NULL,
+                trade_keys TEXT,
+                counterparty_pubkey TEXT,
+                order_chat_shared_key_hex TEXT,
+                is_mine INTEGER NOT NULL,
+                buyer_invoice TEXT,
+                request_id INTEGER,
+                trade_index INTEGER,
+                created_at INTEGER,
+                expires_at INTEGER,
+                last_seen_dm_ts INTEGER
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let keys = Keys::generate();
+        let pending_id = Uuid::new_v4();
+        let expired_id = Uuid::new_v4();
+        let no_keys_id = Uuid::new_v4();
+
+        Order::new(
+            &pool,
+            SmallOrder {
+                id: Some(pending_id),
+                kind: Some(mostro_core::order::Kind::Sell),
+                status: Some(Status::Pending),
+                amount: 1,
+                fiat_code: "EUR".to_string(),
+                fiat_amount: 1,
+                payment_method: "sepa".to_string(),
+                premium: 0,
+                ..Default::default()
+            },
+            &keys,
+            None,
+            1,
+            true,
+        )
+        .await
+        .unwrap();
+
+        Order::new(
+            &pool,
+            SmallOrder {
+                id: Some(expired_id),
+                kind: Some(mostro_core::order::Kind::Sell),
+                status: Some(Status::Expired),
+                amount: 1,
+                fiat_code: "EUR".to_string(),
+                fiat_amount: 1,
+                payment_method: "sepa".to_string(),
+                premium: 0,
+                ..Default::default()
+            },
+            &keys,
+            None,
+            2,
+            true,
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"INSERT INTO orders (
+                id, kind, status, amount, fiat_code, min_amount, max_amount,
+                fiat_amount, payment_method, premium, is_mine, trade_keys,
+                counterparty_pubkey, order_chat_shared_key_hex, buyer_invoice,
+                request_id, trade_index, created_at, expires_at, last_seen_dm_ts
+            ) VALUES (?, 'sell', 'pending', 1, 'EUR', NULL, NULL, 1, 'sepa', 0, 1, '', NULL, NULL, NULL, NULL, 3, 0, NULL, NULL)"#,
+        )
+        .bind(no_keys_id.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let ids = Order::list_ids_for_targeted_relay_reconcile(&pool)
+            .await
+            .unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], pending_id.to_string());
     }
 }

--- a/src/util/order_utils/relay_order_db_reconcile.rs
+++ b/src/util/order_utils/relay_order_db_reconcile.rs
@@ -48,9 +48,15 @@ pub async fn reconcile_one_order_if_terminal(pool: &SqlitePool, relay_order: &Sm
     let Some(order_id) = relay_order.id else {
         return;
     };
-    let Ok(row) = Order::get_by_id(pool, &order_id.to_string()).await else {
-        return;
+
+    let row = match Order::get_by_id(pool, &order_id.to_string()).await {
+        Ok(row) => row,
+        Err(e) => {
+            log::warn!("Failed to get order by id: {}", e);
+            return;
+        }
     };
+
     let current = row.status.as_deref().and_then(|s| Status::from_str(s).ok());
     let kind = relay_order.kind.or_else(|| {
         row.kind
@@ -73,10 +79,12 @@ pub async fn reconcile_one_order_if_terminal(pool: &SqlitePool, relay_order: &Sm
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::SqlitePool;
+    use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
 
     async fn test_pool() -> SqlitePool {
-        SqlitePool::connect("sqlite::memory:")
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
             .await
             .expect("sqlite memory pool")
     }
@@ -210,5 +218,12 @@ mod tests {
         reconcile_terminal_order_statuses_from_relay(&pool, &relay_latest)
             .await
             .unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM orders WHERE id = ?")
+            .bind(oid.to_string())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0);
     }
 }

--- a/src/util/order_utils/relay_order_db_reconcile.rs
+++ b/src/util/order_utils/relay_order_db_reconcile.rs
@@ -1,0 +1,214 @@
+//! Align local `orders` rows with terminal statuses seen on Mostro nostr order events.
+
+use anyhow::Result;
+use mostro_core::prelude::*;
+use nostr_sdk::prelude::*;
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::str::FromStr;
+use uuid::Uuid;
+
+use crate::models::Order;
+
+use super::helper::{
+    aggregate_latest_orders_by_id, fetch_mostro_order_events, is_terminal_trade_status,
+    should_apply_status_transition,
+};
+
+/// Fetch latest order snapshots from relays and apply [`reconcile_one_order_if_terminal`] for each entry.
+pub async fn reconcile_terminal_order_statuses_from_relay(
+    pool: &SqlitePool,
+    relay_latest: &HashMap<Uuid, SmallOrder>,
+) -> Result<()> {
+    for relay_order in relay_latest.values() {
+        reconcile_one_order_if_terminal(pool, relay_order).await;
+    }
+    Ok(())
+}
+
+/// One relay snapshot fetch plus DB reconcile; shared by periodic scheduler and startup.
+pub async fn run_relay_order_db_reconcile_once(
+    client: &Client,
+    pool: &SqlitePool,
+    mostro_pubkey: PublicKey,
+) -> Result<()> {
+    let events = fetch_mostro_order_events(client, mostro_pubkey).await?;
+    let latest = aggregate_latest_orders_by_id(&events);
+    reconcile_terminal_order_statuses_from_relay(pool, &latest).await
+}
+
+/// If `relay_order` carries a terminal status and the local row exists, update SQLite when allowed.
+pub async fn reconcile_one_order_if_terminal(pool: &SqlitePool, relay_order: &SmallOrder) {
+    let Some(candidate_status) = relay_order.status else {
+        return;
+    };
+    if !is_terminal_trade_status(candidate_status) {
+        return;
+    }
+    let Some(order_id) = relay_order.id else {
+        return;
+    };
+    let Ok(row) = Order::get_by_id(pool, &order_id.to_string()).await else {
+        return;
+    };
+    let current = row.status.as_deref().and_then(|s| Status::from_str(s).ok());
+    let kind = relay_order.kind.or_else(|| {
+        row.kind
+            .as_deref()
+            .and_then(|k| mostro_core::order::Kind::from_str(k).ok())
+    });
+    if !should_apply_status_transition(current, candidate_status, kind) {
+        return;
+    }
+    if let Err(e) = Order::update_status(pool, &order_id.to_string(), candidate_status).await {
+        log::warn!(
+            "Relay reconcile: failed to update order {} to {}: {}",
+            order_id,
+            candidate_status,
+            e
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn test_pool() -> SqlitePool {
+        SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory pool")
+    }
+
+    #[tokio::test]
+    async fn reconcile_updates_pending_row_when_relay_expired() {
+        let pool = test_pool().await;
+        sqlx::query(
+            r#"
+            CREATE TABLE orders (
+                id TEXT PRIMARY KEY,
+                kind TEXT,
+                status TEXT,
+                amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL,
+                min_amount INTEGER,
+                max_amount INTEGER,
+                fiat_amount INTEGER NOT NULL,
+                payment_method TEXT NOT NULL,
+                premium INTEGER NOT NULL,
+                trade_keys TEXT,
+                counterparty_pubkey TEXT,
+                order_chat_shared_key_hex TEXT,
+                is_mine INTEGER NOT NULL,
+                buyer_invoice TEXT,
+                request_id INTEGER,
+                trade_index INTEGER,
+                created_at INTEGER,
+                expires_at INTEGER,
+                last_seen_dm_ts INTEGER
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let trade_keys = Keys::generate();
+        let oid = Uuid::new_v4();
+        let small_pending = SmallOrder {
+            id: Some(oid),
+            kind: Some(mostro_core::order::Kind::Sell),
+            status: Some(Status::Pending),
+            amount: 10_000,
+            fiat_code: "EUR".to_string(),
+            fiat_amount: 50,
+            payment_method: "sepa".to_string(),
+            premium: 0,
+            ..Default::default()
+        };
+
+        Order::new(&pool, small_pending, &trade_keys, None, 1, true)
+            .await
+            .unwrap();
+
+        let mut relay_latest: HashMap<Uuid, SmallOrder> = HashMap::new();
+        relay_latest.insert(
+            oid,
+            SmallOrder {
+                id: Some(oid),
+                kind: Some(mostro_core::order::Kind::Sell),
+                status: Some(Status::Expired),
+                amount: 10_000,
+                fiat_code: "EUR".to_string(),
+                fiat_amount: 50,
+                payment_method: "sepa".to_string(),
+                premium: 0,
+                ..Default::default()
+            },
+        );
+
+        reconcile_terminal_order_statuses_from_relay(&pool, &relay_latest)
+            .await
+            .unwrap();
+
+        let row = Order::get_by_id(&pool, &oid.to_string()).await.unwrap();
+        assert_eq!(
+            row.status.as_deref().and_then(|s| Status::from_str(s).ok()),
+            Some(Status::Expired)
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_skips_when_no_local_row() {
+        let pool = test_pool().await;
+        sqlx::query(
+            r#"CREATE TABLE orders (
+                id TEXT PRIMARY KEY,
+                kind TEXT,
+                status TEXT,
+                amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL,
+                min_amount INTEGER,
+                max_amount INTEGER,
+                fiat_amount INTEGER NOT NULL,
+                payment_method TEXT NOT NULL,
+                premium INTEGER NOT NULL,
+                trade_keys TEXT,
+                counterparty_pubkey TEXT,
+                order_chat_shared_key_hex TEXT,
+                is_mine INTEGER NOT NULL,
+                buyer_invoice TEXT,
+                request_id INTEGER,
+                trade_index INTEGER,
+                created_at INTEGER,
+                expires_at INTEGER,
+                last_seen_dm_ts INTEGER
+            );"#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let oid = Uuid::new_v4();
+        let mut relay_latest: HashMap<Uuid, SmallOrder> = HashMap::new();
+        relay_latest.insert(
+            oid,
+            SmallOrder {
+                id: Some(oid),
+                kind: Some(mostro_core::order::Kind::Buy),
+                status: Some(Status::Canceled),
+                amount: 1,
+                fiat_code: "USD".to_string(),
+                fiat_amount: 1,
+                payment_method: "x".to_string(),
+                premium: 0,
+                ..Default::default()
+            },
+        );
+
+        reconcile_terminal_order_statuses_from_relay(&pool, &relay_latest)
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes local SQLite `orders` rows staying non-terminal (e.g. `pending`) when Mostro already published **expired** / **canceled** (etc.) nostr order events while Mostrix was closed. The Orders tab reconcile previously fetched **pending-only**, so the latest terminal state from the relay was dropped before it could touch the DB.

## What changed
- **Single relay fetch** per tick: aggregate latest `SmallOrder` per order id (no status filter), then:
  - run **terminal status reconcile** against local rows (`should_apply_status_transition` + `Order::update_status`);
  - fill the in-memory book with **pending + currency filter** only (unchanged UX).
- **Live** nostr order events: reconcile terminal statuses **before** the pending-filtered UI update so DB stays aligned without waiting for the 30s poll.
- **Startup**: one `run_relay_order_db_reconcile_once` when relays are reachable, before user order chat hydration.
- Thread **`SqlitePool`** through `start_fetch_scheduler` / `spawn_fetch_scheduler_loops` (main + key reload + scheduler reload + reconnect paths).
- **Naming/doc**: replace misleading `create_seven_days_filter` with `create_mostro_list_fetch_filter` and document that there is **no `since`**—only author + kind + `MOSTRO_LIST_FETCH_EVENT_LIMIT` (50).

## Limitations
Relay list snapshots are still capped by [`MOSTRO_LIST_FETCH_EVENT_LIMIT`](src/util/filters.rs); very old terminal updates might not appear in the fetched window until a targeted query exists.

## Breaking changes
- **Public re-export**: `create_seven_days_filter` removed from `mostrix::util`; use `create_mostro_list_fetch_filter` and/or `MOSTRO_LIST_FETCH_EVENT_LIMIT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reconciliation to keep local order statuses synced with relay state, including startup and targeted background reconciliation.
  * Background scheduler now reliably receives DB context for its tasks.

* **Refactor**
  * Order fetch/parsing and reconciliation logic reorganized for latest-per-id aggregation and targeted relay queries.

* **Bug Fixes**
  * Fetching capped at 500 events with strict author/kind filtering (removed 7-day window).

* **Documentation**
  * Coding standards example updated to show new exports and limits.

* **Tests**
  * Added reconciliation tests for terminal-status updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostrix/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->