### PR TITLE
feat(ui): role-aware waiting-phase trade status popups

### DIFF
--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -975,6 +975,7 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
                         scroll_y: 0,
                         action_selection: InvoiceNotificationActionSelection::Primary,
                     };
+                    // Acting party: invoice/payment input. Waiting party: read-only trade-status popup.
                     if local_user_must_act_on_invoice_popup(msg, &invoice_popup_action) {
                         let notification = order_message_to_notification(msg);
                         if invoice_popup_action == Action::AddInvoice {

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -9,7 +9,8 @@ use crate::ui::key_handler::input_helpers::{
     prepare_admin_chat_message, send_admin_chat_message_via_shared_key,
 };
 use crate::ui::orders::{
-    invoice_popup_allowed_for_order_status, message_action_compact_label_for_message,
+    invoice_popup_allowed_for_order_status, local_user_must_act_on_invoice_popup,
+    message_action_compact_label_for_message, order_message_to_waiting_notification,
     strip_new_order_messages_and_clamp_selected,
 };
 use crate::ui::{
@@ -966,25 +967,34 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             let action = inner_message_kind.action.clone();
             if let Some(invoice_popup_action) = invoice_popup_action_for_message_action(&action) {
                 if invoice_popup_allowed_for_order_status(&invoice_popup_action, msg.order_status) {
-                    // Show invoice/payment popup only when the phase still requires it.
-                    let notification = order_message_to_notification(msg);
-                    if invoice_popup_action == Action::AddInvoice {
-                        app.mode = present_add_invoice_popup(
-                            &mut app.buyer_invoice_preference,
-                            notification,
-                        );
+                    let invoice_state = InvoiceInputState {
+                        invoice_input: String::new(),
+                        focused: false,
+                        just_pasted: false,
+                        copied_to_clipboard: false,
+                        scroll_y: 0,
+                        action_selection: InvoiceNotificationActionSelection::Primary,
+                    };
+                    if local_user_must_act_on_invoice_popup(msg, &invoice_popup_action) {
+                        let notification = order_message_to_notification(msg);
+                        if invoice_popup_action == Action::AddInvoice {
+                            app.mode = present_add_invoice_popup(
+                                &mut app.buyer_invoice_preference,
+                                notification,
+                            );
+                        } else {
+                            app.mode = UiMode::NewMessageNotification(
+                                notification,
+                                invoice_popup_action,
+                                invoice_state,
+                            );
+                        }
                     } else {
-                        let invoice_state = InvoiceInputState {
-                            invoice_input: String::new(),
-                            focused: false,
-                            just_pasted: false,
-                            copied_to_clipboard: false,
-                            scroll_y: 0,
-                            action_selection: InvoiceNotificationActionSelection::Primary,
-                        };
+                        let notification = order_message_to_waiting_notification(msg);
+                        let waiting_action = notification.action.clone();
                         app.mode = UiMode::NewMessageNotification(
                             notification,
-                            invoice_popup_action,
+                            waiting_action,
                             invoice_state,
                         );
                     }

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -298,6 +298,13 @@ pub fn handle_enter_message_notification(
             // Primary path for PayBondInvoice is acknowledgement: close popup.
             app.mode = role_default_mode(app.user_role);
         }
+        Action::WaitingSellerToPay | Action::WaitingBuyerInvoice => {
+            if should_send_cancel_from_invoice_popup(invoice_state.action_selection) {
+                spawn_cancel_from_notification(app, ctx, order_id);
+                return;
+            }
+            app.mode = role_default_mode(app.user_role);
+        }
         _ => {
             let _ = ctx
                 .order_result_tx

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -967,7 +967,11 @@ pub fn handle_key_event(
                 }
                 UiMode::NewMessageNotification(
                     _,
-                    Action::AddInvoice | Action::PayInvoice | Action::PayBondInvoice,
+                    Action::AddInvoice
+                    | Action::PayInvoice
+                    | Action::PayBondInvoice
+                    | Action::WaitingSellerToPay
+                    | Action::WaitingBuyerInvoice,
                     ref mut invoice_state,
                 ) => {
                     return Some(update_invoice_notification_action_selection(

--- a/src/ui/message_notification.rs
+++ b/src/ui/message_notification.rs
@@ -499,6 +499,95 @@ fn render_pay_bond_invoice(
     );
 }
 
+/// Inset a rect horizontally so wrapped text does not touch popup borders.
+fn inset_horizontal(area: Rect, pad: u16) -> Rect {
+    if area.width <= pad.saturating_mul(2) {
+        return area;
+    }
+    Rect {
+        x: area.x.saturating_add(pad),
+        y: area.y,
+        width: area.width.saturating_sub(pad.saturating_mul(2)),
+        height: area.height,
+    }
+}
+
+/// Waiting-phase popup when the local user has no invoice/payment action yet.
+fn render_waiting_phase_popup(
+    f: &mut ratatui::Frame,
+    popup: Rect,
+    notification: &MessageNotification,
+    invoice_state: &InvoiceInputState,
+) {
+    let [inner] = Layout::new(Direction::Vertical, [Constraint::Min(0)])
+        .margin(1)
+        .areas(popup);
+
+    let chunks = Layout::new(
+        Direction::Vertical,
+        [
+            Constraint::Length(1), // order id
+            Constraint::Length(1), // phase label
+            Constraint::Length(1), // spacer
+            Constraint::Length(5), // description (fixed height; avoids pushing buttons down)
+            Constraint::Length(1), // spacer before buttons
+            Constraint::Length(3), // action buttons
+            Constraint::Length(1), // help text
+        ],
+    )
+    .split(inner);
+
+    let order_id_str = helpers::format_order_id(notification.order_id);
+    render_order_id_header(f, chunks[0], &order_id_str);
+
+    render_message_preview(f, chunks[1], &notification.message_preview, true);
+
+    let body_text = notification
+        .body
+        .as_deref()
+        .unwrap_or("Waiting for the counterparty. No action is required from you right now.");
+    f.render_widget(
+        Paragraph::new(body_text)
+            .style(Style::default().fg(Color::White))
+            .wrap(ratatui::widgets::Wrap { trim: true })
+            .alignment(ratatui::layout::Alignment::Center),
+        inset_horizontal(chunks[3], 2),
+    );
+
+    helpers::render_yes_no_buttons(
+        f,
+        chunks[5],
+        matches!(
+            invoice_state.action_selection,
+            InvoiceNotificationActionSelection::Primary
+        ),
+        "Ok",
+        "Cancel Order",
+    );
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Press ", Style::default()),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" to confirm, ", Style::default()),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(PRIMARY_COLOR)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" to dismiss", Style::default()),
+        ]))
+        .alignment(ratatui::layout::Alignment::Center),
+        chunks[6],
+    );
+}
+
 /// Renders default notification popup for other actions
 fn render_default_notification(
     f: &mut ratatui::Frame,
@@ -575,6 +664,8 @@ pub fn render_message_notification(
         }
         // Bond popup is one row taller for the "Locked, not spent" explanation line.
         mostro_core::prelude::Action::PayBondInvoice => (90, 20),
+        mostro_core::prelude::Action::WaitingSellerToPay
+        | mostro_core::prelude::Action::WaitingBuyerInvoice => (90, 16),
         _ => (70, 8),
     };
 
@@ -585,6 +676,8 @@ pub fn render_message_notification(
         mostro_core::prelude::Action::AddInvoice => "📝 Invoice Request",
         mostro_core::prelude::Action::PayInvoice => "💳 Payment Request",
         mostro_core::prelude::Action::PayBondInvoice => "🛡️ Anti-abuse Bond Invoice",
+        mostro_core::prelude::Action::WaitingSellerToPay
+        | mostro_core::prelude::Action::WaitingBuyerInvoice => "📋 Trade Status",
         _ => "📨 New Message",
     };
 
@@ -603,6 +696,10 @@ pub fn render_message_notification(
         }
         mostro_core::prelude::Action::PayBondInvoice => {
             render_pay_bond_invoice(f, popup, notification, invoice_state);
+        }
+        mostro_core::prelude::Action::WaitingSellerToPay
+        | mostro_core::prelude::Action::WaitingBuyerInvoice => {
+            render_waiting_phase_popup(f, popup, notification, invoice_state);
         }
         _ => {
             render_default_notification(f, popup, notification);

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -1254,7 +1254,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Buy),
             Some(true),
         );
-        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+        assert!(!local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayInvoice
+        ));
     }
 
     #[test]
@@ -1264,7 +1267,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Buy),
             Some(false),
         );
