### PR TITLE
feat: animated startup splash during post-terminal boot

### DIFF
--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -5,7 +5,19 @@ This guide explains Mostrix’s boot sequence and configuration surfaces.
 ## Overview
 - Entry: `src/main.rs:98`
 - Initializes database, derives identity keys, initializes settings, then logger, terminal (raw mode), shared state, Nostr client, and background tasks.
+- Shows an animated **startup splash** (Mostro wordmark + loading dots) while post-terminal init runs; see [Startup splash](#startup-splash) below.
 - Enters the main event loop to handle UI updates and user input.
+
+## Startup splash
+
+After the terminal enters alternate screen mode, Mostrix draws a full-screen splash until background boot work finishes (`src/startup.rs`, `src/ui/startup_splash.rs`).
+
+- **Wordmark**: multi-line logo from the project art (same style as the desktop `logo.txt` export).
+- **Loading dots**: one reusable glyph (` <>`) repeated 1–4 times on the last logo row, cycled every ~400 ms while the splash tick runs (~150 ms redraw interval).
+- **Phase text**: short status under the art (`Starting…`, `Connecting to relays…`, `Loading market data…`, `Restoring chats…`, `Almost ready…`) updated as init steps complete.
+- **Minimum display**: splash stays visible for at least ~800 ms so fast boots do not flash the screen.
+- **Narrow terminals**: if the terminal is narrower than the padded logo width, a one-line `mostro is loading` + dots + phase is shown instead.
+- **CI / scripts**: set `MOSTRIX_NO_SPLASH=1` to skip the splash loop and run init directly.
 
 ## Initialization Sequence
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ pub mod db;
 pub mod models;
 pub mod settings;
 pub mod shared;
+pub mod startup;
 pub mod ui;
 pub mod util;
 
@@ -10,36 +11,27 @@ use crate::models::User;
 use crate::settings::{init_settings, Settings};
 use crate::ui::helpers::{
     admin_chat_keys_clone_for_role, apply_admin_chat_updates, apply_user_order_chat_updates,
-    expire_attachment_toast, hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
-    load_user_order_chats_at_startup, refresh_my_trades_maker_book_cache,
+    expire_attachment_toast, load_admin_disputes_at_startup, refresh_my_trades_maker_book_cache,
     sync_user_order_history_messages_from_db,
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
-    handle_mouse_invoice_paste_fallback, reload_runtime_session_after_reconnect,
-    spawn_refresh_mostro_info_task, AppChannels, RuntimeReconnectContext,
+    handle_mouse_invoice_paste_fallback, reload_runtime_session_after_reconnect, AppChannels,
+    RuntimeReconnectContext,
 };
-use crate::ui::network_status::spawn_network_status_monitor;
 use crate::ui::{LnAddressVerifyResult, MostroInfoFetchResult, OperationResult};
 use crate::util::{
-    any_relay_reachable, blossom_servers_from_settings, catch_unwind_request_fatal_restart,
-    connect_client_safely, handle_message_notification, handle_operation_result,
-    hydrate_startup_active_order_dm_state, install_background_panic_hook,
-    listen_for_order_messages,
-    order_utils::{
-        run_relay_order_db_reconcile_once, run_targeted_relay_order_db_reconcile_tick,
-        spawn_admin_chat_fetch, spawn_user_order_chat_fetch, start_fetch_scheduler,
-        validate_range_amount, FetchSchedulerResult,
-    },
+    blossom_servers_from_settings, handle_message_notification, handle_operation_result,
+    install_background_panic_hook,
+    order_utils::{spawn_admin_chat_fetch, spawn_user_order_chat_fetch, validate_range_amount},
     set_dm_router_cmd_tx, set_fatal_error_tx, set_order_result_tx, spawn_save_attachment,
-    spawn_send_order_chat_attachment, StartupDmHydration,
+    spawn_send_order_chat_attachment,
 };
 use crossterm::event::EventStream;
 use mostro_core::prelude::*;
 
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::task::JoinHandle;
 
 use chrono::Local;
 use crossterm::execute;
@@ -58,7 +50,6 @@ use ratatui::Terminal;
 use std::io::stdout;
 use std::sync::OnceLock;
 use tokio::time::{interval, Duration};
-use zeroize::Zeroizing;
 
 /// Constructs (or copies) the configuration file and loads it.
 pub static SETTINGS: OnceLock<Settings> = OnceLock::new();
@@ -275,6 +266,7 @@ async fn main() -> Result<(), anyhow::Error> {
         mut user_order_chat_updates_rx,
         save_attachment_tx,
         mut save_attachment_rx,
+
         send_order_attachment_tx: _send_order_attachment_tx,
         mut send_order_attachment_rx,
         mostro_info_tx,
@@ -299,13 +291,6 @@ async fn main() -> Result<(), anyhow::Error> {
     })?;
     set_order_result_tx(order_result_tx.clone()).map_err(|msg| anyhow::anyhow!(msg))?;
 
-    // Configure Nostr client.
-    let my_keys = settings
-        .nsec_privkey
-        .parse::<Keys>()
-        .map_err(|e| anyhow::anyhow!("Invalid NSEC privkey: {}", e))?;
-    let mut client = Client::new(my_keys);
-
     let configured_relays: Vec<String> = settings
         .relays
         .iter()
@@ -314,150 +299,39 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|relay| relay.to_owned())
         .collect();
 
