### PR TITLE
fix(dm): handle NewOrder book republish after pre-Active taker cancel

### DIFF
--- a/docs/DM_LISTENER_FLOW.md
+++ b/docs/DM_LISTENER_FLOW.md
@@ -160,7 +160,14 @@ This function is where `OrderMessage` is created/updated and pushed into `messag
 Key behaviors:
 
 - **Early return for non-trade hydration actions**  
-  `Action::NewOrder` and **`Action::CantDo`** return immediately (same as book-side noise). **`CantDo`** is an error response from Mostro (`Payload::CantDo`); it is handled on the **waiter** path (`order_utils/helper.rs` → user-facing `OperationResult`) and must **not** upsert SQLite or replace the per-order Messages row. Treating `CantDo` like a normal trade DM caused bogus order hydration after failed takes or invalid actions.
+  **`Action::CantDo`** returns immediately. It is an error response from Mostro (`Payload::CantDo`); it is handled on the **waiter** path (`order_utils/helper.rs` → user-facing `OperationResult`) and must **not** upsert SQLite or replace the per-order Messages row.
+
+- **Trade-DM `Action::NewOrder` (special cases only)**  
+  Create-order `NewOrder` uses the **waiter** path (`send_new_order`), not this listener. On a tracked trade subscription, `try_handle_new_order_trade_dm` handles only:
+  - pre-Active **taker** republish → delete stale take row and remove from Messages;
+  - pre-Active **maker** republish → revert DB to `pending`, remove from Messages, refresh My Trades maker-book cache;
+  - **range child** listing (`Payload::Order` + `pending`, no local row) → `save_order` + track.
+  When that helper returns `false`, the message continues through generic trade-DM hydration. Replayed `NewOrder` must not replace an established non-`NewOrder` Messages row (`new_order_would_regress_messages_row`).
 
 - **DB refresh/upsert for certain actions**  
   For `add-invoice`, `pay-invoice`, and **`pay-bond-invoice`** (Mostro Phase 1.5+ anti-abuse bond) where the payload embeds an order, the listener persists/upserts the order row (including request id when available). `pay-bond-invoice` is additionally allow-listed for null `request_id` DMs (`src/util/order_utils/helper.rs`) since Mostro emits these unsolicited after a take.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use crate::settings::{init_settings, Settings};
 use crate::ui::helpers::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     expire_attachment_toast, hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
-    load_user_order_chats_at_startup, sync_user_order_history_messages_from_db,
+    load_user_order_chats_at_startup, refresh_my_trades_maker_book_cache,
+    sync_user_order_history_messages_from_db,
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
@@ -29,7 +30,8 @@ use crate::util::{
         spawn_admin_chat_fetch, spawn_user_order_chat_fetch, start_fetch_scheduler,
         validate_range_amount, FetchSchedulerResult,
     },
-    set_dm_router_cmd_tx, set_fatal_error_tx, spawn_save_attachment, StartupDmHydration,
+    set_dm_router_cmd_tx, set_fatal_error_tx, set_order_result_tx, spawn_save_attachment,
+    StartupDmHydration,
 };
 use crossterm::event::EventStream;
 use mostro_core::prelude::*;
@@ -208,6 +210,7 @@ async fn main() -> Result<(), anyhow::Error> {
     set_dm_router_cmd_tx(dm_subscription_tx.clone()).map_err(|msg| {
         anyhow::anyhow!("{msg}: DM router sender was not registered; restart the application.")
     })?;
+    set_order_result_tx(order_result_tx.clone()).map_err(|msg| anyhow::anyhow!(msg))?;
 
     // Configure Nostr client.
     let my_keys = settings
@@ -437,8 +440,19 @@ async fn main() -> Result<(), anyhow::Error> {
                     // flows. Do not tie this to arbitrary `OperationResult::Success`.
                     let resync_my_trades_from_db =
                         matches!(&result, OperationResult::OrderHistoryDeleted { .. });
+                    let refresh_maker_book_cache = matches!(
+                        &result,
+                        OperationResult::MyTradesMakerBookChanged
+                            | OperationResult::Success(_)
+                    );
 
-                    handle_operation_result(result, &mut app);
+                    if refresh_maker_book_cache && app.user_role == UserRole::User {
+                        refresh_my_trades_maker_book_cache(&pool, &mut app).await;
+                    }
+
+                    if !matches!(result, OperationResult::MyTradesMakerBookChanged) {
+                        handle_operation_result(result, &mut app);
+                    }
                     if resync_my_trades_from_db && app.user_role == UserRole::User {
                         sync_user_order_history_messages_from_db(&pool, &mut app).await;
                     }

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -13,6 +13,7 @@ use crate::ui::chat::{
     AdminChatLastSeen, ChatParty, DisputeChatMessage, DisputeFilter, OrderChatLastSeen,
     UserOrderChatMessage,
 };
+use crate::ui::helpers::OrderChatListItem;
 use crate::ui::navigation::{Tab, UserRole};
 use crate::ui::orders::{
     BuyerInvoicePreference, InvoiceInputState, KeyInputState, MessageNotification,
@@ -163,6 +164,8 @@ pub struct AppState {
     pub order_chat_input_enabled: bool,
     /// Per-order static header (id, kind, created_at, trade index, initiator) from take/create and DB.
     pub order_chat_static: HashMap<Uuid, OrderChatStaticHeader>,
+    /// Maker `pending` listings on the book without a trade-DM row in Messages (refreshed on events).
+    pub my_trades_maker_book: Vec<OrderChatListItem>,
     pub order_chats: HashMap<String, Vec<UserOrderChatMessage>>, // Chat messages per order id
     pub order_chat_scrollview_state: tui_scrollview::ScrollViewState,
     pub order_chat_selected_message_idx: Option<usize>,
@@ -245,6 +248,7 @@ impl AppState {
             order_chat_input: String::new(),
             order_chat_input_enabled: true,
             order_chat_static: HashMap::new(),
+            my_trades_maker_book: Vec::new(),
             order_chats: HashMap::new(),
             order_chat_scrollview_state: tui_scrollview::ScrollViewState::default(),
             order_chat_selected_message_idx: None,

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -24,10 +24,13 @@ pub use formatting::{format_order_id, format_user_rating, is_dispute_finalized};
 pub use layout::{
     create_centered_popup, render_help_text, render_yes_no_buttons, render_yes_no_cancel_buttons,
 };
-pub use order_chat_projection::{build_active_order_chat_list, OrderChatListItem};
+pub use order_chat_projection::{
+    active_order_chat_list_len, active_order_chat_list_snapshot, build_active_order_chat_list,
+    order_chat_list_item_from_db_order, OrderChatListItem,
+};
 pub use startup::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
     hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
     load_user_order_chats_at_startup, recover_admin_chat_from_files,
-    sync_user_order_history_messages_from_db,
+    refresh_my_trades_maker_book_cache, sync_user_order_history_messages_from_db,
 };

--- a/src/ui/helpers/order_chat_projection.rs
+++ b/src/ui/helpers/order_chat_projection.rs
@@ -1,9 +1,11 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use mostro_core::prelude::{Payload, Peer, SmallOrder, Status, UserInfo};
 
-use crate::ui::OrderMessage;
+use crate::models::Order;
+use crate::ui::{AppState, OrderMessage};
 
 /// One row in the My Trades sidebar, derived from order DMs. Live status, amounts, and `Payload::Peer`
 /// ratings. Static id/kind/created/trade/initiator come from [`crate::ui::AppState::order_chat_static`].
@@ -22,6 +24,35 @@ pub struct OrderChatListItem {
     /// Reputation for the buyer/seller trade pubkey when the daemon sent `Payload::Peer` with matching pubkey.
     pub buyer_reputation: Option<UserInfo>,
     pub seller_reputation: Option<UserInfo>,
+}
+
+/// Maker listings back on the book (`pending`) with no active trade-DM row in Messages.
+#[must_use]
+pub fn order_chat_list_item_from_db_order(order: &Order) -> Option<OrderChatListItem> {
+    if !order.is_mine {
+        return None;
+    }
+    let status = order
+        .status
+        .as_deref()
+        .and_then(|s| Status::from_str(s).ok());
+    if status != Some(Status::Pending) {
+        return None;
+    }
+    let order_id = order.id.as_deref()?.to_string();
+    Some(OrderChatListItem {
+        order_id,
+        status,
+        amount: Some(order.amount),
+        fiat: Some((order.fiat_amount, order.fiat_code.clone())),
+        trade_index: order.trade_index,
+        payment_method: Some(order.payment_method.clone()),
+        premium: Some(order.premium),
+        buyer_trade_pubkey: None,
+        seller_trade_pubkey: None,
+        buyer_reputation: None,
+        seller_reputation: None,
+    })
 }
 
 fn merge_order_fields(entry: &mut OrderChatListItem, order: &SmallOrder, msg: &OrderMessage) {
@@ -69,11 +100,19 @@ fn status_from_message(msg: &OrderMessage) -> Option<Status> {
     msg.order_status
 }
 
-/// Shared projection for the "My Trades" sidebar and Enter/action handlers.
-///
-/// Important: ordering must stay stable and match the sidebar ordering, otherwise
-/// `selected_order_chat_idx` can desync from the action target.
-pub fn build_active_order_chat_list(messages: &[OrderMessage]) -> Vec<OrderChatListItem> {
+fn sort_order_chat_rows(rows: &mut [OrderChatListItem]) {
+    rows.sort_by(|a, b| match (a.trade_index, b.trade_index) {
+        (Some(ia), Some(ib)) => match ib.cmp(&ia) {
+            Ordering::Equal => a.order_id.cmp(&b.order_id),
+            o => o,
+        },
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a.order_id.cmp(&b.order_id),
+    });
+}
+
+fn build_order_chat_list_from_messages(messages: &[OrderMessage]) -> Vec<OrderChatListItem> {
     let mut by_order: HashMap<String, OrderChatListItem> = HashMap::new();
     for msg in messages {
         let Some(order_id) = msg.order_id else {
@@ -101,17 +140,55 @@ pub fn build_active_order_chat_list(messages: &[OrderMessage]) -> Vec<OrderChatL
                 entry
             });
     }
+    by_order.into_values().collect()
+}
 
-    let mut rows: Vec<OrderChatListItem> = by_order.into_values().collect();
-    // Newest trades first: higher NIP-06 trade index ⇒ more recently allocated key.
-    rows.sort_by(|a, b| match (a.trade_index, b.trade_index) {
-        (Some(ia), Some(ib)) => match ib.cmp(&ia) {
-            Ordering::Equal => a.order_id.cmp(&b.order_id),
-            o => o,
-        },
-        (Some(_), None) => Ordering::Less,
-        (None, Some(_)) => Ordering::Greater,
-        (None, None) => a.order_id.cmp(&b.order_id),
-    });
+/// Append maker-on-book rows that have no trade-DM row in Messages (DM rows win on duplicate id).
+fn append_maker_book_rows_without_dm(
+    rows: &mut Vec<OrderChatListItem>,
+    maker_book: &[OrderChatListItem],
+) {
+    let message_ids: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.order_id.clone()).collect();
+    for item in maker_book {
+        if !message_ids.contains(&item.order_id) {
+            rows.push(item.clone());
+        }
+    }
+}
+
+/// Shared projection for the "My Trades" sidebar and Enter/action handlers.
+///
+/// Trade DMs in `messages` take precedence; `maker_book` fills maker `pending` rows with no DM row
+/// (e.g. after a pre-Active taker cancel republish).
+///
+/// Important: ordering must stay stable and match the sidebar ordering, otherwise
+/// `selected_order_chat_idx` can desync from the action target.
+pub fn build_active_order_chat_list(
+    messages: &[OrderMessage],
+    maker_book: &[OrderChatListItem],
+) -> Vec<OrderChatListItem> {
+    let mut rows = build_order_chat_list_from_messages(messages);
+    append_maker_book_rows_without_dm(&mut rows, maker_book);
+    sort_order_chat_rows(&mut rows);
     rows
+}
+
+/// My Trades row count from the shared projection (navigation clamping).
+#[must_use]
+pub fn active_order_chat_list_len(app: &AppState) -> usize {
+    match app.messages.lock() {
+        Ok(g) => build_active_order_chat_list(&g, &app.my_trades_maker_book).len(),
+        Err(_) => 0,
+    }
+}
+
+/// My Trades sidebar/action projection from current [`AppState`] (clones `messages` once).
+#[must_use]
+pub fn active_order_chat_list_snapshot(app: &AppState) -> Vec<OrderChatListItem> {
+    let messages = match app.messages.lock() {
+        Ok(g) => g.clone(),
+        Err(_) => return Vec::new(),
+    };
+    build_active_order_chat_list(&messages, &app.my_trades_maker_book)
 }

--- a/src/ui/helpers/order_chat_projection.rs
+++ b/src/ui/helpers/order_chat_projection.rs
@@ -174,21 +174,35 @@ pub fn build_active_order_chat_list(
     rows
 }
 
+fn fatal_on_poisoned_messages_lock(e: impl std::fmt::Display) {
+    crate::util::request_fatal_restart(format!(
+        "Mostrix encountered an internal error (poisoned messages lock: {e}). Please restart the app."
+    ));
+}
+
 /// My Trades row count from the shared projection (navigation clamping).
 #[must_use]
 pub fn active_order_chat_list_len(app: &AppState) -> usize {
     match app.messages.lock() {
-        Ok(g) => build_active_order_chat_list(&g, &app.my_trades_maker_book).len(),
-        Err(_) => 0,
+        Ok(guard) => build_active_order_chat_list(&guard, &app.my_trades_maker_book).len(),
+        Err(e) => {
+            fatal_on_poisoned_messages_lock(e);
+            0
+        }
     }
 }
 
 /// My Trades sidebar/action projection from current [`AppState`] (clones `messages` once).
 #[must_use]
 pub fn active_order_chat_list_snapshot(app: &AppState) -> Vec<OrderChatListItem> {
-    let messages = match app.messages.lock() {
-        Ok(g) => g.clone(),
-        Err(_) => return Vec::new(),
-    };
-    build_active_order_chat_list(&messages, &app.my_trades_maker_book)
+    match app.messages.lock() {
+        Ok(guard) => {
+            let messages = guard.clone();
+            build_active_order_chat_list(&messages, &app.my_trades_maker_book)
+        }
+        Err(e) => {
+            fatal_on_poisoned_messages_lock(e);
+            Vec::new()
+        }
+    }
 }

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -6,6 +6,7 @@ use nostr_sdk::prelude::{Client, Keys, PublicKey};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
+use super::order_chat_projection::order_chat_list_item_from_db_order;
 use crate::models::{AdminDispute, Order, User};
 use crate::ui::{
     AdminChatLastSeen, AdminChatUpdate, AppState, ChatParty, ChatSender, DisputeChatMessage,
@@ -148,6 +149,25 @@ pub async fn load_user_order_chats_at_startup(
         .await
         .unwrap_or_default();
     apply_user_order_chat_updates(app, updates);
+    refresh_my_trades_maker_book_cache(pool, app).await;
+}
+
+/// Rebuild [`crate::ui::AppState::my_trades_maker_book`] from SQLite (maker + `pending` only).
+pub async fn refresh_my_trades_maker_book_cache(pool: &SqlitePool, app: &mut AppState) {
+    let rows = match Order::get_user_history_orders(pool).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            log::warn!(
+                "Failed to load orders for My Trades maker-book cache: {}",
+                e
+            );
+            return;
+        }
+    };
+    app.my_trades_maker_book = rows
+        .iter()
+        .filter_map(order_chat_list_item_from_db_order)
+        .collect();
 }
 
 fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<OrderMessage> {
@@ -163,8 +183,6 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         .as_deref()
         .and_then(|k| OrderKind::from_str(k).ok());
 
-    // Use non-NewOrder actions for history projection so My Trades can be DB-fed
-    // without polluting Messages-tab rows that are intentionally stripped.
     let action = match kind {
         Some(OrderKind::Buy) => Action::TakeBuy,
         Some(OrderKind::Sell) => Action::TakeSell,
@@ -212,7 +230,6 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         is_mine: Some(order.is_mine),
         order_status: status,
         read: true,
-        // This is need to avoid the missing visualization of the invoice popup when the order is in the WaitingBuyerInvoice status
         auto_popup_shown: !matches!(status, Some(Status::WaitingBuyerInvoice)),
     };
     Some(history_message)

--- a/src/ui/key_handler/chat_helpers.rs
+++ b/src/ui/key_handler/chat_helpers.rs
@@ -1,4 +1,4 @@
-use crate::ui::helpers::build_active_order_chat_list;
+use crate::ui::helpers::active_order_chat_list_snapshot;
 use crate::ui::{
     helpers::message_visible_for_party, AdminMode, AppState, ChatParty, MessageViewState,
     OperationResult, RatingOrderState, UiMode, ViewingMessageButtonSelection,
@@ -125,8 +125,7 @@ pub fn resolve_selected_mytrades_order_id(app: &AppState) -> Option<Uuid> {
 
 /// Resolve selected MyTrades order id + status from the same projection used by sidebar rendering.
 pub fn resolve_selected_mytrades_order_status(app: &AppState) -> Option<(Uuid, Option<Status>)> {
-    let messages_snapshot = app.messages.lock().ok()?.clone();
-    let rows = build_active_order_chat_list(&messages_snapshot);
+    let rows = active_order_chat_list_snapshot(app);
     rows.get(app.selected_order_chat_idx).and_then(|row| {
         Uuid::parse_str(&row.order_id)
             .ok()

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -141,7 +141,7 @@ fn resolve_selected_order_chat_target(app: &AppState) -> Option<OrderChatTarget>
         }
     };
 
-    build_active_order_chat_list(&messages_snapshot)
+    build_active_order_chat_list(&messages_snapshot, &app.my_trades_maker_book)
         .get(app.selected_order_chat_idx)
         .map(|row| OrderChatTarget {
             order_id: row.order_id.clone(),

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -1,4 +1,4 @@
-use crate::ui::helpers::build_active_order_chat_list;
+use crate::ui::helpers::active_order_chat_list_len;
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::{
     AdminMode, AdminTab, AppState, FormState, Tab, UiMode, UserMode, UserRole, UserTab,
@@ -257,16 +257,12 @@ fn handle_up_key(
                     } else if app.selected_message_idx > 0 {
                         app.selected_message_idx -= 1;
                     }
-                    // Mark selected message as read
                     if let Some(msg) = messages.get_mut(app.selected_message_idx) {
                         msg.read = true;
                     }
                 }
             } else if let Tab::User(UserTab::MyTrades) = app.active_tab {
-                let n = match app.messages.lock() {
-                    Ok(g) => build_active_order_chat_list(&g).len(),
-                    Err(_) => 0,
-                };
+                let n = active_order_chat_list_len(app);
                 if n > 0 && app.selected_order_chat_idx > 0 {
                     app.selected_order_chat_idx -= 1;
                 }
@@ -412,16 +408,12 @@ fn handle_down_key(
                     } else if app.selected_message_idx < messages_len.saturating_sub(1) {
                         app.selected_message_idx += 1;
                     }
-                    // Mark selected message as read
                     if let Some(msg) = messages.get_mut(app.selected_message_idx) {
                         msg.read = true;
                     }
                 }
             } else if let Tab::User(UserTab::MyTrades) = app.active_tab {
-                let n = match app.messages.lock() {
-                    Ok(g) => build_active_order_chat_list(&g).len(),
-                    Err(_) => 0,
-                };
+                let n = active_order_chat_list_len(app);
                 if n > 0 && app.selected_order_chat_idx < n.saturating_sub(1) {
                     app.selected_order_chat_idx += 1;
                 }

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -18,7 +18,8 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
         | OperationResult::Info(_)
         | OperationResult::InvoiceSubmitted { .. }
         | OperationResult::TradeClosed { .. }
-        | OperationResult::OrderHistoryDeleted { .. } => 8,
+        | OperationResult::OrderHistoryDeleted { .. }
+        | OperationResult::MyTradesMakerBookChanged => 8,
     };
     // Center the popup using Flex::Center
     let popup = {
@@ -234,5 +235,6 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
         }
+        OperationResult::MyTradesMakerBookChanged => {}
     }
 }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -162,6 +162,8 @@ pub enum OperationResult {
         deleted_order_ids: Vec<uuid::Uuid>,
         message: String,
     },
+    /// Rebuild [`crate::ui::AppState::my_trades_maker_book`] from SQLite (no UI popup).
+    MyTradesMakerBookChanged,
 }
 
 /// Result of async Lightning address LNURL verification and save (settings flow; not order/dispute).

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -15,7 +15,7 @@ use crate::ui::constants::{
     FOOTER_MYTRADES_SHIFT_I_ENABLE, FOOTER_MYTRADES_SHIFT_R_RELEASE, FOOTER_MYTRADES_SHIFT_V_RATE,
     HELP_KEY,
 };
-use crate::ui::helpers::{build_active_order_chat_list, format_user_rating};
+use crate::ui::helpers::{active_order_chat_list_snapshot, format_user_rating};
 use crate::ui::UserOrderChatMessage;
 use crate::ui::{AppState, UiMode, UserChatSender, UserMode};
 use crate::ui::{BACKGROUND_COLOR, PRIMARY_COLOR};
@@ -136,11 +136,7 @@ fn build_order_chat_content(
 }
 
 pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut AppState) {
-    let messages_snapshot = match app.messages.lock() {
-        Ok(g) => g.clone(),
-        Err(_) => Vec::new(),
-    };
-    let active_orders = build_active_order_chat_list(&messages_snapshot);
+    let active_orders = active_order_chat_list_snapshot(app);
 
     let chunks = Layout::new(
         Direction::Horizontal,

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -4,12 +4,14 @@
 mod dm_helpers;
 mod notifications_ch_mng;
 mod order_ch_mng;
+mod order_result_tx;
 
 pub use dm_helpers::seed_admin_chat_last_seen;
 pub use notifications_ch_mng::{
     apply_saved_ln_address_invoice_choice, handle_message_notification, present_add_invoice_popup,
 };
 pub use order_ch_mng::handle_operation_result;
+pub use order_result_tx::{set_order_result_tx, try_notify_my_trades_maker_book_changed};
 
 use anyhow::Result;
 use mostro_core::prelude::*;
@@ -27,7 +29,7 @@ use uuid::Uuid;
 use crate::models::{Order, User};
 use crate::ui::order_message_to_notification;
 use crate::ui::{MessageNotification, OrderMessage};
-use crate::util::db_utils::{delete_order_by_id, update_order_status};
+use crate::util::db_utils::{delete_order_by_id, save_order, update_order_status};
 use crate::util::filters::filter_giftwrap_to_recipient;
 use crate::util::mostro_info::{nostr_pow_from_instance, MostroInstanceInfo};
 use crate::util::order_utils::{
@@ -370,6 +372,42 @@ fn is_pre_active_status(status: Status) -> bool {
     )
 }
 
+fn order_status_from_row(row: &Order) -> Option<Status> {
+    row.status.as_ref().and_then(|s| Status::from_str(s).ok())
+}
+
+fn is_pre_active_taker_take(row: &Order) -> bool {
+    !row.is_mine
+        && order_status_from_row(row)
+            .map(is_pre_active_status)
+            .unwrap_or(false)
+}
+
+fn is_pre_active_maker_listing(row: &Order) -> bool {
+    row.is_mine
+        && order_status_from_row(row)
+            .map(is_pre_active_status)
+            .unwrap_or(false)
+}
+
+/// Drop SQLite row and Messages-tab entries for a taker take that ended before Active.
+async fn drop_pre_active_taker_take(
+    pool: &sqlx::SqlitePool,
+    messages: &Arc<Mutex<Vec<OrderMessage>>>,
+    order_id: Uuid,
+    log_context: &str,
+) {
+    if let Err(e) = delete_order_by_id(pool, &order_id.to_string()).await {
+        log::warn!(
+            "Failed to delete pre-Active taker row on {} {}: {}",
+            log_context,
+            order_id,
+            e
+        );
+    }
+    remove_order_from_messages(messages, order_id);
+}
+
 /// Refreshes the local `orders` row from embedded order data on trade DMs that carry a full
 /// `SmallOrder` (e.g. `add-invoice`, `pay-invoice`, `buyer-took-order`, `hold-invoice-payment-accepted`).
 async fn upsert_order_from_trade_dm(
@@ -392,6 +430,7 @@ async fn upsert_order_from_trade_dm(
         (Action::HoldInvoicePaymentAccepted, Some(Payload::Order(o))) => {
             ("HoldInvoicePaymentAccepted", o.clone())
         }
+        (Action::NewOrder, Some(Payload::Order(o))) => ("NewOrder", o.clone()),
         _ => return,
     };
     let msg_request_id = request_id.and_then(|u| i64::try_from(u).ok());
@@ -430,6 +469,148 @@ async fn upsert_order_from_trade_dm(
 /// - **Row existed before upsert** (create/take already persisted): post-upsert `is_mine` is trusted.
 /// - **No row before upsert** (typical taker race: `TrackOrder` before `save_order(false)`): keep
 ///   `None` unless an earlier Messages row already carried role; UI helpers then default to taker.
+fn try_send_track_order(order_id: Uuid, trade_index: i64) {
+    let Ok(guard) = DM_ROUTER_CMD_TX.lock() else {
+        return;
+    };
+    if let Some(tx) = guard.as_ref() {
+        let _ = tx.send(DmRouterCmd::TrackOrder {
+            order_id,
+            trade_index,
+        });
+    }
+}
+
+/// `NewOrder` + `Payload::Order` with `status: pending` — book republish or range child listing.
+fn small_order_pending_from_new_order_payload(payload: &Option<Payload>) -> Option<SmallOrder> {
+    match payload.as_ref()? {
+        Payload::Order(o) if o.status == Some(Status::Pending) => Some(o.clone()),
+        _ => None,
+    }
+}
+
+/// Maker listing returns to the book after a pre-Active taker cancel (`NewOrder` republish).
+async fn revert_maker_to_pending_on_book_republish(
+    pool: &sqlx::SqlitePool,
+    messages: &Arc<Mutex<Vec<OrderMessage>>>,
+    order_id: Uuid,
+    trade_index: i64,
+    inner_kind: &MessageKind,
+    trade_keys: &Keys,
+) {
+    upsert_order_from_trade_dm(
+        pool,
+        order_id,
+        &Action::NewOrder,
+        &inner_kind.payload,
+        inner_kind.request_id,
+        trade_keys,
+    )
+    .await;
+    if let Err(e) = update_order_status(pool, &order_id.to_string(), Status::Pending).await {
+        log::warn!(
+            "Failed to revert maker order {} to pending after NewOrder republish: {}",
+            order_id,
+            e
+        );
+    }
+
+    remove_order_from_messages(messages, order_id);
+    try_notify_my_trades_maker_book_changed();
+
+    log::info!(
+        "Order {} reverted to pending on book (NewOrder republish, trade_index={}); removed from Messages",
+        order_id,
+        trade_index
+    );
+}
+
+/// Range-order child listing on a fresh trade key when no local row exists yet.
+async fn persist_range_child_listing_from_new_order(
+    pool: &sqlx::SqlitePool,
+    order_id: Uuid,
+    trade_index: i64,
+    small_order: &SmallOrder,
+    request_id: u64,
+    trade_keys: &Keys,
+) -> bool {
+    if let Err(e) = save_order(
+        small_order.clone(),
+        trade_keys,
+        request_id,
+        trade_index,
+        pool,
+        true,
+    )
+    .await
+    {
+        log::error!(
+            "Failed to persist range child order {} from NewOrder DM: {}",
+            order_id,
+            e
+        );
+        return false;
+    }
+
+    try_send_track_order(order_id, trade_index);
+    try_notify_my_trades_maker_book_changed();
+
+    log::info!(
+        "Persisted new pending child listing {} from NewOrder DM (trade_index={})",
+        order_id,
+        trade_index
+    );
+    true
+}
+
+/// Handle `Action::NewOrder` on the trade-DM listener (not the create-order waiter).
+///
+/// Returns `true` when the message was consumed (caller should return).
+async fn try_handle_new_order_trade_dm(
+    messages: &Arc<Mutex<Vec<OrderMessage>>>,
+    order_id: Uuid,
+    trade_index: i64,
+    inner_kind: &MessageKind,
+    pool: &sqlx::SqlitePool,
+    trade_keys: &Keys,
+) -> bool {
+    let Some(small_order) = small_order_pending_from_new_order_payload(&inner_kind.payload) else {
+        return false;
+    };
+
+    let db_order = Order::get_by_id(pool, &order_id.to_string()).await.ok();
+
+    if let Some(ref row) = db_order {
+        if is_pre_active_taker_take(row) {
+            drop_pre_active_taker_take(pool, messages, order_id, "NewOrder book republish").await;
+            return true;
+        }
+        if is_pre_active_maker_listing(row) {
+            revert_maker_to_pending_on_book_republish(
+                pool,
+                messages,
+                order_id,
+                trade_index,
+                inner_kind,
+                trade_keys,
+            )
+            .await;
+            return true;
+        }
+        return false;
+    }
+
+    persist_range_child_listing_from_new_order(
+        pool,
+        order_id,
+        trade_index,
+        &small_order,
+        inner_kind.request_id.unwrap_or(0),
+        trade_keys,
+    )
+    .await
+}
+
 fn effective_is_mine_for_trade_dm_message(
     had_local_row_before_upsert: bool,
     post_upsert_is_mine: Option<bool>,
@@ -461,7 +642,19 @@ async fn handle_trade_dm_for_order(
 ) {
     let inner_kind = message.get_inner_message_kind();
     let action = inner_kind.action.clone();
-    if matches!(action, Action::NewOrder | Action::CantDo) {
+    if matches!(action, Action::CantDo) {
+        return;
+    }
+    if matches!(action, Action::NewOrder) {
+        let _ = try_handle_new_order_trade_dm(
+            messages,
+            order_id,
+            trade_index,
+            inner_kind,
+            pool,
+            trade_keys,
+        )
+        .await;
         return;
     }
 
@@ -469,9 +662,7 @@ async fn handle_trade_dm_for_order(
     // already established maker/taker (vs a DM-only row inserted below).
     let db_order = Order::get_by_id(pool, &order_id.to_string()).await.ok();
     let had_local_row_before_upsert = db_order.is_some();
-    let status_from_db = db_order
-        .as_ref()
-        .and_then(|r| r.status.as_ref().and_then(|s| Status::from_str(s).ok()));
+    let status_from_db = db_order.as_ref().and_then(order_status_from_row);
 
     let status_candidate = resolved_status_candidate(&action, &inner_kind.payload);
 
@@ -479,17 +670,9 @@ async fn handle_trade_dm_for_order(
     // keeping it as terminal trade state.
     if matches!(action, Action::Canceled)
         && inner_kind.payload.is_none()
-        && db_order.as_ref().map(|r| !r.is_mine).unwrap_or(false)
-        && status_from_db.map(is_pre_active_status).unwrap_or(false)
+        && db_order.as_ref().is_some_and(is_pre_active_taker_take)
     {
-        if let Err(e) = delete_order_by_id(pool, &order_id.to_string()).await {
-            log::warn!(
-                "Failed to delete pre-Active taker-canceled order {}: {}",
-                order_id,
-                e
-            );
-        }
-        remove_order_from_messages(messages, order_id);
+        drop_pre_active_taker_take(pool, messages, order_id, "Canceled").await;
         return;
     }
 
@@ -726,11 +909,7 @@ async fn handle_trade_dm_for_order(
     let should_replace_row = match &existing_message_data {
         None => true,
         Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status)) => {
-            // Never let replayed `NewOrder` replace an already-established trade row.
-            // Otherwise Messages can regress to only NewOrder rows, which the UI strips.
-            if matches!(action, Action::NewOrder) && !matches!(existing_action, Action::NewOrder) {
-                false
-            } else if timestamp > *existing_timestamp {
+            if timestamp > *existing_timestamp {
                 true
             } else if timestamp == *existing_timestamp {
                 action != *existing_action

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -563,9 +563,19 @@ async fn persist_range_child_listing_from_new_order(
     true
 }
 
+/// Returns `true` when a replayed trade-DM `NewOrder` would overwrite a non-`NewOrder` Messages row.
+fn new_order_would_regress_messages_row(action: &Action, existing_action: &Action) -> bool {
+    matches!(action, Action::NewOrder) && !matches!(existing_action, Action::NewOrder)
+}
+
 /// Handle `Action::NewOrder` on the trade-DM listener (not the create-order waiter).
 ///
-/// Returns `true` when the message was consumed (caller should return).
+/// Returns `true` only for handled special cases (caller may return early):
+/// - pre-Active taker republish (drop stale take row),
+/// - pre-Active maker republish (revert to `pending`, refresh maker-book cache),
+/// - range child listing (no local row, `save_order` ok).
+///
+/// Returns `false` for all other trade-DM `NewOrder` shapes; caller continues generic hydration.
 async fn try_handle_new_order_trade_dm(
     messages: &Arc<Mutex<Vec<OrderMessage>>>,
     order_id: Uuid,
@@ -645,8 +655,10 @@ async fn handle_trade_dm_for_order(
     if matches!(action, Action::CantDo) {
         return;
     }
+    // Trade-DM `NewOrder` special cases only (create-order `NewOrder` uses the waiter path).
+    // Unhandled shapes fall through to generic hydration with `new_order_would_regress_messages_row`.
     if matches!(action, Action::NewOrder) {
-        let _ = try_handle_new_order_trade_dm(
+        if try_handle_new_order_trade_dm(
             messages,
             order_id,
             trade_index,
@@ -654,8 +666,14 @@ async fn handle_trade_dm_for_order(
             pool,
             trade_keys,
         )
-        .await;
-        return;
+        .await
+        {
+            return;
+        }
+        log::debug!(
+            "Trade-DM NewOrder not handled by republish/range-child path; continuing generic hydration order_id={}",
+            order_id
+        );
     }
 
     // Snapshot before upsert: used for status/cancel paths and to detect whether `save_order`
@@ -909,7 +927,9 @@ async fn handle_trade_dm_for_order(
     let should_replace_row = match &existing_message_data {
         None => true,
         Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status)) => {
-            if timestamp > *existing_timestamp {
+            if new_order_would_regress_messages_row(&action, existing_action) {
+                false
+            } else if timestamp > *existing_timestamp {
                 true
             } else if timestamp == *existing_timestamp {
                 action != *existing_action
@@ -1791,8 +1811,13 @@ pub async fn listen_for_order_messages(
 
 #[cfg(test)]
 mod tests {
-    use super::{effective_is_mine_for_trade_dm_message, trade_message_is_terminal};
-    use mostro_core::prelude::{Action, Message};
+    use super::{
+        effective_is_mine_for_trade_dm_message, is_pre_active_maker_listing,
+        is_pre_active_taker_take, new_order_would_regress_messages_row,
+        small_order_pending_from_new_order_payload, trade_message_is_terminal,
+    };
+    use crate::models::Order;
+    use mostro_core::prelude::{Action, Message, Payload, SmallOrder, Status};
 
     #[test]
     fn action_only_canceled_is_terminal() {
@@ -1827,5 +1852,87 @@ mod tests {
             effective_is_mine_for_trade_dm_message(false, Some(true), Some(false)),
             Some(false)
         );
+    }
+
+    fn sample_order_row(is_mine: bool, status: &str) -> Order {
+        Order {
+            id: Some("00000000-0000-0000-0000-000000000001".to_string()),
+            kind: Some("buy".to_string()),
+            status: Some(status.to_string()),
+            amount: 1000,
+            fiat_code: "USD".to_string(),
+            min_amount: None,
+            max_amount: None,
+            fiat_amount: 100,
+            payment_method: "bank".to_string(),
+            premium: 0,
+            trade_keys: None,
+            counterparty_pubkey: None,
+            order_chat_shared_key_hex: None,
+            is_mine,
+            buyer_invoice: None,
+            request_id: Some(1),
+            trade_index: Some(1),
+            created_at: None,
+            expires_at: None,
+            last_seen_dm_ts: None,
+        }
+    }
+
+    #[test]
+    fn small_order_pending_from_new_order_requires_pending_status() {
+        let pending = SmallOrder {
+            status: Some(Status::Pending),
+            ..Default::default()
+        };
+        let active = SmallOrder {
+            status: Some(Status::Active),
+            ..Default::default()
+        };
+        assert!(
+            small_order_pending_from_new_order_payload(&Some(Payload::Order(pending))).is_some()
+        );
+        assert!(
+            small_order_pending_from_new_order_payload(&Some(Payload::Order(active))).is_none()
+        );
+        assert!(small_order_pending_from_new_order_payload(&None).is_none());
+    }
+
+    #[test]
+    fn pre_active_taker_take_predicate() {
+        let row = sample_order_row(false, "waiting-payment");
+        assert!(is_pre_active_taker_take(&row));
+        assert!(!is_pre_active_maker_listing(&row));
+    }
+
+    #[test]
+    fn pre_active_maker_listing_predicate() {
+        let row = sample_order_row(true, "waiting-taker-bond");
+        assert!(is_pre_active_maker_listing(&row));
+        assert!(!is_pre_active_taker_take(&row));
+    }
+
+    #[test]
+    fn active_trade_is_not_pre_active_special_case() {
+        let maker = sample_order_row(true, "active");
+        let taker = sample_order_row(false, "active");
+        assert!(!is_pre_active_maker_listing(&maker));
+        assert!(!is_pre_active_taker_take(&taker));
+    }
+
+    #[test]
+    fn new_order_does_not_regress_non_new_order_messages_row() {
+        assert!(new_order_would_regress_messages_row(
+            &Action::NewOrder,
+            &Action::PayBondInvoice,
+        ));
+        assert!(!new_order_would_regress_messages_row(
+            &Action::NewOrder,
+            &Action::NewOrder,
+        ));
+        assert!(!new_order_would_regress_messages_row(
+            &Action::PayInvoice,
+            &Action::NewOrder,
+        ));
     }
 }

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -49,7 +49,7 @@ fn remove_many_orders_from_messages_tab(app: &mut AppState, order_ids: &[Uuid]) 
                 &mut messages,
                 &mut app.selected_message_idx,
             );
-            let n = build_active_order_chat_list(&messages).len();
+            let n = build_active_order_chat_list(&messages, &app.my_trades_maker_book).len();
             if n == 0 {
                 app.selected_order_chat_idx = 0;
             } else if app.selected_order_chat_idx >= n {

--- a/src/util/dm_utils/order_result_tx.rs
+++ b/src/util/dm_utils/order_result_tx.rs
@@ -1,0 +1,28 @@
+use std::sync::Mutex;
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::ui::OperationResult;
+
+static ORDER_RESULT_TX: Mutex<Option<UnboundedSender<OperationResult>>> = Mutex::new(None);
+
+/// Registers the main-loop channel used to refresh UI state after background trade events.
+pub fn set_order_result_tx(tx: UnboundedSender<OperationResult>) -> Result<(), &'static str> {
+    match ORDER_RESULT_TX.lock() {
+        Ok(mut guard) => {
+            *guard = Some(tx);
+            Ok(())
+        }
+        Err(_) => Err("ORDER_RESULT_TX mutex poisoned"),
+    }
+}
+
+/// Notify the UI thread to rebuild the My Trades maker-on-book sidebar cache from SQLite.
+pub fn try_notify_my_trades_maker_book_changed() {
+    let Ok(guard) = ORDER_RESULT_TX.lock() else {
+        return;
+    };
+    if let Some(tx) = guard.as_ref() {
+        let _ = tx.send(OperationResult::MyTradesMakerBookChanged);
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -20,8 +20,8 @@ pub use db_utils::save_order;
 pub use dm_utils::{
     handle_message_notification, handle_operation_result, hydrate_startup_active_order_dm_state,
     listen_for_order_messages, parse_dm_events, seed_admin_chat_last_seen, send_dm,
-    set_dm_router_cmd_tx, wait_for_dm, OrderDmSubscriptionCmd, StartupDmHydration,
-    FETCH_EVENTS_TIMEOUT,
+    set_dm_router_cmd_tx, set_order_result_tx, try_notify_my_trades_maker_book_changed,
+    wait_for_dm, OrderDmSubscriptionCmd, StartupDmHydration, FETCH_EVENTS_TIMEOUT,
 };
 pub use fatal::{
     catch_unwind_request_fatal_restart, fatal_requested, install_background_panic_hook,

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -76,7 +76,7 @@ pub fn inferred_status_from_trade_action(action: &Action) -> Option<Status> {
         Action::WaitingSellerToPay | Action::PayInvoice => Some(Status::WaitingPayment),
         Action::PayBondInvoice => Some(Status::WaitingTakerBond),
         Action::AdminCanceled => Some(Status::CanceledByAdmin),
-        Action::FiatSentOk => Some(Status::Success),
+        Action::FiatSentOk => Some(Status::FiatSent),
         Action::Release | Action::Released => Some(Status::Success),
         _ => None,
     }
@@ -101,7 +101,7 @@ fn status_phase_rank_for_actor(
     kind: Option<mostro_core::order::Kind>,
 ) -> Option<u8> {
     match status {
-        Status::Pending => Some(0),
+        Status::Pending | Status::WaitingTakerBond => Some(0),
         // Stage ordering follows listing kind progression (same for maker/taker):
         // Buy listing:  waiting-payment -> waiting-buyer-invoice
         // Sell listing: waiting-buyer-invoice -> waiting-payment
@@ -665,6 +665,16 @@ mod tests {
             Some(mostro_core::order::Kind::Buy),
         );
         assert!(!allow);
+    }
+
+    #[test]
+    fn waiting_taker_bond_can_revert_to_pending() {
+        let kind = Some(mostro_core::order::Kind::Buy);
+        assert!(should_apply_status_transition(
+            Some(Status::WaitingTakerBond),
+            Status::Pending,
+            kind,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Summary

- **Trade DM listener**: Handle Action::NewOrder with Payload::Order + status: pending on the trade-DM path (not only the create-order waiter). Pre-Active taker takes are deleted and removed from Messages; pre-Active maker listings revert to pending, drop from Messages, and refresh the My Trades sidebar cache.

- **My Trades UX**: Event-driven my_trades_maker_book cache (SQLite maker + pending) merged into build_active_order_chat_list so republished listings stay visible without per-frame DB reads. OperationResult::MyTradesMakerBookChanged triggers a silent cache refresh.

- **Refactors**: Extract helpers (try_handle_new_order_trade_dm, revert_maker_to_pending_on_book_republish, drop_pre_active_taker_take, projection snapshot helpers) for clarity and DRY.

- **Status transitions**: WaitingTakerBond can revert to Pending; FiatSentOk maps to Status::FiatSent in inferred status.
Motivation

When a taker cancels before Active, Mostro often republishes the order with NewOrder rather than Canceled. The listener previously ignored all trade-DM NewOrder messages, so makers did not revert to book state and My Trades could lose the listing after Messages cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My Trades" maker-book cache to surface pending maker listings alongside chat-derived orders; background refreshes trigger UI updates without popups.

* **Bug Fixes**
  * Improved handling of pre-active maker/taker order republish to avoid stale or regressed order states.
  * Fixed order state sync on republished listings and improved navigation/selection stability in active orders.

* **Documentation**
  * Clarified DM listener behavior for NewOrder and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostrix/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->