-        assert!(local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+        assert!(local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayInvoice
+        ));
     }
 
     #[test]
@@ -1274,7 +1280,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Sell),
             Some(true),
         );
-        assert!(local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+        assert!(local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayInvoice
+        ));
     }
 
     #[test]
@@ -1284,7 +1293,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Sell),
             Some(false),
         );
-        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+        assert!(!local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayInvoice
+        ));
     }
 
     #[test]
@@ -1294,7 +1306,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Buy),
             Some(true),
         );
-        assert!(local_user_must_act_on_invoice_popup(&m, &Action::AddInvoice));
+        assert!(local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::AddInvoice
+        ));
     }
 
     #[test]
@@ -1304,7 +1319,10 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Sell),
             Some(false),
         );
-        assert!(local_user_must_act_on_invoice_popup(&m, &Action::AddInvoice));
+        assert!(local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::AddInvoice
+        ));
     }
 
     #[test]
@@ -1314,6 +1332,9 @@ mod invoice_popup_role_tests {
             Some(mostro_core::order::Kind::Buy),
             Some(true),
         );
-        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayBondInvoice));
+        assert!(!local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayBondInvoice
+        ));
     }
 }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -294,7 +294,10 @@ pub struct OrderMessage {
     pub buyer_invoice: Option<String>,
     /// Book side (`buy` / `sell`) for this trade, carried across DMs that omit `Payload::Order`.
     pub order_kind: Option<mostro_core::order::Kind>,
-    /// `true` = maker (created the order), `false` = taker, from local DB when known.
+    /// `true` = maker (created the order), `false` = taker.
+    ///
+    /// `None` = role not hydrated yet (e.g. first take-order DM before `save_order(false)`).
+    /// Populated from SQLite in the trade-DM listener after upsert (see `util::dm_utils`).
     pub is_mine: Option<bool>,
     /// Last known Mostro order status for this trade (payload or DB).
     pub order_status: Option<mostro_core::order::Status>,
@@ -362,6 +365,10 @@ pub fn invoice_popup_allowed_for_order_status(
 }
 
 /// Whether the local user must act on an invoice/payment popup (`AddInvoice`, `PayInvoice`, `PayBondInvoice`).
+///
+/// Buy/sell listing kind swaps which side is maker vs taker for each action. When [`OrderMessage::is_mine`]
+/// is still `None`, we assume **taker** (same as the Messages timeline): safe for the common pre-`save_order`
+/// take-order race; once the DM listener hydrates role from SQLite, `Some(true/false)` drives the decision.
 #[must_use]
 pub fn local_user_must_act_on_invoice_popup(msg: &OrderMessage, popup_action: &Action) -> bool {
     let is_maker = msg.is_mine.unwrap_or(false);
@@ -1335,6 +1342,35 @@ mod invoice_popup_role_tests {
         assert!(!local_user_must_act_on_invoice_popup(
             &m,
             &Action::PayBondInvoice
+        ));
+    }
+
+    /// When `is_mine` is still `None` (pre-`save_order` hydration), timeline defaults to taker;
+    /// buy taker must still see PayInvoice as actionable.
+    #[test]
+    fn buy_taker_unknown_role_still_acts_on_pay_invoice() {
+        let m = sample_order_message(
+            Action::PayInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            None,
+        );
+        assert!(local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::PayInvoice
+        ));
+    }
+
+    /// Unknown role must not be treated as maker for buy AddInvoice (would block maker popup).
+    #[test]
+    fn buy_maker_unknown_role_does_not_act_on_add_invoice_via_taker_default() {
+        let m = sample_order_message(
+            Action::AddInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            None,
+        );
+        assert!(!local_user_must_act_on_invoice_popup(
+            &m,
+            &Action::AddInvoice
         ));
     }
 }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -324,6 +324,8 @@ pub struct MessageNotification {
     pub action: Action,
     pub sat_amount: Option<i64>,
     pub invoice: Option<String>,
+    /// Long explanatory text for waiting-phase popups.
+    pub body: Option<String>,
 }
 
 /// Whether an invoice modal is appropriate for the current trade phase.