-    // Add relays.
-    for relay in &configured_relays {
-        client.add_relay(relay).await?;
-    }
-    let relays_reachable = any_relay_reachable(&configured_relays).await;
-    if !relays_reachable {
-        log::warn!("No configured relays reachable; nostr connect may fail");
-    }
-    if let Err(e) = connect_client_safely(&client).await {
-        log::warn!("Failed to connect Nostr client at startup: {e}");
-    }
+    let user_role = UserRole::from_str(&settings.user_mode)?;
 
-    let mut mostro_pubkey = PublicKey::from_str(&settings.mostro_pubkey)
-        .map_err(|e| anyhow::anyhow!("Invalid Mostro pubkey: {}", e))?;
-    let current_mostro_pubkey = Arc::new(std::sync::Mutex::new(mostro_pubkey));
-
-    // Start background tasks to fetch orders and disputes
-    let FetchSchedulerResult {
+    let startup::StartupBootstrap {
+        mut client,
+        mut mostro_pubkey,
+        current_mostro_pubkey,
         orders,
         disputes,
         mut order_task,
         mut dispute_task,
-    } = start_fetch_scheduler(
-        client.clone(),
-        Arc::clone(&current_mostro_pubkey),
-        settings,
-        pool.clone(),
-    );
+        mut app,
+        mut message_listener_handle,
+        ..
+    } = startup::run_startup_with_splash(
+        &mut terminal,
+        startup::PostTerminalStartupInput {
+            pool: &pool,
+            settings,
+            did_generate_new_settings_file: init.did_generate_new_settings_file,
+            user_role,
+            configured_relays,
+            dm_subscription_rx,
+            mostro_info_tx: mostro_info_tx.clone(),
+            network_status_tx,
+            message_notification_tx: message_notification_tx.clone(),
+        },
+    )
+    .await?;
 
     // Event handling: keyboard input and periodic UI refresh.
     let mut events = EventStream::new();
     let mut refresh_interval = interval(Duration::from_millis(150));
     let mut admin_chat_interval = interval(Duration::from_secs(2));
