### PR TITLE
feat(admin): Step1 - bond resolution foundation for dispute finalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f73dc932127909d84e64a3dd1a5cd0e9b6549fdef3eb6ec02a1de26a71472f9"
+checksum = "0b972de34af6574c8fbb2a6e8fd6a8e478fd45875ef4eae45165668b30246cf0"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = "0.11.0"
+mostro-core = "0.11.3"
 nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.5", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ When `user_mode = "admin"` and `admin_privkey` is set in `settings.toml`, Mostri
   - For each `(dispute, party)` pair, a shared key is derived between the admin key and the party’s trade pubkey and stored as hex in the local DB.
   - Admin and party chat via NIP‑59 gift-wrap events addressed to the shared key’s public key, providing restart‑safe, per‑dispute conversations.
   - Use **Tab** to switch chat view, **Shift+I** to enable/disable chat input, **PageUp** / **PageDown** to scroll, **End** to jump to latest. Press **Ctrl+S** to save the selected attachment to `~/.mostrix/downloads/`. Press **Shift+F** to open the finalization popup.
-- **Finalization**: From the popup you can **Pay Buyer** (AdminSettle: release sats to buyer) or **Refund Seller** (AdminCancel: refund to seller), or **Exit** without action. Finalized disputes (Settled, SellerRefunded, Released) cannot be modified.
+- **Finalization**: From the popup you can **Pay Buyer** (`AdminSettle`) or **Refund Seller** (`AdminCancel`), or **Exit**. Anti-abuse **bond slash** options (none / buyer / seller / both) per [Mostro protocol](https://mostro.network/protocol/admin_settle_order.html) are in progress — see [docs/FINALIZE_DISPUTES.md](docs/FINALIZE_DISPUTES.md). Finalized disputes (Settled, SellerRefunded, Released) cannot be modified.
 - **Settings (admin)**: **Add Dispute Solver** (add another solver by `npub`), **Change Admin Key** (update `admin_privkey`).
 
 For detailed flows and UI, see [docs/ADMIN_DISPUTES.md](docs/ADMIN_DISPUTES.md), [docs/FINALIZE_DISPUTES.md](docs/FINALIZE_DISPUTES.md), and [docs/TUI_INTERFACE.md](docs/TUI_INTERFACE.md).

--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -75,7 +75,7 @@ The interface is divided into three main sections:
 - **Party switching**: Tab key toggles between buyer and seller
 - **Message history**: Per-dispute chat storage with scrolling
 - **Dynamic input**: Input box grows from 1 to 10 lines
-   - **Finalization**: Press **Shift+F** to open the dispute finalization popup from the Disputes in Progress tab
+   - **Finalization**: Press **Shift+F** to open the dispute finalization popup from the Disputes in Progress tab (see [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md)). **Planned:** after choosing Pay Buyer or Refund Seller, pick a **bond slash** option (none / buyer / seller / both) when the Mostro instance has anti-abuse bonds enabled; [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) and protocol `bond_resolution` payload are implemented, UI and `execute_admin_*` wiring are not yet.
 - **Visual indicators**: Focus states, colors, and icons for clarity
 
 #### Keyboard Navigation
@@ -353,7 +353,7 @@ pub struct SolverDisputeInfo {
 
 **Identity & Status**:
 
-- **`id`**: Unique identifier (UUID) for the **order** associated with this dispute. Mostrix stores this as the primary key in the `admin_disputes` table and uses it as the ID sent to Mostro when performing admin finalization actions (AdminSettle/AdminCancel).
+- **`id`**: Unique identifier (UUID) for the **order** associated with this dispute. Mostrix stores this as the primary key in the `admin_disputes` table and uses it as the ID sent to Mostro when performing admin finalization actions (`AdminSettle` / `AdminCancel`). Optional [`bond_resolution`](https://mostro.network/protocol/admin_settle_order.html) payload (slash buyer/seller/both/none) will be attached via [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) once the execute layer and TUI are wired.
 - **`kind`**: Order kind (e.g., "Buy" or "Sell")
 - **`status`**: Current dispute status (see [Dispute States](#dispute-states) section)
 - **`order_previous_status`**: The order's status before the dispute was initiated

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -221,6 +221,11 @@ cargo clippy --all-targets --all-features  # Lint code
 
 **Example**: `AppState` uses `Arc<Mutex<>>` for thread-safe access to messages and trade indices.
 
+## Dependencies
+
+- **`mostro-core`**: Pin in [`Cargo.toml`](../Cargo.toml) to the same minor line as the Mostro daemon you test against (currently **0.11.3**). Protocol types (`Action`, `Payload`, `BondResolution`, `CantDoReason`, …) must come from `mostro_core::prelude::*` — do not duplicate wire shapes in Mostrix.
+- **Admin bond slash**: use [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) for `admin-settle` / `admin-cancel` payloads; see [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md).
+
 ## Summary Checklist
 
 When writing or reviewing code, ensure:

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -4,6 +4,17 @@
 
 This document describes how admins finalize disputes in Mostrix after reviewing the case and communicating with the buyer and seller.
 
+### Implementation status (anti-abuse bond slash)
+
+| Layer | Status | Notes |
+|-------|--------|--------|
+| **`mostro-core` 0.11.3** | Done | `BondResolution`, `Payload::BondResolution`, `CantDoReason::InvalidPayload` |
+| **`BondSlashChoice`** | Done | [`src/util/order_utils/bond_resolution.rs`](../src/util/order_utils/bond_resolution.rs) — wire mapping + unit tests |
+| **Execute layer** (`execute_admin_settle` / `cancel`) | Pending | Still sends `payload: null`; step 3 will pass `BondSlashChoice` |
+| **TUI** (slash picker + confirm summary) | Pending | Still two-step: outcome → confirm only |
+
+Protocol references: [Admin Settle](https://mostro.network/protocol/admin_settle_order.html), [Admin Cancel](https://mostro.network/protocol/admin_cancel_order.html). Daemon bond payout (`Action::AddBondInvoice`, Mostro PR [#738](https://github.com/MostroP2P/mostro/pull/738)) is documented under trade flows, not admin finalization.
+
 ## User Flow
 
 1. **Navigate to Disputes**: Admin opens the "Disputes in Progress" tab
@@ -19,8 +30,12 @@ This document describes how admins finalize disputes in Mostrix after reviewing 
    - Visual scrollbar on the right shows position in chat history
 5. **Open Finalization**: Press Shift+F to open finalization popup
 6. **Review Full Details**: Popup shows complete dispute information
-7. **Choose Action**: Use Left/Right arrows to select action button
-8. **Execute**: Press Enter to execute the selected action
+7. **Choose trade outcome**: Use Left/Right arrows — **Pay Buyer** (`AdminSettle`) or **Refund Seller** (`AdminCancel`), or **Exit**
+8. **Choose bond slash** *(planned)*: Four options — no slash, slash buyer, slash seller, slash both (skipped when instance `bond_enabled` is false)
+9. **Confirm** *(planned)*: Yes/No popup summarizing outcome + bond choice
+10. **Execute**: Press Enter on confirm — sends encrypted DM to Mostro
+
+**Current UI (until step 4–5 land):** steps 7 → confirm (no bond slash step); wire payload is always `null`.
 
 ## Finalization Actions
 
@@ -42,6 +57,23 @@ This document describes how admins finalize disputes in Mostrix after reviewing 
 
 - **Effect**: Returns to dispute management without taking action
 - **Use Case**: Need more information, want to continue chatting with parties
+
+### Bond resolution (anti-abuse bonds)
+
+Independent of settle vs cancel: the admin chooses whether to **slash** posted anti-abuse bonds. Valid on both `admin-settle` and `admin-cancel` only.
+
+| Choice | `slash_seller` | `slash_buyer` | When to use |
+|--------|----------------|---------------|-------------|
+| No bond slash | false | false | Release bonds; no penalty |
+| Slash buyer bond | false | true | Buyer at fault (e.g. false claim on sell order) |
+| Slash seller bond | true | false | Seller at fault |
+| Slash both bonds | true | true | Both parties violated rules |
+
+Mostrix maps these to [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) → `Payload::BondResolution`. Legacy clients used `payload: null` (server treats as no slash); new code uses explicit `{false, false}` via `BondSlashChoice::None`.
+
+If the daemon rejects a slash (e.g. side has no bond row), Mostro may reply with `CantDo(InvalidPayload)` — surfaced as *"Invalid payload - check bond slash choices or message format"* ([`get_cant_do_description`](../src/util/types.rs)).
+
+After a slash, the non-slashed party may receive `Action::AddBondInvoice` to claim their share of the bond (see Mostro anti-abuse bond spec / PR #738); that is handled on the **trader** path, not in the admin finalization popup.
 
 ## UI Components
 
@@ -105,17 +137,41 @@ The popup displays comprehensive dispute information:
 
 ### Message Structure
 
-Both finalization actions use the same message structure:
+Both finalization actions use `Message::new_dispute` with the **order** UUID (from `admin_disputes.id`), not the dispute UUID:
 
 ```rust
+use mostrix::util::order_utils::BondSlashChoice;
+
+let bond = BondSlashChoice::SlashBuyer; // example
+
 Message::new_dispute(
-    Some(order_id),  // UUID of the order associated with this dispute (Mostro expects the order ID)
-    None,            // No request_id needed
-    None,            // No trade_index needed
-    action,          // AdminSettle or AdminCancel
-    None             // No payload needed
+    Some(order_id),
+    None,
+    None,
+    Action::AdminSettle, // or AdminCancel
+    bond.to_optional_payload(), // Some(Payload::BondResolution(...)) when wired; today: None
 )
 ```
+
+Example JSON (settle + slash buyer), per [protocol](https://mostro.network/protocol/admin_settle_order.html):
+
+```json
+{
+  "dispute": {
+    "version": 1,
+    "id": "<order-uuid>",
+    "action": "admin-settle",
+    "payload": {
+      "bond_resolution": {
+        "slash_seller": false,
+        "slash_buyer": true
+      }
+    }
+  }
+}
+```
+
+> **Note:** Mostrix serializes `Message::Dispute` (not the `order` wrapper shown in some protocol examples); `mostro-core` accepts both shapes on decode. The `id` field is always the **order** id.
 
 Internally, Mostrix:
 
@@ -243,9 +299,11 @@ Tab: Switch Party | Shift+F: Finalize | ↑↓: Select Dispute | PgUp/PgDn: Scro
 
 ## Related Files
 
+- `src/util/order_utils/bond_resolution.rs` - `BondSlashChoice`, `Payload::BondResolution` mapping, wire tests
 - `src/ui/dispute_finalization_popup.rs` - Popup rendering logic
-- `src/util/order_utils/execute_admin_settle.rs` - AdminSettle implementation
-- `src/util/order_utils/execute_admin_cancel.rs` - AdminCancel implementation
+- `src/util/order_utils/execute_admin_settle.rs` - AdminSettle implementation (payload wiring pending)
+- `src/util/order_utils/execute_admin_cancel.rs` - AdminCancel implementation (payload wiring pending)
+- `src/util/order_utils/execute_finalize_dispute.rs` - DB checks + dispatches settle/cancel
 - `src/ui/disputes_in_progress_tab.rs` - Main disputes UI with chat interface
 - `src/ui/key_handler/enter_handlers.rs` - Enter key handling and chat message sending
 - `src/ui/key_handler/mod.rs` - Chat input handling and clipboard operations

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -69,7 +69,7 @@ Independent of settle vs cancel: the admin chooses whether to **slash** posted a
 | Slash seller bond | true | false | Seller at fault |
 | Slash both bonds | true | true | Both parties violated rules |
 
-Mostrix maps these to [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) → `Payload::BondResolution`. Legacy clients used `payload: null` (server treats as no slash); new code uses explicit `{false, false}` via `BondSlashChoice::None`.
+Mostrix maps these via [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs): `to_optional_payload()` sends `payload: null` for **no slash** and `Payload::BondResolution` only when a side is slashed. Use `to_payload()` if you need an explicit `{false, false}` object (same server semantics as null).
 
 If the daemon rejects a slash (e.g. side has no bond row), Mostro may reply with `CantDo(InvalidPayload)` — surfaced as *"Invalid payload - check bond slash choices or message format"* ([`get_cant_do_description`](../src/util/types.rs)).
 
@@ -149,7 +149,7 @@ Message::new_dispute(
     None,
     None,
     Action::AdminSettle, // or AdminCancel
-    bond.to_optional_payload(), // Some(Payload::BondResolution(...)) when wired; today: None
+    bond.to_optional_payload(), // None for no slash; Some(BondResolution) when slashing; today: execute still passes None
 )
 ```
 

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -140,7 +140,7 @@ The popup displays comprehensive dispute information:
 Both finalization actions use `Message::new_dispute` with the **order** UUID (from `admin_disputes.id`), not the dispute UUID:
 
 ```rust
-use mostrix::util::order_utils::BondSlashChoice;
+use crate::util::order_utils::BondSlashChoice;
 
 let bond = BondSlashChoice::SlashBuyer; // example
 

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -547,6 +547,10 @@ If the response's `request_id` doesn't match the sent request, the operation is 
 
 If a message cannot be decrypted (wrong key, corrupted data, etc.), it is logged and skipped rather than crashing the listener.
 
+### `CantDo` reasons (`mostro-core` 0.11.3+)
+
+User-facing strings for `Payload::CantDo(Some(reason))` come from [`get_cant_do_description`](../src/util/types.rs). Notable for admin work: **`InvalidPayload`** — wrong payload shape or impossible values (e.g. `bond_resolution` slashing a side with no bond). Trade DMs carrying `CantDo` are not upserted into the Messages list ([DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md)); they surface via waiters / `OperationResult` popups.
+
 ## Admin Chat Fetch (Single-Flight, Shared-Key Based)
 
 When the user is in **Admin** mode, the main event loop runs a periodic admin chat sync so the "Disputes in Progress" tab stays up to date with NIP‑59 gift-wrap messages exchanged over **per‑dispute shared keys**.
@@ -570,6 +574,24 @@ This avoids overlapping relay queries and duplicate work when the 5‑second tic
 
 ### Database Errors
 Database operations (saving orders, updating trade indices) log errors but don't necessarily fail the entire operation, allowing the user to continue using the client.
+
+## Admin dispute finalization (`AdminSettle` / `AdminCancel`)
+
+Admins resolve in-progress disputes by sending encrypted DMs signed with `admin_privkey` ([FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md)).
+
+| Action | Trade outcome | Typical payload today | Planned payload |
+|--------|---------------|----------------------|-----------------|
+| `AdminSettle` | Pay buyer (release escrow to buyer) | `null` | `Payload::BondResolution` via [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) |
+| `AdminCancel` | Refund seller | `null` | same |
+
+**Bond resolution** (Mostro anti-abuse bond Phase 2+): optional `bond_resolution: { slash_seller, slash_buyer }` on both actions only. Four combinations plus legacy `null` (= no slash). See [admin settle](https://mostro.network/protocol/admin_settle_order.html) / [admin cancel](https://mostro.network/protocol/admin_cancel_order.html).
+
+- **Client types**: `mostro-core` 0.11.3 — `BondResolution`, `Payload::BondResolution`.
+- **Mostrix helper**: `BondSlashChoice::to_payload()` builds the wire payload; unit tests in `bond_resolution.rs`.
+- **Errors**: invalid slash (e.g. no bond for that side) → `CantDo(InvalidPayload)` → user string from [`get_cant_do_description`](../src/util/types.rs).
+- **Post-slash payout**: slashed bonds may trigger `Action::AddBondInvoice` to the non-slashed party (daemon PR [#738](https://github.com/MostroP2P/mostro/pull/738)); handled on the trader notification path, not admin UI.
+
+**Entry points (today):** `execute_finalize_dispute` → `execute_admin_settle` / `execute_admin_cancel` in `src/util/order_utils/`.
 
 ## Stateless Recovery
 

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -587,7 +587,7 @@ Admins resolve in-progress disputes by sending encrypted DMs signed with `admin_
 **Bond resolution** (Mostro anti-abuse bond Phase 2+): optional `bond_resolution: { slash_seller, slash_buyer }` on both actions only. Four combinations plus legacy `null` (= no slash). See [admin settle](https://mostro.network/protocol/admin_settle_order.html) / [admin cancel](https://mostro.network/protocol/admin_cancel_order.html).
 
 - **Client types**: `mostro-core` 0.11.3 — `BondResolution`, `Payload::BondResolution`.
-- **Mostrix helper**: `BondSlashChoice::to_payload()` builds the wire payload; unit tests in `bond_resolution.rs`.
+- **Mostrix helper**: `BondSlashChoice::to_optional_payload()` — `None` for no slash (`payload: null`), `Some(BondResolution)` when slashing; unit tests in `bond_resolution.rs`.
 - **Errors**: invalid slash (e.g. no bond for that side) → `CantDo(InvalidPayload)` → user string from [`get_cant_do_description`](../src/util/types.rs).
 - **Post-slash payout**: slashed bonds may trigger `Action::AddBondInvoice` to the non-slashed party (daemon PR [#738](https://github.com/MostroP2P/mostro/pull/738)); handled on the trader notification path, not admin UI.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 ## Admin
 
 - **Admin Disputes**: [ADMIN_DISPUTES.md](ADMIN_DISPUTES.md) — Tabs, shared-keys chat, workflows
-- **Finalize disputes**: [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) — Pay buyer / refund seller popups
+- **Finalize disputes**: [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) — Pay buyer / refund seller; **bond slash** on `admin-settle` / `admin-cancel` (`BondSlashChoice` + `mostro-core` 0.11.3 — protocol helpers done, TUI/execute wiring pending)
 
 ## Contributing & tooling
 
@@ -36,5 +36,5 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 
 ## Implementation plans (AI / contributors)
 
-- Tracked Markdown plans for larger features live under **[`.cursor/plans/`](../.cursor/plans/README.md)** (git-tracked; see root `.gitignore` exceptions). Use them to capture design decisions and link to `src/` paths for codegen and reviews.
+- Tracked Markdown plans for larger features live under **[`.cursor/plans/`](../.cursor/plans/README.md)** (git-tracked; see root `.gitignore` exceptions). Use them to capture design decisions and link to `src/` paths for codegen and reviews. Current: [admin dispute bond slash](../.cursor/plans/admin_dispute_bond_slash.plan.md).
 

--- a/src/util/order_utils/bond_resolution.rs
+++ b/src/util/order_utils/bond_resolution.rs
@@ -18,6 +18,15 @@ pub enum BondSlashChoice {
     SlashBoth,
 }
 
+// Default for bond slash choice is None
+impl Default for BondSlashChoice {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+
+// BondSlashChoice implementation
 impl BondSlashChoice {
     /// All choices in UI display order.
     pub const ALL: [Self; 4] = [
@@ -27,6 +36,7 @@ impl BondSlashChoice {
         Self::SlashBoth,
     ];
 
+    /// Human-readable label for TUI display.
     pub fn label(self) -> &'static str {
         match self {
             Self::None => "No bond slash",
@@ -36,31 +46,38 @@ impl BondSlashChoice {
         }
     }
 
+    /// Returns `true` if the seller's bond should be slashed.
     pub fn slash_seller(self) -> bool {
         matches!(self, Self::SlashSeller | Self::SlashBoth)
     }
 
+    /// Returns `true` if the buyer's bond should be slashed.
     pub fn slash_buyer(self) -> bool {
         matches!(self, Self::SlashBuyer | Self::SlashBoth)
     }
 
-    pub fn to_bond_resolution(self) -> BondResolution {
+    pub(crate) fn to_bond_resolution(self) -> BondResolution {
         BondResolution {
             slash_seller: self.slash_seller(),
             slash_buyer: self.slash_buyer(),
         }
     }
 
-    /// Wire payload for `admin-settle` / `admin-cancel`.
-    ///
-    /// Always emits an explicit [`Payload::BondResolution`]; `{false, false}` means
-    /// no slash (same semantics as legacy `payload: null` on the server).
+    /// Explicit [`Payload::BondResolution`] (including `{ slash_seller: false, slash_buyer: false }`
+    /// for [`Self::None`]). Prefer [`Self::to_optional_payload`] for wire messages.
     pub fn to_payload(self) -> Payload {
         Payload::BondResolution(self.to_bond_resolution())
     }
 
+    /// Wire payload for `admin-settle` / `admin-cancel`.
+    ///
+    /// [`Self::None`] → `None` (`payload: null`, legacy no-slash). Slash variants →
+    /// `Some(Payload::BondResolution(..))`.
     pub fn to_optional_payload(self) -> Option<Payload> {
-        Some(self.to_payload())
+        match self {
+            Self::None => None,
+            _ => Some(self.to_payload()),
+        }
     }
 }
 
@@ -146,17 +163,46 @@ mod tests {
     }
 
     #[test]
-    fn bond_resolution_none_is_explicit_false_false() {
+    fn bond_resolution_none_omits_payload() {
         let msg = dispute_message(Action::AdminSettle, BondSlashChoice::None);
+        assert!(msg.verify());
         let json = msg.as_json().expect("serialize");
-        assert!(json.contains("\"slash_seller\":false"));
-        assert!(json.contains("\"slash_buyer\":false"));
+        assert!(
+            json.contains("\"payload\":null"),
+            "None should serialize as legacy null payload, got: {json}"
+        );
+        assert!(
+            !json.contains("bond_resolution"),
+            "None must not emit bond_resolution, got: {json}"
+        );
     }
 
     #[test]
-    fn bond_resolution_slash_both_roundtrip() {
-        let msg = dispute_message(Action::AdminCancel, BondSlashChoice::SlashBoth);
+    fn to_payload_none_is_explicit_false_false() {
+        let payload = BondSlashChoice::None.to_payload();
+        let BondResolution {
+            slash_seller,
+            slash_buyer,
+        } = match payload {
+            Payload::BondResolution(b) => b,
+            other => panic!("expected BondResolution, got {other:?}"),
+        };
+        assert!(!slash_seller);
+        assert!(!slash_buyer);
+    }
+
+    #[test]
+    fn bond_resolution_wire_format_slash_both() {
+        let msg = dispute_message(Action::AdminSettle, BondSlashChoice::SlashBoth);
         let json = msg.as_json().expect("serialize");
+        assert!(
+            json.contains("\"bond_resolution\""),
+            "expected snake_case discriminator, got: {json}"
+        );
+        assert!(json.contains("\"slash_seller\":true"));
+        assert!(json.contains("\"slash_buyer\":true"));
+        assert!(json.contains("\"action\":\"admin-settle\""));
+
         let decoded = Message::from_json(&json).expect("deserialize");
         assert!(decoded.verify());
         let b = bond_resolution_from_message(&decoded);

--- a/src/util/order_utils/bond_resolution.rs
+++ b/src/util/order_utils/bond_resolution.rs
@@ -1,0 +1,166 @@
+//! Bond slash choices for admin dispute finalization (`admin-settle` / `admin-cancel`).
+//!
+//! See [admin settle](https://mostro.network/protocol/admin_settle_order.html) and
+//! [admin cancel](https://mostro.network/protocol/admin_cancel_order.html).
+
+use mostro_core::prelude::*;
+
+/// How to resolve anti-abuse bonds when an admin finalizes a dispute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BondSlashChoice {
+    /// Release bonds; do not slash either party.
+    None,
+    /// Slash the buyer's bond (if posted).
+    SlashBuyer,
+    /// Slash the seller's bond (if posted).
+    SlashSeller,
+    /// Slash both parties' bonds (if posted).
+    SlashBoth,
+}
+
+impl BondSlashChoice {
+    /// All choices in UI display order.
+    pub const ALL: [Self; 4] = [
+        Self::None,
+        Self::SlashBuyer,
+        Self::SlashSeller,
+        Self::SlashBoth,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "No bond slash",
+            Self::SlashBuyer => "Slash buyer bond",
+            Self::SlashSeller => "Slash seller bond",
+            Self::SlashBoth => "Slash both bonds",
+        }
+    }
+
+    pub fn slash_seller(self) -> bool {
+        matches!(self, Self::SlashSeller | Self::SlashBoth)
+    }
+
+    pub fn slash_buyer(self) -> bool {
+        matches!(self, Self::SlashBuyer | Self::SlashBoth)
+    }
+
+    pub fn to_bond_resolution(self) -> BondResolution {
+        BondResolution {
+            slash_seller: self.slash_seller(),
+            slash_buyer: self.slash_buyer(),
+        }
+    }
+
+    /// Wire payload for `admin-settle` / `admin-cancel`.
+    ///
+    /// Always emits an explicit [`Payload::BondResolution`]; `{false, false}` means
+    /// no slash (same semantics as legacy `payload: null` on the server).
+    pub fn to_payload(self) -> Payload {
+        Payload::BondResolution(self.to_bond_resolution())
+    }
+
+    pub fn to_optional_payload(self) -> Option<Payload> {
+        Some(self.to_payload())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::uuid;
+
+    fn dispute_message(action: Action, bond: BondSlashChoice) -> Message {
+        Message::new_dispute(
+            Some(uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23")),
+            None,
+            None,
+            action,
+            bond.to_optional_payload(),
+        )
+    }
+
+    fn bond_resolution_from_message(msg: &Message) -> BondResolution {
+        match msg {
+            Message::Dispute(kind) => match &kind.payload {
+                Some(Payload::BondResolution(b)) => b.clone(),
+                other => panic!("expected BondResolution payload, got {other:?}"),
+            },
+            other => panic!("expected Dispute message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_flags_match_choice() {
+        assert!(!BondSlashChoice::None.slash_seller());
+        assert!(!BondSlashChoice::None.slash_buyer());
+
+        assert!(!BondSlashChoice::SlashBuyer.slash_seller());
+        assert!(BondSlashChoice::SlashBuyer.slash_buyer());
+
+        assert!(BondSlashChoice::SlashSeller.slash_seller());
+        assert!(!BondSlashChoice::SlashSeller.slash_buyer());
+
+        assert!(BondSlashChoice::SlashBoth.slash_seller());
+        assert!(BondSlashChoice::SlashBoth.slash_buyer());
+    }
+
+    #[test]
+    fn admin_settle_and_cancel_verify_with_bond_resolution() {
+        for action in [Action::AdminSettle, Action::AdminCancel] {
+            for bond in BondSlashChoice::ALL {
+                let msg = dispute_message(action.clone(), bond);
+                assert!(msg.verify(), "{action:?} + {bond:?} should verify");
+            }
+        }
+    }
+
+    #[test]
+    fn bond_resolution_wire_format_admin_settle() {
+        let msg = dispute_message(Action::AdminSettle, BondSlashChoice::SlashBuyer);
+        let json = msg.as_json().expect("serialize");
+        assert!(
+            json.contains("\"bond_resolution\""),
+            "expected snake_case discriminator, got: {json}"
+        );
+        assert!(json.contains("\"slash_seller\":false"));
+        assert!(json.contains("\"slash_buyer\":true"));
+        assert!(json.contains("\"action\":\"admin-settle\""));
+
+        let decoded = Message::from_json(&json).expect("deserialize");
+        assert!(decoded.verify());
+        let b = bond_resolution_from_message(&decoded);
+        assert!(!b.slash_seller);
+        assert!(b.slash_buyer);
+    }
+
+    #[test]
+    fn bond_resolution_wire_format_admin_cancel_slash_seller() {
+        let msg = dispute_message(Action::AdminCancel, BondSlashChoice::SlashSeller);
+        let json = msg.as_json().expect("serialize");
+        assert!(json.contains("\"action\":\"admin-cancel\""));
+        assert!(json.contains("\"slash_seller\":true"));
+        assert!(json.contains("\"slash_buyer\":false"));
+
+        let decoded = Message::from_json(&json).expect("deserialize");
+        assert!(decoded.verify());
+    }
+
+    #[test]
+    fn bond_resolution_none_is_explicit_false_false() {
+        let msg = dispute_message(Action::AdminSettle, BondSlashChoice::None);
+        let json = msg.as_json().expect("serialize");
+        assert!(json.contains("\"slash_seller\":false"));
+        assert!(json.contains("\"slash_buyer\":false"));
+    }
+
+    #[test]
+    fn bond_resolution_slash_both_roundtrip() {
+        let msg = dispute_message(Action::AdminCancel, BondSlashChoice::SlashBoth);
+        let json = msg.as_json().expect("serialize");
+        let decoded = Message::from_json(&json).expect("deserialize");
+        assert!(decoded.verify());
+        let b = bond_resolution_from_message(&decoded);
+        assert!(b.slash_seller);
+        assert!(b.slash_buyer);
+    }
+}

--- a/src/util/order_utils/bond_resolution.rs
+++ b/src/util/order_utils/bond_resolution.rs
@@ -25,7 +25,6 @@ impl Default for BondSlashChoice {
     }
 }
 
-
 // BondSlashChoice implementation
 impl BondSlashChoice {
     /// All choices in UI display order.

--- a/src/util/order_utils/execute_admin_cancel.rs
+++ b/src/util/order_utils/execute_admin_cancel.rs
@@ -42,8 +42,8 @@ pub async fn execute_admin_cancel(
     mostro_pubkey: PublicKey,
     mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
-    // Create AdminCancel message
-    // No payload needed - just the order ID (Mostro expects the order UUID here)
+    // Create AdminCancel message (order UUID in `id`; dispute UUID is local-only).
+    // TODO(bond-slash): accept `BondSlashChoice` and pass `bond.to_optional_payload()` here.
     let cancel_message =
         Message::new_dispute(Some(*order_id), None, None, Action::AdminCancel, None)
             .as_json()

--- a/src/util/order_utils/execute_admin_settle.rs
+++ b/src/util/order_utils/execute_admin_settle.rs
@@ -42,8 +42,8 @@ pub async fn execute_admin_settle(
     mostro_pubkey: PublicKey,
     mostro_instance: Option<&MostroInstanceInfo>,
 ) -> Result<()> {
-    // Create AdminSettle message
-    // No payload needed - just the order ID (Mostro expects the order UUID here)
+    // Create AdminSettle message (order UUID in `id`; dispute UUID is local-only).
+    // TODO(bond-slash): accept `BondSlashChoice` and pass `bond.to_optional_payload()` here.
     let settle_message =
         Message::new_dispute(Some(*order_id), None, None, Action::AdminSettle, None)
             .as_json()

--- a/src/util/order_utils/mod.rs
+++ b/src/util/order_utils/mod.rs
@@ -1,4 +1,5 @@
 // Order utilities module
+mod bond_resolution;
 mod execute_add_invoice;
 mod execute_admin_add_solver;
 mod execute_admin_cancel;
@@ -13,6 +14,7 @@ mod send_new_order;
 mod take_order;
 
 // Re-export public functions
+pub use bond_resolution::BondSlashChoice;
 pub use execute_add_invoice::execute_add_invoice;
 pub use execute_admin_add_solver::execute_admin_add_solver;
 pub use execute_admin_cancel::execute_admin_cancel;

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -39,6 +39,9 @@ pub fn get_cant_do_description(reason: &CantDoReason) -> String {
         CantDoReason::InvalidParameters => {
             "Invalid parameters - check your order details".to_string()
         }
+        CantDoReason::InvalidPayload => {
+            "Invalid payload - check bond slash choices or message format".to_string()
+        }
         CantDoReason::OrderAlreadyCanceled => "Order is already canceled".to_string(),
         CantDoReason::CantCreateUser => "Cannot create user - please contact support".to_string(),
         CantDoReason::IsNotYourOrder => "This is not your order".to_string(),


### PR DESCRIPTION
## Summary

Prepares Mostrix for anti-abuse **bond slash** options on admin dispute finalization (`admin-settle` / `admin-cancel`), aligned with [Mostro protocol](https://mostro.network/protocol/admin_settle_order.html) and daemon work in [MostroP2P/mostro#738](https://github.com/MostroP2P/mostro/pull/738).

- Bump **`mostro-core` 0.11.0 → 0.11.3** (`BondResolution`, `Payload::BondResolution`, `CantDoReason::InvalidPayload`)
- Add **`BondSlashChoice`** (`None`, `SlashBuyer`, `SlashSeller`, `SlashBoth`) with `to_payload()` and wire-format unit tests
- Map **`InvalidPayload`** in `get_cant_do_description` for admin-facing errors
- Update admin/finalization docs with implementation status (protocol layer done; execute + TUI pending)

**Not in this PR:** wiring `BondSlashChoice` into `execute_admin_settle` / `cancel`, bond-slash TUI step, or `AddBondInvoice` payout handling for traders.

## Motivation

Admins resolving disputes must be able to settle or cancel the trade **and** independently choose whether to slash buyer/seller/both/none anti-abuse bonds. This PR lands the dependency bump and shared protocol helper so follow-up PRs can focus on execute + UI.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (includes 6 new tests in `bond_resolution.rs`)
- [ ] Manual: no behavior change expected (finalization still sends `payload: null`)

## Follow-up

1. Thread `BondSlashChoice` through `execute_finalize_dispute` / `execute_admin_*`
2. TUI: bond slash picker + confirm summary
3. Gate slash step on `bond_enabled` from kind-38385 instance info
4. (Optional) `Action::AddBondInvoice` / `BondPayoutRequest` for non-admin payout recipients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anti-abuse bond slash options (none/buyer/seller/both) for admin dispute finalization

* **Documentation**
  * Expanded admin dispute finalization guide with bond resolution details and implementation status
  * Updated coding standards with dependency and protocol type guidance
  * Added CantDo error reasons documentation

* **Chores**
  * Updated mostro-core dependency to version 0.11.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostrix/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->