@@ -357,6 +359,112 @@ pub fn invoice_popup_allowed_for_order_status(
         ),
         _ => false,
     }
+}
+
+/// Whether the local user must act on an invoice/payment popup (`AddInvoice`, `PayInvoice`, `PayBondInvoice`).
+#[must_use]
+pub fn local_user_must_act_on_invoice_popup(msg: &OrderMessage, popup_action: &Action) -> bool {
+    let is_maker = msg.is_mine.unwrap_or(false);
+    match (msg.order_kind, popup_action) {
+        (Some(mostro_core::order::Kind::Buy), Action::AddInvoice) => is_maker,
+        (Some(mostro_core::order::Kind::Buy), Action::PayInvoice | Action::PayBondInvoice) => {
+            !is_maker
+        }
+        (Some(mostro_core::order::Kind::Sell), Action::AddInvoice) => !is_maker,
+        (Some(mostro_core::order::Kind::Sell), Action::PayInvoice | Action::PayBondInvoice) => {
+            is_maker
+        }
+        (None, Action::PayInvoice | Action::PayBondInvoice) => msg
+            .buyer_invoice
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        (None, Action::AddInvoice) => false,
+        _ => false,
+    }
+}
+
+/// Explanatory text when the local user is waiting on the counterparty (no invoice action required).
+#[must_use]
+pub fn waiting_phase_description(msg: &OrderMessage) -> &'static str {
+    let is_maker = msg.is_mine.unwrap_or(false);
+    let action = msg.message.get_inner_message_kind().action.clone();
+    match (msg.order_kind, is_maker, action) {
+        (
+            Some(mostro_core::order::Kind::Buy),
+            true,
+            Action::WaitingSellerToPay | Action::PayInvoice,
+        ) => "Your order was taken. Waiting for the seller to pay the hold invoice. You will be prompted to add your Lightning invoice when it is your turn.",
+        (
+            Some(mostro_core::order::Kind::Sell),
+            false,
+            Action::WaitingSellerToPay | Action::PayInvoice,
+        ) => "Waiting for the seller to pay the hold invoice.",
+        (
+            Some(mostro_core::order::Kind::Buy),
+            false,
+            Action::WaitingBuyerInvoice | Action::AddInvoice,
+        ) => "Waiting for the buyer to add their Lightning invoice.",
+        (
+            Some(mostro_core::order::Kind::Sell),
+            true,
+            Action::WaitingBuyerInvoice | Action::AddInvoice,
+        ) => "Waiting for the buyer to add their Lightning invoice.",
+        (_, true, Action::PayBondInvoice) => {
+            "Waiting for the taker to pay the anti-abuse bond."
+        }
+        _ => "Waiting for the counterparty. No action is required from you right now.",
+    }
+}
+
+/// Short phase title for waiting-phase popups.
+#[must_use]
+pub fn waiting_phase_short_label(msg: &OrderMessage) -> &'static str {
+    let is_maker = msg.is_mine.unwrap_or(false);
+    let action = msg.message.get_inner_message_kind().action.clone();
+    match (msg.order_kind, is_maker, action) {
+        (_, true, Action::PayBondInvoice) => "Waiting for Taker Bond",
+        (
+            Some(mostro_core::order::Kind::Buy),
+            true,
+            Action::WaitingSellerToPay | Action::PayInvoice,
+        )
+        | (
+            Some(mostro_core::order::Kind::Sell),
+            false,
+            Action::WaitingSellerToPay | Action::PayInvoice,
+        ) => "Waiting for Seller to Pay",
+        (
+            Some(mostro_core::order::Kind::Buy),
+            false,
+            Action::WaitingBuyerInvoice | Action::AddInvoice,
+        )
+        | (
+            Some(mostro_core::order::Kind::Sell),
+            true,
+            Action::WaitingBuyerInvoice | Action::AddInvoice,
+        ) => "Waiting for Buyer to Add Invoice",
+        _ => "Trade status",
+    }
+}
+
+/// UI action for a waiting-phase popup (preserves phase semantics for rendering).
+#[must_use]
+pub fn waiting_popup_action_for_message(msg: &OrderMessage) -> Action {
+    match msg.message.get_inner_message_kind().action {
+        Action::WaitingBuyerInvoice | Action::AddInvoice => Action::WaitingBuyerInvoice,
+        _ => Action::WaitingSellerToPay,
+    }
+}
+
+/// Build a waiting-phase notification from an order message row.
+#[must_use]
+pub fn order_message_to_waiting_notification(msg: &OrderMessage) -> MessageNotification {
+    let mut notification = order_message_to_notification(msg);
+    notification.message_preview = waiting_phase_short_label(msg).to_string();
+    notification.body = Some(waiting_phase_description(msg).to_string());
+    notification.action = waiting_popup_action_for_message(msg);
+    notification
 }
 
 /// State for handling invoice input in AddInvoice notifications