-    let user_role = &settings.user_mode;
-    let mut app = AppState::new(UserRole::from_str(user_role)?);
-    // On first launch, ensure the new user can immediately back up the 12 words.
-    // Do NOT force switching into Settings tab; show the overlay on the normal initial tab.
-    if init.did_generate_new_settings_file {
-        match User::get(&pool).await {
-            Ok(user) => {
-                app.backup_requires_restart = false;
-                app.mode = UiMode::BackupNewKeys(Zeroizing::new(user.mnemonic));
-            }
-            Err(e) => {
-                log::error!(
-                    "First-run backup flow: failed to load generated user mnemonic: {}",
-                    e
-                );
-                app.mode = UiMode::operation_result(OperationResult::Error(
-                    "First-run setup completed, but mnemonic backup could not be loaded from the database. Please use Settings -> Generate New Keys and back up the new 12 words immediately.".to_string(),
-                ));
-            }
-        }
-    }
-    // Seed currencies filter cache from settings so UI-side filtering does not
-    // need to hit the filesystem on every render.
-    app.currencies_filter = settings.currencies_filter.clone();
-    hydrate_app_admin_keys_from_privkey(&mut app, &settings.admin_privkey);
-
-    if !relays_reachable {
-        app.offline_overlay_message = Some(
-            "No internet / relays unreachable. Mostrix is retrying connection automatically."
-                .to_string(),
-        );
-    }
-
-    // Background offline monitor: emit status transitions every 5 seconds.
-    spawn_network_status_monitor(configured_relays.clone(), network_status_tx.clone());
-
-    // Initial Mostro instance info (same path as manual refresh; no startup toast).
-    // Only attempt this when at least one relay is reachable, otherwise some
-    // nostr client paths may panic on machines without network.
-    if relays_reachable {
-        spawn_refresh_mostro_info_task(
-            client.clone(),
-            mostro_pubkey,
-            mostro_info_tx.clone(),
-            false,
-        );
-    }
-
-    // Load admin disputes at startup (only when role is admin)
-    load_admin_disputes_at_startup(&pool, &mut app).await;
-    if relays_reachable {
-        if let Err(e) = run_relay_order_db_reconcile_once(&client, &pool, mostro_pubkey).await {
-            log::warn!("Startup relay order DB reconcile failed: {}", e);
-        }
-        let startup_targeted_cursor = std::sync::Arc::new(std::sync::Mutex::new(0usize));
-        if let Err(e) = run_targeted_relay_order_db_reconcile_tick(
-            &client,
-            &pool,
-            mostro_pubkey,
-            &startup_targeted_cursor,
-        )
-        .await
-        {
-            log::warn!("Startup targeted relay order DB reconcile failed: {}", e);
-        }
-    }
-    load_user_order_chats_at_startup(&client, &pool, &mut app).await;
-
-    // Spawn background task to listen for messages on active orders
-    let startup_dm_hydration = match hydrate_startup_active_order_dm_state(&pool).await {
-        Ok(h) => h,
-        Err(e) => {
-            log::warn!(
-                "Failed to hydrate startup active order DM state from DB: {}",
-                e
-            );
-            StartupDmHydration::empty()
-        }
-    };
-    if let Ok(mut indices) = app.active_order_trade_indices.lock() {
-        *indices = startup_dm_hydration.active_order_trade_indices.clone();
-    } else {
-        log::warn!("Failed to seed startup active order map (poisoned lock)");
-    }
-    app.startup_popup_floor_ts = startup_dm_hydration.order_last_seen_dm_ts.clone();
-
-    let client_for_messages = client.clone();
-    let pool_for_messages = pool.clone();
-    let active_order_trade_indices_clone = Arc::clone(&app.active_order_trade_indices);
-    let order_last_seen_dm_ts_clone = startup_dm_hydration.order_last_seen_dm_ts.clone();
-    let messages_clone = Arc::clone(&app.messages);
-    let message_notification_tx_clone = message_notification_tx.clone();
-    let pending_notifications_clone = Arc::clone(&app.pending_notifications);
-    let dropped_user_history_clone = Arc::clone(&app.dropped_user_history_order_ids);
-    let mut message_listener_handle: JoinHandle<()> = tokio::spawn(async move {
-        catch_unwind_request_fatal_restart("trade DM listener", async move {
-            listen_for_order_messages(
-                client_for_messages,
-                pool_for_messages,
-                active_order_trade_indices_clone,
-                order_last_seen_dm_ts_clone,
-                messages_clone,
-                message_notification_tx_clone,
-                pending_notifications_clone,
-                dropped_user_history_clone,
-                dm_subscription_rx,
-            )
-            .await;
-        })
-        .await;
-    });
 
     loop {
         tokio::select! {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,277 @@
+//! Post-terminal boot: Nostr connect, schedulers, chat restore, DM listener.
+
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use mostro_core::prelude::*;
+use nostr_sdk::prelude::*;
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use sqlx::SqlitePool;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::interval;
+use zeroize::Zeroizing;
+
+use crate::models::User;
+use crate::settings::Settings;
+use crate::ui::helpers::{
+    hydrate_app_admin_keys_from_privkey, load_admin_disputes_at_startup,
+    load_user_order_chats_at_startup,
+};
+use crate::ui::key_handler::spawn_refresh_mostro_info_task;
+use crate::ui::network_status::spawn_network_status_monitor;
+use crate::ui::startup_splash::{
+    dot_count_from_elapsed, render_startup_splash, SPLASH_MIN_DISPLAY_MS, SPLASH_TICK_MS,
+};
+use crate::ui::{AppState, OperationResult, UiMode, UserRole};
+use crate::util::{
+    any_relay_reachable, catch_unwind_request_fatal_restart, connect_client_safely,
+    hydrate_startup_active_order_dm_state, listen_for_order_messages,
+    order_utils::{
+        run_relay_order_db_reconcile_once, run_targeted_relay_order_db_reconcile_tick,
+        start_fetch_scheduler, FetchSchedulerResult,
+    },
+    StartupDmHydration,
+};
+
+pub struct PostTerminalStartupInput<'a> {
+    pub pool: &'a SqlitePool,
+    pub settings: &'a Settings,
+    pub did_generate_new_settings_file: bool,
+    pub user_role: UserRole,
+    pub configured_relays: Vec<String>,
+    pub dm_subscription_rx:
+        tokio::sync::mpsc::UnboundedReceiver<crate::util::OrderDmSubscriptionCmd>,
+    pub mostro_info_tx: tokio::sync::mpsc::UnboundedSender<crate::ui::MostroInfoFetchResult>,
+    pub network_status_tx: tokio::sync::mpsc::UnboundedSender<crate::ui::NetworkStatus>,
+    pub message_notification_tx: tokio::sync::mpsc::UnboundedSender<crate::ui::MessageNotification>,
+}
+
+pub struct StartupBootstrap {
+    pub client: Client,
+    pub mostro_pubkey: PublicKey,
+    pub current_mostro_pubkey: Arc<Mutex<PublicKey>>,
+    pub orders: Arc<Mutex<Vec<SmallOrder>>>,
+    pub disputes: Arc<Mutex<Vec<Dispute>>>,
+    pub order_task: JoinHandle<()>,
+    pub dispute_task: JoinHandle<()>,
+    pub app: AppState,
+    pub message_listener_handle: JoinHandle<()>,
+    pub relays_reachable: bool,
+}
+
+fn set_startup_phase(phase_tx: &watch::Sender<String>, message: &str) {
+    let _ = phase_tx.send(message.to_string());
+}
+
+pub async fn run_post_terminal_startup(
+    input: PostTerminalStartupInput<'_>,
+    phase_tx: &watch::Sender<String>,
+) -> Result<StartupBootstrap> {
+    set_startup_phase(phase_tx, "Starting…");
+
+    let my_keys = input
+        .settings
+        .nsec_privkey
+        .parse::<Keys>()
+        .map_err(|e| anyhow::anyhow!("Invalid NSEC privkey: {}", e))?;
+    let client = Client::new(my_keys);
+
+    for relay in &input.configured_relays {
+        client.add_relay(relay).await?;
+    }
+
+    set_startup_phase(phase_tx, "Connecting to relays…");
+    let relays_reachable = any_relay_reachable(&input.configured_relays).await;
+    if !relays_reachable {
+        log::warn!("No configured relays reachable; nostr connect may fail");
+    }
+    if let Err(e) = connect_client_safely(&client).await {
+        log::warn!("Failed to connect Nostr client at startup: {e}");
+    }
+
+    let mostro_pubkey = PublicKey::from_str(&input.settings.mostro_pubkey)
+        .map_err(|e| anyhow::anyhow!("Invalid Mostro pubkey: {}", e))?;
+    let current_mostro_pubkey = Arc::new(Mutex::new(mostro_pubkey));
+
+    set_startup_phase(phase_tx, "Loading market data…");
+    let FetchSchedulerResult {
+        orders,
+        disputes,
+        order_task,
+        dispute_task,
+    } = start_fetch_scheduler(
+        client.clone(),
+        Arc::clone(&current_mostro_pubkey),
+        input.settings,
+        input.pool.clone(),
+    );
+
+    let mut app = AppState::new(input.user_role);
+    if input.did_generate_new_settings_file {
+        match User::get(input.pool).await {
+            Ok(user) => {
+                app.backup_requires_restart = false;
+                app.mode = UiMode::BackupNewKeys(Zeroizing::new(user.mnemonic));
+            }
+            Err(e) => {
+                log::error!(
+                    "First-run backup flow: failed to load generated user mnemonic: {}",
+                    e
+                );
+                app.mode = UiMode::operation_result(OperationResult::Error(
+                    "First-run setup completed, but mnemonic backup could not be loaded from the database. Please use Settings -> Generate New Keys and back up the new 12 words immediately.".to_string(),
+                ));
+            }
+        }
+    }
+    app.currencies_filter = input.settings.currencies_filter.clone();
+    hydrate_app_admin_keys_from_privkey(&mut app, &input.settings.admin_privkey);
+
+    if !relays_reachable {
+        app.offline_overlay_message = Some(
+            "No internet / relays unreachable. Mostrix is retrying connection automatically."
+                .to_string(),
+        );
+    }
+
+    spawn_network_status_monitor(
+        input.configured_relays.clone(),
+        input.network_status_tx.clone(),
+    );
+
+    if relays_reachable {
+        spawn_refresh_mostro_info_task(
+            client.clone(),
+            mostro_pubkey,
+            input.mostro_info_tx.clone(),
+            false,
+        );
+    }
+
+    set_startup_phase(phase_tx, "Restoring chats…");
+    load_admin_disputes_at_startup(input.pool, &mut app).await;
+    if relays_reachable {
+        if let Err(e) = run_relay_order_db_reconcile_once(&client, input.pool, mostro_pubkey).await
+        {
+            log::warn!("Startup relay order DB reconcile failed: {}", e);
+        }
+        let startup_targeted_cursor = Arc::new(Mutex::new(0usize));
+        if let Err(e) = run_targeted_relay_order_db_reconcile_tick(
+            &client,
+            input.pool,
+            mostro_pubkey,
+            &startup_targeted_cursor,
+        )
+        .await
+        {
+            log::warn!("Startup targeted relay order DB reconcile failed: {}", e);
+        }
+    }
+    load_user_order_chats_at_startup(&client, input.pool, &mut app).await;
+
+    set_startup_phase(phase_tx, "Almost ready…");
+    let startup_dm_hydration = match hydrate_startup_active_order_dm_state(input.pool).await {
+        Ok(h) => h,
+        Err(e) => {
+            log::warn!(
+                "Failed to hydrate startup active order DM state from DB: {}",
+                e
+            );
+            StartupDmHydration::empty()
+        }
+    };
+    if let Ok(mut indices) = app.active_order_trade_indices.lock() {
+        *indices = startup_dm_hydration.active_order_trade_indices.clone();
+    } else {
+        log::warn!("Failed to seed startup active order map (poisoned lock)");
+    }
+    app.startup_popup_floor_ts = startup_dm_hydration.order_last_seen_dm_ts.clone();
+
+    let client_for_messages = client.clone();
+    let pool_for_messages = input.pool.clone();
+    let active_order_trade_indices_clone = Arc::clone(&app.active_order_trade_indices);
+    let order_last_seen_dm_ts_clone = startup_dm_hydration.order_last_seen_dm_ts.clone();
+    let messages_clone = Arc::clone(&app.messages);
+    let message_notification_tx_clone = input.message_notification_tx.clone();
+    let pending_notifications_clone = Arc::clone(&app.pending_notifications);
+    let dropped_user_history_clone = Arc::clone(&app.dropped_user_history_order_ids);
+    let dm_subscription_rx = input.dm_subscription_rx;
+
+    let message_listener_handle = tokio::spawn(async move {
+        catch_unwind_request_fatal_restart("trade DM listener", async move {
+            listen_for_order_messages(
+                client_for_messages,
+                pool_for_messages,
+                active_order_trade_indices_clone,
+                order_last_seen_dm_ts_clone,
+                messages_clone,
+                message_notification_tx_clone,
+                pending_notifications_clone,
+                dropped_user_history_clone,
+                dm_subscription_rx,
+            )
+            .await;
+        })
+        .await;
+    });
+
+    Ok(StartupBootstrap {
+        client,
+        mostro_pubkey,
+        current_mostro_pubkey,
+        orders,
+        disputes,
+        order_task,
+        dispute_task,
+        app,
+        message_listener_handle,
+        relays_reachable,
+    })
+}
+
+/// Runs post-terminal init behind an animated splash unless `MOSTRIX_NO_SPLASH` is set.
+pub async fn run_startup_with_splash(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    input: PostTerminalStartupInput<'_>,
+) -> Result<StartupBootstrap> {
+    let (phase_tx, phase_rx) = watch::channel(String::from("Starting…"));
+
+    if std::env::var_os("MOSTRIX_NO_SPLASH").is_some() {
+        return run_post_terminal_startup(input, &phase_tx).await;
+    }
+
+    let splash_started = Instant::now();
+    let mut splash_tick = interval(Duration::from_millis(SPLASH_TICK_MS));
+    splash_tick.tick().await;
+
+    let mut init = Box::pin(run_post_terminal_startup(input, &phase_tx));
+
+    let bootstrap = loop {
+        tokio::select! {
+            biased;
+            res = &mut init => break res?,
+            _ = splash_tick.tick() => {
+                let dots = dot_count_from_elapsed(&splash_started);
+                let phase = phase_rx.borrow().clone();
+                terminal.draw(|f| render_startup_splash(f, dots, &phase))?;
+            }
+        }
+    };
+
+    let min_display = Duration::from_millis(SPLASH_MIN_DISPLAY_MS);
+    while splash_started.elapsed() < min_display {
+        tokio::select! {
+            _ = splash_tick.tick() => {
+                let dots = dot_count_from_elapsed(&splash_started);
+                let phase = phase_rx.borrow().clone();
+                terminal.draw(|f| render_startup_splash(f, dots, &phase))?;
+            }
+        }
+    }
+
+    Ok(bootstrap)
+}

--- a/src/ui/helpers/ascii_art.rs
+++ b/src/ui/helpers/ascii_art.rs
@@ -1,0 +1,43 @@
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+/// Renders each line centered horizontally within `area`, one row per line.
+pub fn render_centered_lines<F>(f: &mut ratatui::Frame, area: Rect, lines: &[&str], style_line: F)
+where
+    F: Fn(&str) -> Vec<Span<'static>>,
+{
+    if lines.is_empty() {
+        return;
+    }
+
+    let logo_height = lines.len() as u16;
+    let start_y = if logo_height < area.height {
+        area.y + (area.height.saturating_sub(logo_height)) / 2
+    } else {
+        area.y
+    };
+
+    for (idx, line) in lines.iter().enumerate() {
+        let y = start_y + idx as u16;
+        if y >= area.y.saturating_add(area.height) {
+            break;
+        }
+
+        let line_width = line.chars().count() as u16;
+        let start_x = if line_width < area.width {
+            area.x + (area.width.saturating_sub(line_width)) / 2
+        } else {
+            area.x
+        };
+
+        let centered_rect = Rect {
+            x: start_x,
+            y,
+            width: line_width.min(area.width),
+            height: 1,
+        };
+
+        f.render_widget(Paragraph::new(Line::from(style_line(line))), centered_rect);
+    }
+}

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -1,3 +1,4 @@
+mod ascii_art;
 mod attachments;
 mod chat_render;
 mod chat_storage;
@@ -6,6 +7,8 @@ mod formatting;
 mod layout;
 mod order_chat_projection;
 mod startup;
+
+pub use ascii_art::render_centered_lines;
 
 pub(crate) use attachments::try_parse_attachment_message;
 pub use attachments::{

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,6 +28,7 @@ pub mod order_form;
 pub mod order_take;
 pub(crate) mod orders;
 pub mod save_attachment_popup;
+pub mod startup_splash;
 pub mod state;
 pub mod status;
 pub mod tabs;

--- a/src/ui/startup_splash.rs
+++ b/src/ui/startup_splash.rs
@@ -1,0 +1,231 @@
+use std::time::Instant;
+
+use ratatui::layout::{Alignment, Constraint, Flex, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, Paragraph};
+
+use crate::ui::helpers::render_centered_lines;
+use crate::ui::{BACKGROUND_COLOR, PRIMARY_COLOR};
+
+pub const SPLASH_TICK_MS: u64 = 150;
+pub const SPLASH_DOT_CYCLE_MS: u64 = 400;
+pub const SPLASH_MIN_DISPLAY_MS: u64 = 800;
+
+/// One animated dot (diamond), including a leading space separator.
+pub const LOADING_DOT_UNIT: &str = " <>";
+
+/// Multi-line Mostro wordmark (from project logo); dots animate on the last row.
+pub const MOSTRO_LOADING_LINES: &[&str] = &[
+    "                        __         .__         .__         .__                    .___.__",
+    "  _____   ____  _______╱  │________│__│__  ___ │__│ ______ │  │   _________     __│ _╱│__│ ____    ____",
+    " ╱     ╲ ╱  _ ╲╱  ___╱╲   __╲_  __ ╲  ╲  ╲╱  ╱ │  │╱  ___╱ │  │  ╱  _ ╲__  ╲   ╱ __ │ │  │╱    ╲  ╱ ___╲",
+    "│  Y Y  (  <_> )___ ╲  │  │  │  │ ╲╱  │>    <  │  │╲___ ╲  │  │_(  <_> ) __ ╲_╱ ╱_╱ │ │  │   │  ╲╱ ╱_╱  >",
+    "│__│_│  ╱╲____╱____  > │__│  │__│  │__╱__╱╲_ ╲ │__╱____  > │____╱╲____(____  ╱╲____ │ │__│___│  ╱╲___  ╱",
+    "      ╲╱           ╲╱                       ╲╱         ╲╱                  ╲╱      ╲╱         ╲╱╱_____╱",
+];
+
+/// Width reserved on the last line for up to four dots.
+const MAX_DOT_SUFFIX_CHARS: usize = LOADING_DOT_UNIT.len() * 4;
+
+/// Last line index in [`MOSTRO_LOADING_LINES`] that receives the animated dots.
+const LOADING_DOTS_LINE_INDEX: usize = 5;
+
+fn max_raw_art_width() -> usize {
+    MOSTRO_LOADING_LINES
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Padded width of every splash frame line (constant across dot counts 1–4).
+pub fn logo_line_width() -> usize {
+    let raw_max = max_raw_art_width();
+    let last_raw = MOSTRO_LOADING_LINES[LOADING_DOTS_LINE_INDEX]
+        .chars()
+        .count();
+    raw_max.max(last_raw + MAX_DOT_SUFFIX_CHARS)
+}
+
+fn pad_line_to_width(line: &str, width: usize) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    if chars.len() >= width {
+        chars.into_iter().take(width).collect()
+    } else {
+        let mut out = line.to_string();
+        out.push_str(&" ".repeat(width - chars.len()));
+        out
+    }
+}
+
+/// Builds the suffix for `dot_count` dots (1–4). Values outside 1..=4 clamp to 1..=4.
+pub fn dot_suffix(dot_count: u8) -> String {
+    let n = dot_count.clamp(1, 4) as usize;
+    LOADING_DOT_UNIT.repeat(n)
+}
+
+/// Maps elapsed time since splash start to a dot count in 1..=4.
+pub fn dot_count_from_elapsed(started: &Instant) -> u8 {
+    let elapsed = started.elapsed().as_millis() as u64;
+    let frame = (elapsed / SPLASH_DOT_CYCLE_MS) % 4;
+    (frame + 1) as u8
+}
+
+/// Returns wordmark lines with dots appended on the last row (fixed total width).
+pub fn splash_lines_with_dots(dot_count: u8) -> Vec<String> {
+    let width = logo_line_width();
+    let suffix = dot_suffix(dot_count);
+    let suffix_len = suffix.chars().count();
+
+    MOSTRO_LOADING_LINES
+        .iter()
+        .enumerate()
+        .map(|(idx, line)| {
+            if idx == LOADING_DOTS_LINE_INDEX {
+                let base = pad_line_to_width(line, width.saturating_sub(suffix_len));
+                format!("{base}{suffix}")
+            } else {
+                pad_line_to_width(line, width)
+            }
+        })
+        .collect()
+}
+
+fn splash_fits_wordmark(terminal_width: u16) -> bool {
+    terminal_width >= logo_line_width() as u16
+}
+
+fn style_loading_line(line: &str) -> Vec<Span<'static>> {
+    line.chars()
+        .map(|c| {
+            let highlight = matches!(
+                c,
+                '/' | '\\' | '_' | '<' | '>' | '|' | '=' | '│' | '╱' | '╲' | '▀' | '▄'
+            );
+            if highlight {
+                Span::styled(
+                    c.to_string(),
+                    Style::default()
+                        .fg(PRIMARY_COLOR)
+                        .bg(BACKGROUND_COLOR)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                Span::styled(
+                    c.to_string(),
+                    Style::default().fg(Color::White).bg(BACKGROUND_COLOR),
+                )
+            }
+        })
+        .collect()
+}
+
+fn render_compact_splash(f: &mut ratatui::Frame, dot_count: u8, phase: &str) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+
+    let text = format!(
+        "mostro is loading{}{}",
+        dot_suffix(dot_count),
+        if phase.is_empty() {
+            String::new()
+        } else {
+            format!("\n\n{phase}")
+        }
+    );
+
+    let paragraph = Paragraph::new(text)
+        .alignment(Alignment::Center)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(Color::White));
+
+    let [block] = Layout::vertical([Constraint::Percentage(100)])
+        .flex(Flex::Center)
+        .areas(area);
+    f.render_widget(paragraph, block);
+}
+
+/// Full-screen startup splash with animated dots and optional phase subtitle.
+pub fn render_startup_splash(f: &mut ratatui::Frame, dot_count: u8, phase: &str) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+
+    if !splash_fits_wordmark(area.width) {
+        render_compact_splash(f, dot_count, phase);
+        return;
+    }
+
+    let art_owned = splash_lines_with_dots(dot_count);
+    let art_lines: Vec<&str> = art_owned.iter().map(String::as_str).collect();
+
+    let phase_height: u16 = if phase.is_empty() { 0 } else { 2 };
+    let art_height = art_lines.len() as u16;
+    let total_height = art_height.saturating_add(phase_height);
+
+    let [center_block] = Layout::vertical([Constraint::Length(total_height)])
+        .flex(Flex::Center)
+        .areas(area);
+
+    let chunks = if phase.is_empty() {
+        Layout::vertical([Constraint::Length(art_height)]).split(center_block)
+    } else {
+        Layout::vertical([
+            Constraint::Length(art_height),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(center_block)
+    };
+
+    render_centered_lines(f, chunks[0], &art_lines, style_loading_line);
+
+    if !phase.is_empty() && chunks.len() > 2 {
+        let phase_line = Line::from(Span::styled(
+            phase,
+            Style::default().fg(Color::Gray).bg(BACKGROUND_COLOR),
+        ));
+        f.render_widget(
+            Paragraph::new(phase_line)
+                .alignment(Alignment::Center)
+                .style(Style::default().bg(BACKGROUND_COLOR)),
+            chunks[2],
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logo_lines_share_max_width() {
+        let w = logo_line_width();
+        for line in splash_lines_with_dots(4) {
+            assert_eq!(line.chars().count(), w);
+        }
+    }
+
+    #[test]
+    fn dot_suffix_lengths_are_monotonic() {
+        let w1 = dot_suffix(1).chars().count();
+        let w4 = dot_suffix(4).chars().count();
+        assert!(w4 > w1);
+        assert_eq!(w4, LOADING_DOT_UNIT.len() * 4);
+    }
+
+    #[test]
+    fn dot_count_from_elapsed_in_range() {
+        let started = Instant::now();
+        let n = dot_count_from_elapsed(&started);
+        assert!((1..=4).contains(&n));
+    }
+
+    #[test]
+    fn splash_last_line_width_stable_across_dot_counts() {
+        let w = logo_line_width();
+        for dots in 1..=4u8 {
+            let lines = splash_lines_with_dots(dots);
+            assert_eq!(lines[LOADING_DOTS_LINE_INDEX].chars().count(), w);
+        }
+    }
+}

--- a/src/ui/startup_splash.rs
+++ b/src/ui/startup_splash.rs
@@ -139,7 +139,7 @@ fn render_compact_splash(f: &mut ratatui::Frame, dot_count: u8, phase: &str) {
         .alignment(Alignment::Center)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(Color::White));
 
-    let [block] = Layout::vertical([Constraint::Percentage(100)])
+    let [block] = Layout::vertical([Constraint::Min(1)])
         .flex(Flex::Center)
         .areas(area);
     f.render_widget(paragraph, block);

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -5,7 +5,8 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
 
 use crate::ui::{
-    helpers, MessageViewState, RatingOrderState, ThreeState, ViewingMessageButtonSelection,
+    helpers::{self, render_centered_lines},
+    MessageViewState, RatingOrderState, ThreeState, ViewingMessageButtonSelection,
     BACKGROUND_COLOR, PRIMARY_COLOR,
 };
 
@@ -36,28 +37,46 @@ fn get_mostro_logo() -> Vec<&'static str> {
     ]
 }
 
+fn style_exit_logo_line(line: &str) -> Vec<Span<'static>> {
+    if line.contains('█') {
+        line.chars()
+            .map(|c| {
+                if c == '█' {
+                    Span::styled(
+                        c.to_string(),
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    Span::raw(c.to_string())
+                }
+            })
+            .collect()
+    } else if line.contains('╔') || line.contains('║') || line.contains('╚') {
+        line.chars()
+            .map(|c| {
+                if ['╔', '║', '╚', '═', '╗', '╝'].contains(&c) {
+                    Span::styled(
+                        c.to_string(),
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    Span::raw(c.to_string())
+                }
+            })
+            .collect()
+    } else {
+        vec![Span::raw(line.to_string())]
+    }
+}
+
 /// Renders the Exit tab content with ASCII art logo
 pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
     let logo_lines = get_mostro_logo();
 
-    // Create a layout to center the logo vertically
-    let inner_area = Block::default()
-        .title("Exit")
-        .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR))
-        .inner(area);
-
-    let logo_height = logo_lines.len() as u16;
-    let available_height = inner_area.height;
-
-    // Calculate vertical centering
-    let start_y = if logo_height < available_height {
-        inner_area.y + (available_height.saturating_sub(logo_height)) / 2
-    } else {
-        inner_area.y
-    };
-
-    // Render the block
     f.render_widget(
         Block::default()
             .title("Exit")
@@ -66,65 +85,14 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
         area,
     );
 