@@ -496,6 +604,7 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
         action,
         sat_amount: msg.sat_amount,
         invoice: msg.buyer_invoice.clone(),
+        body: None,
     }
 }
 
@@ -1109,5 +1218,102 @@ mod timeline_step_tests {
             message_trade_timeline_step(&m),
             FlowStep::SellFlowStep(StepLabelsSell::StepPendingOrder)
         );
+    }
+}
+
+#[cfg(test)]
+mod invoice_popup_role_tests {
+    use super::*;
+
+    fn sample_order_message(
+        action: Action,
+        order_kind: Option<mostro_core::order::Kind>,
+        is_mine: Option<bool>,
+    ) -> OrderMessage {
+        let keys = nostr_sdk::Keys::generate();
+        OrderMessage {
+            message: Message::new_order(None, None, None, action, None),
+            timestamp: 0,
+            sender: keys.public_key(),
+            order_id: None,
+            trade_index: 0,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind,
+            is_mine,
+            order_status: None,
+            read: false,
+            auto_popup_shown: false,
+        }
+    }
+
+    #[test]
+    fn buy_maker_waiting_seller_pay_does_not_act_on_pay_invoice() {
+        let m = sample_order_message(
+            Action::WaitingSellerToPay,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+        );
+        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+    }
+
+    #[test]
+    fn buy_taker_pays_hold_invoice() {
+        let m = sample_order_message(
+            Action::PayInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            Some(false),
+        );
+        assert!(local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+    }
+
+    #[test]
+    fn sell_maker_pays_hold_invoice() {
+        let m = sample_order_message(
+            Action::PayInvoice,
+            Some(mostro_core::order::Kind::Sell),
+            Some(true),
+        );
+        assert!(local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+    }
+
+    #[test]
+    fn sell_taker_waiting_seller_pay_does_not_act_on_pay_invoice() {
+        let m = sample_order_message(
+            Action::WaitingSellerToPay,
+            Some(mostro_core::order::Kind::Sell),
+            Some(false),
+        );
+        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayInvoice));
+    }
+
+    #[test]
+    fn buy_maker_adds_invoice() {
+        let m = sample_order_message(
+            Action::AddInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+        );
+        assert!(local_user_must_act_on_invoice_popup(&m, &Action::AddInvoice));
+    }
+
+    #[test]
+    fn sell_taker_adds_invoice() {
+        let m = sample_order_message(
+            Action::AddInvoice,
+            Some(mostro_core::order::Kind::Sell),
+            Some(false),
+        );
+        assert!(local_user_must_act_on_invoice_popup(&m, &Action::AddInvoice));
+    }
+
+    #[test]
+    fn buy_maker_does_not_pay_bond() {
+        let m = sample_order_message(
+            Action::PayBondInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+        );
+        assert!(!local_user_must_act_on_invoice_popup(&m, &Action::PayBondInvoice));
     }
 }

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -414,6 +414,35 @@ async fn upsert_order_from_trade_dm(
     }
 }
 