-    // Render ASCII art logo line by line
-    for (idx, line) in logo_lines.iter().enumerate() {
-        let y = start_y + idx as u16;
-        if y < inner_area.y + inner_area.height {
-            // Center the line horizontally
-            let line_width = line.chars().count() as u16;
-            let start_x = if line_width < inner_area.width {
-                inner_area.x + (inner_area.width.saturating_sub(line_width)) / 2
-            } else {
-                inner_area.x
-            };
+    let inner_area = Block::default()
+        .title("Exit")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(BACKGROUND_COLOR))
+        .inner(area);
 
-            let centered_rect = Rect {
-                x: start_x,
-                y,
-                width: line_width.min(inner_area.width),
-                height: 1,
-            };
-
-            // Style different parts of the logo
-            let spans: Vec<Span> = if line.contains('█') {
-                // Style the ASCII art logo (block characters) with primary color
-                line.chars()
-                    .map(|c| {
-                        if c == '█' {
-                            Span::styled(
-                                c.to_string(),
-                                Style::default()
-                                    .fg(PRIMARY_COLOR)
-                                    .add_modifier(Modifier::BOLD),
-                            )
-                        } else {
-                            Span::raw(c.to_string())
-                        }
-                    })
-                    .collect()
-            } else if line.contains('╔') || line.contains('║') || line.contains('╚') {
-                // Style the box with primary color
-                line.chars()
-                    .map(|c| {
-                        if ['╔', '║', '╚', '═', '╗', '╝'].contains(&c) {
-                            Span::styled(
-                                c.to_string(),
-                                Style::default()
-                                    .fg(PRIMARY_COLOR)
-                                    .add_modifier(Modifier::BOLD),
-                            )
-                        } else {
-                            Span::raw(c.to_string())
-                        }
-                    })
-                    .collect()
-            } else {
-                vec![Span::raw(*line)]
-            };
-
-            f.render_widget(Paragraph::new(Line::from(spans)), centered_rect);
-        }
-    }
+    let line_refs: Vec<&str> = logo_lines.to_vec();
+    render_centered_lines(f, inner_area, &line_refs, style_exit_logo_line);
 }
 
 pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState) {


### PR DESCRIPTION
## Summary

- Add a full-screen **startup splash** after the terminal enters alternate screen: multi-line Mostro wordmark with **1–4 animated loading dots** (` <>`) on the last row.
- Run post-terminal init concurrently with splash redraws (~150 ms) and phase text (`Starting…` … `Almost ready…`).
- Extract boot into `src/startup.rs`; shared `render_centered_lines` for Exit tab (unchanged look).
- Narrow-terminal compact fallback; `MOSTRIX_NO_SPLASH=1` for CI.
- Docs in `docs/STARTUP_AND_CONFIG.md`.

## Motivation

The TUI entered raw mode but drew nothing until the main loop, so users saw a blank screen during slow relay/chat startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an animated startup splash screen with loading indicator and real-time status updates during application initialization.
  * Added environment variable option to disable the splash screen if preferred.

* **Documentation**
  * Updated startup and configuration guide with details about the new splash screen behavior and customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->