+/// Resolve maker/taker for [`crate::ui::OrderMessage::is_mine`] after a trade DM is stored.
+///
+/// Callers must pass SQLite **after** [`upsert_order_from_trade_dm`], not the pre-upsert snapshot
+/// (see `handle_trade_dm_for_order`).
+///
+/// # Why `Option<bool>`
+///
+/// - [`crate::util::db_utils::save_order`] always writes `is_mine` (`true` = maker, `false` = taker).
+/// - [`crate::models::Order::upsert_from_small_order_dm`] may insert a row first and defaults new
+///   rows to maker; that must not be treated as role-known until `save_order` runs.
+///
+/// # Branches
+///
+/// - **Row existed before upsert** (create/take already persisted): post-upsert `is_mine` is trusted.
+/// - **No row before upsert** (typical taker race: `TrackOrder` before `save_order(false)`): keep
+///   `None` unless an earlier Messages row already carried role; UI helpers then default to taker.
+fn effective_is_mine_for_trade_dm_message(
+    had_local_row_before_upsert: bool,
+    post_upsert_is_mine: Option<bool>,
+    prior_message_is_mine: Option<bool>,
+) -> Option<bool> {
+    if had_local_row_before_upsert {
+        // Maker after `send_new_order`, or taker after `take_order` — DB role is authoritative.
+        return post_upsert_is_mine.or(prior_message_is_mine);
+    }
+    // First DM before `save_order`: ignore upsert's maker default (`true` in SQLite).
+    prior_message_is_mine
+}
+
 /// Handle a single decoded trade DM for a given order/trade index.
 #[allow(clippy::too_many_arguments)]
 async fn handle_trade_dm_for_order(
@@ -436,7 +465,10 @@ async fn handle_trade_dm_for_order(
         return;
     }
 
+    // Snapshot before upsert: used for status/cancel paths and to detect whether `save_order`
+    // already established maker/taker (vs a DM-only row inserted below).
     let db_order = Order::get_by_id(pool, &order_id.to_string()).await.ok();
+    let had_local_row_before_upsert = db_order.is_some();
     let status_from_db = db_order
         .as_ref()
         .and_then(|r| r.status.as_ref().and_then(|s| Status::from_str(s).ok()));
@@ -592,8 +624,18 @@ async fn handle_trade_dm_for_order(
         }
     }
 
-    // `Order.is_mine` is `bool` (not `Option<bool>`) so taker (`false`) is never confused with “unknown”.
-    let effective_is_mine = db_order.as_ref().map(|r| r.is_mine).or(prior_is_mine);
+    // Re-read after upsert so `OrderMessage.is_mine` matches SQLite once `save_order` ran.
+    // Without this, we kept the pre-upsert `db_order` snapshot and makers could stay `None`
+    // while invoice/waiting popups gated on [`crate::ui::orders::local_user_must_act_on_invoice_popup`].
+    let post_upsert_is_mine = Order::get_by_id(pool, &order_id.to_string())
+        .await
+        .ok()
+        .map(|r| r.is_mine);
+    let effective_is_mine = effective_is_mine_for_trade_dm_message(
+        had_local_row_before_upsert,
+        post_upsert_is_mine,
+        prior_is_mine,
+    );
 
     let baseline_status = status_from_db.or(prior_order_status);
     let should_accept_candidate = status_candidate
@@ -1570,12 +1612,41 @@ pub async fn listen_for_order_messages(
 
 #[cfg(test)]
 mod tests {
-    use super::trade_message_is_terminal;
+    use super::{effective_is_mine_for_trade_dm_message, trade_message_is_terminal};
     use mostro_core::prelude::{Action, Message};
 
     #[test]
     fn action_only_canceled_is_terminal() {
         let message = Message::new_order(None, None, None, Action::Canceled, None);
         assert!(trade_message_is_terminal(&message));
+    }
+
+    #[test]
+    fn effective_is_mine_uses_post_upsert_db_when_row_existed() {
+        assert_eq!(
+            effective_is_mine_for_trade_dm_message(true, Some(true), None),
+            Some(true)
+        );
+        assert_eq!(
+            effective_is_mine_for_trade_dm_message(true, Some(false), None),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn effective_is_mine_ignores_dm_upsert_default_without_prior_save_order_row() {
+        // DM-only insert defaults to maker in SQLite; do not treat as authoritative yet.
+        assert_eq!(
+            effective_is_mine_for_trade_dm_message(false, Some(true), None),
+            None
+        );
+    }
+
+    #[test]
+    fn effective_is_mine_keeps_prior_message_role_before_db_row() {
+        assert_eq!(
+            effective_is_mine_for_trade_dm_message(false, Some(true), Some(false)),
+            Some(false)
+        );
     }
 }

--- a/src/util/dm_utils/notifications_ch_mng.rs
+++ b/src/util/dm_utils/notifications_ch_mng.rs
@@ -58,6 +58,8 @@ fn check_if_popup_should_be_shown(notification: &MessageNotification, app: &AppS
             return false;
         }
 
+        // Role-aware gate: counterparty waiting on hold/bond/invoice should not get an input popup.
+        // Relies on `order_msg.is_mine` hydrated in the trade-DM path (post-upsert DB read).
         if !local_user_must_act_on_invoice_popup(order_msg, &notification.action) {
             log::debug!(
                 "[popup] suppressed invoice modal for {:?}: local user is not the acting party",

--- a/src/util/dm_utils/notifications_ch_mng.rs
+++ b/src/util/dm_utils/notifications_ch_mng.rs
@@ -1,9 +1,9 @@
 // Notifications channel manager - handles message notifications from async tasks
 use crate::settings::load_settings_from_disk;
+use crate::ui::orders::BuyerInvoicePreference;
 use crate::ui::orders::{
     invoice_popup_allowed_for_order_status, local_user_must_act_on_invoice_popup,
 };
-use crate::ui::orders::BuyerInvoicePreference;
 use crate::ui::{
     AppState, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification, UiMode,
 };

--- a/src/util/dm_utils/notifications_ch_mng.rs
+++ b/src/util/dm_utils/notifications_ch_mng.rs
@@ -1,6 +1,8 @@
 // Notifications channel manager - handles message notifications from async tasks
 use crate::settings::load_settings_from_disk;
-use crate::ui::orders::invoice_popup_allowed_for_order_status;
+use crate::ui::orders::{
+    invoice_popup_allowed_for_order_status, local_user_must_act_on_invoice_popup,
+};
 use crate::ui::orders::BuyerInvoicePreference;
 use crate::ui::{
     AppState, InvoiceInputState, InvoiceNotificationActionSelection, MessageNotification, UiMode,
@@ -52,6 +54,14 @@ fn check_if_popup_should_be_shown(notification: &MessageNotification, app: &AppS
                 "[popup] suppressed invoice modal for {:?} (order_status={:?})",
                 notification.action,
                 order_msg.order_status
+            );
+            return false;
+        }
+
+        if !local_user_must_act_on_invoice_popup(order_msg, &notification.action) {
+            log::debug!(
+                "[popup] suppressed invoice modal for {:?}: local user is not the acting party",
+                notification.action,
             );
             return false;
         }

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -203,6 +203,7 @@ pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) 
             action: action.clone(),
             sat_amount: *sat_amount,
             invoice: Some(invoice.clone()),
+            body: None,
         };
 
         let invoice_state = InvoiceInputState {


### PR DESCRIPTION
## Summary

Invoice and payment popups were shown to both maker and taker even when only one party must act (e.g. buy maker seeing a Pay Invoice modal while waiting for the seller). This PR gates popups on **who must act** and adds a **waiting-phase** modal when the local user only needs to wait.

- Add `local_user_must_act_on_invoice_popup` with buy/sell maker/taker rules for `AddInvoice`, `PayInvoice`, and `PayBondInvoice`
- When the user must not act, show a **Trade Status** waiting popup (`WaitingSellerToPay` / `WaitingBuyerInvoice`) with phase-specific title and body text instead of an invoice input form
- Suppress auto-popups in the notifications channel when the local user is not the acting party
- Support Ok / Cancel Order on waiting-phase popups (same selection UX as bond/invoice modals)
- Unit tests for role-based popup eligibility

## Motivation

Early trade phases assign different actions to maker vs taker. Showing payment/invoice forms to the wrong party is confusing and can imply action is required when the user should only wait for the counterparty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice and payment notifications now distinguish between actions the user must complete and scenarios where they're waiting for the other party.
  * Added "Trade Status" notification popups that display waiting states for invoice and payment workflows with order details and action options.
  * Enhanced keyboard navigation (left/right arrow keys) for managing invoice and payment notification action selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostrix/pull/73)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->