### PR TITLE
feat(protocol): parse protocol_version and bump mostro-core 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -976,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2138,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92c273ca52a38a27cdd74f3635055e092c0253d7fade399d64a1d5be63f8563"
+checksum = "d763fddd85d86033f78dacadb8b75041100af7dae4d50e5bea9dc91fc1a1d24c"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -2471,7 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3270,7 +3270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4873,7 +4873,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = "0.12.1"
+mostro-core = "0.13.0"
 nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.5", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The **documentation index** is **[docs/README.md](docs/README.md)** — architec
 
 **Quick links:** [Startup & config](docs/STARTUP_AND_CONFIG.md) · [DM listener / Messages sync](docs/DM_LISTENER_FLOW.md) · [Database](docs/DATABASE.md) · [Message flow & protocol](docs/MESSAGE_FLOW_AND_PROTOCOL.md) · [Key management](docs/KEY_MANAGEMENT.md) · [Coding standards](docs/CODING_STANDARDS.md)
 
+Mostrix reads the connected Mostro instance **`protocol_version`** tag (kind 38385) and shows the resolved wire transport on the **Mostro Info** tab; full dual-transport support (GiftWrap vs NIP-44 direct for protocol DMs) is rolling out — see [docs/README.md — Protocol v2](docs/README.md#protocol-v2-nip-44--in-progress).
+
 ### Settings (`settings.toml`)
 
 Mostrix is configured via a TOML file called `settings.toml`.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -223,7 +223,7 @@ cargo clippy --all-targets --all-features  # Lint code
 
 ## Dependencies
 
-- **`mostro-core`**: Pin in [`Cargo.toml`](../Cargo.toml) to the same minor line as the Mostro daemon you test against (currently **0.12.1** — ships `Status::WaitingMakerBond` and Cashu-related `CantDoReason` variants). Protocol types (`Action`, `Payload`, `BondResolution`, `CantDoReason`, …) must come from `mostro_core::prelude::*` — do not duplicate wire shapes in Mostrix.
+- **`mostro-core`**: Pin in [`Cargo.toml`](../Cargo.toml) to the same minor line as the Mostro daemon you test against (currently **0.13.0** — adds `mostro_core::transport::{Transport, wrap_message_with, unwrap_incoming}` for protocol v2). Protocol types (`Action`, `Payload`, `BondResolution`, `CantDoReason`, `Transport`, …) must come from `mostro_core::prelude::*` — do not duplicate wire shapes in Mostrix. Re-export transport helpers from [`src/util/mod.rs`](../src/util/mod.rs) when used across the crate.
 - **Bond invoice replies**: shared [`payment_request_operation_result`](../src/util/order_utils/helper.rs) for `take_order` and `send_new_order` — returns `PaymentRequestRequired`, not `Success`.
 - **Admin bond slash**: use [`BondSlashChoice`](../src/util/order_utils/bond_resolution.rs) — TUI labels via `label()` (emoji + text); state on `ReviewingDisputeForFinalization.bond`; pass through `execute_finalize_dispute(dispute_id, bond, …)` and `bond.to_optional_payload()` on the wire (`None` → `null`); see [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md).
 

--- a/docs/DM_LISTENER_FLOW.md
+++ b/docs/DM_LISTENER_FLOW.md
@@ -5,6 +5,8 @@ This document explains the runtime flow inside `listen_for_order_messages` (in `
 - how the in-memory **message list** (`Vec<OrderMessage>`) is created/updated
 - how “preferences”/routing concepts work: **TrackOrder**, **Waiter**, **Database**, **Action**, **Status**, notifications, and terminal cleanup
 
+> **Protocol v2 (in progress):** Today the listener is **GiftWrap-only** (kind 1059, `filter_giftwrap_to_recipient`). [`AppState.transport`](../src/ui/app_state.rs) is already derived from instance `protocol_version`, but subscribe/decrypt paths will become transport-aware (`filter_protocol_dm_from_mostro`, `unwrap_incoming`, v2 filter `.author(mostro).pubkey(trade_key).kind(14)`). See [docs/README.md — Protocol v2](README.md#protocol-v2-nip-44--in-progress) and [`.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md`](../.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md).
+
 ## Big picture
 
 Mostrix has a **single background task** that:

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -8,7 +8,7 @@ This document describes how admins finalize disputes in Mostrix after reviewing 
 
 | Layer | Status | Notes |
 |-------|--------|--------|
-| **`mostro-core` 0.12.1** | Done | `BondResolution`, `Payload::BondResolution`, `CantDoReason::InvalidPayload`, `Status::WaitingMakerBond` |
+| **`mostro-core` 0.13.0** | Done | `BondResolution`, `Payload::BondResolution`, `CantDoReason::InvalidPayload`, `Status::WaitingMakerBond`, `Transport` |
 | **`BondSlashChoice`** | Done | [`src/util/order_utils/bond_resolution.rs`](../src/util/order_utils/bond_resolution.rs) — wire mapping + unit tests |
 | **Execute layer** (`execute_admin_settle` / `cancel`) | Done | `request_id` + `wait_for_dm` + `handle_mostro_response`; expects `AdminSettled` / `AdminCanceled`; `CantDo` before DB update |
 | **Success / error popup** | Done | `BondSlashChoice::finalize_success_message`; word-wrapped `OperationResult::Info` in `operation_result.rs` |
@@ -81,7 +81,7 @@ After a slash, the non-slashed party may receive `Action::AddBondInvoice` (`Payl
 
 ### Instance `bond_enabled` (kind 38385)
 
-Mostro always emits a `bond_enabled` tag (`"true"` / `"false"`). Mostrix reads it via [`instance_bonds_enabled()`](../src/util/mostro_info.rs): only `"true"` shows the Bond button and confirm bond recap. Fetch instance info from the **Mostro Info** tab (Enter) so gating reflects the connected daemon.
+Mostro always emits a `bond_enabled` tag (`"true"` / `"false"`). Mostrix reads it via [`instance_bonds_enabled()`](../src/util/mostro_info.rs): only `"true"` shows the Bond button and confirm bond recap. The same instance event may include **`protocol_version`** (`"1"` / `"2"`) for wire transport discovery — see [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md). Fetch instance info from the **Mostro Info** tab (Enter) so gating reflects the connected daemon.
 
 ## UI Components
 

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -8,10 +8,28 @@ See also **[DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md)** for the background `list
 
 ## Communication Protocols
 
-Mostrix uses two Nostr protocols for secure communication:
+Mostrix uses Nostr transports for two distinct purposes:
+
+| Traffic | Transport | Notes |
+|---------|-----------|--------|
+| **Mostro protocol DMs** (orders, take, pay, release, admin actions to daemon) | **v1 GiftWrap** (kind 1059) today; **v2 NIP-44 direct** (kind 14) planned | Auto-selected from instance `protocol_version` tag — see **Protocol v2** below |
+| **P2P order chat** (My Trades) and **admin dispute chat** | NIP-59 GiftWrap via `mostro_core::chat` | Unchanged by protocol v2; shared ECDH keys |
+
+### Protocol v2 discovery (implemented)
+
+Mostro daemons advertise wire format on the **instance status** event (kind **38385**):
+
+- Tag **`protocol_version`**: `"1"` → GiftWrap, `"2"` → NIP-44 direct messages.
+- Mostrix parses this into [`MostroInstanceInfo.protocol_version`](../src/util/mostro_info.rs) and resolves [`Transport`](../src/util/mod.rs) with [`transport_from_instance`](../src/util/mostro_info.rs).
+- [`AppState.transport`](../src/ui/app_state.rs) is kept in sync whenever instance info updates ([`set_mostro_info`](../src/ui/app_state.rs) — used from `main.rs`, reconnect, and pubkey-change paths).
+- The **Mostro Info** tab displays protocol version and resolved wire transport.
+
+**Wire cutover (not yet merged):** `send_dm` still calls `wrap_message` (GiftWrap only); `listen_for_order_messages` still subscribes and gates on kind 1059. Steps 3–7 in [`.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md`](../.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md) will switch to `mostro_core::transport::{wrap_message_with, unwrap_incoming}` and v2 subscription filters (`.author(mostro_pubkey).pubkey(trade_key).kind(14)` for inbound Mostro replies).
+
+### Legacy overview (v1 on the wire today)
 
 1. **NIP-59 (Gift Wrap)**: Primary method for communicating with the Mostro daemon. Provides encryption and authentication.
-2. **NIP-44 (Encrypted Direct Messages)**: Alternative method for peer-to-peer communication (used in some scenarios).
+2. **NIP-44 (Encrypted Direct Messages)**: Used for **protocol v2** direct trade DMs (signed kind-14 + encrypted 3-tuple); not used for Mostro protocol traffic until v2 cutover. Peer chat remains GiftWrap-only.
 
 ### Proof-of-work (NIP-13)
 
@@ -550,7 +568,7 @@ If the response's `request_id` doesn't match the sent request, the operation is 
 
 If a message cannot be decrypted (wrong key, corrupted data, etc.), it is logged and skipped rather than crashing the listener.
 
-### `CantDo` reasons (`mostro-core` 0.12.1+)
+### `CantDo` reasons (`mostro-core` 0.13.0+)
 
 User-facing strings for `Payload::CantDo(Some(reason))` come from [`get_cant_do_description`](../src/util/types.rs). Notable cases:
 - **`InvalidPayload`** — wrong payload shape or impossible values (e.g. `bond_resolution` slashing a side with no bond).
@@ -593,7 +611,7 @@ Admins resolve in-progress disputes by sending encrypted DMs signed with `admin_
 
 **Bond resolution** (Mostro anti-abuse bond Phase 2+): optional `bond_resolution: { slash_seller, slash_buyer }` on both actions only. Four combinations plus legacy `null` (= no slash). See [admin settle](https://mostro.network/protocol/admin_settle_order.html) / [admin cancel](https://mostro.network/protocol/admin_cancel_order.html).
 
-- **Client types**: `mostro-core` 0.12.1 — `BondResolution`, `Payload::BondResolution`, `Status::WaitingMakerBond`.
+- **Client types**: `mostro-core` 0.13.0 — `BondResolution`, `Payload::BondResolution`, `Status::WaitingMakerBond`, `Transport` / transport helpers.
 - **Mostrix helper**: `BondSlashChoice::to_optional_payload()` — `None` for no slash (`payload: null`), `Some(BondResolution)` when slashing; unit tests in `bond_resolution.rs`.
 - **Errors**: invalid slash (e.g. no bond for that side) → `CantDo(InvalidPayload)` → user string from [`get_cant_do_description`](../src/util/types.rs).
 - **Post-slash payout**: `Action::AddBondInvoice` with `Payload::BondPayoutRequest` (order amount = counterparty share, `slashed_at` anchor for claim deadline). Mostrix:

--- a/docs/POW_AND_OUTBOUND_EVENTS.md
+++ b/docs/POW_AND_OUTBOUND_EVENTS.md
@@ -4,17 +4,24 @@ This document describes how Mostrix applies **NIP-13 proof-of-work** to events i
 
 ## Source of difficulty
 
-- The Mostro **instance status** event (kind **38385**) includes an optional `pow` tag (unsigned integer). Mostrix parses this into [`MostroInstanceInfo.pow`](../src/util/mostro_info.rs) (`Option<u32>`).
+- The Mostro **instance status** event (kind **38385**) includes optional tags:
+  - **`pow`** — unsigned integer; parsed into [`MostroInstanceInfo.pow`](../src/util/mostro_info.rs) (`Option<u32>`).
+  - **`protocol_version`** — `"1"` or `"2"`; parsed into [`MostroInstanceInfo.protocol_version`](../src/util/mostro_info.rs). Drives [`transport_from_instance`](../src/util/mostro_info.rs) → [`AppState.transport`](../src/ui/app_state.rs) (display + future send/listener selection). Missing tag → legacy GiftWrap.
 - There is **no** `pow` field in [`Settings`](../src/settings.rs) or in the generated `settings.toml` template. Legacy configs may still contain `pow = …`; serde typically ignores unknown keys when deserializing.
 - **Effective bits** for signing: [`nostr_pow_from_instance`](../src/util/mostro_info.rs) maps `Option<&MostroInstanceInfo>` → `u8` by taking `info.pow`, clamping to `u8::MAX`, and using **0** when info is missing or `pow` is `None`.
 
 ## Cached instance info at runtime
 
 - [`AppState.mostro_info`](../src/ui/app_state.rs) holds the latest fetched `MostroInstanceInfo`.
+- [`AppState.transport`](../src/ui/app_state.rs) mirrors the resolved [`Transport`](../src/util/mod.rs) (`GiftWrap` vs `Nip44Direct`). Set together with info via [`set_mostro_info`](../src/ui/app_state.rs).
 - [`EnterKeyContext`](../src/ui/key_handler/mod.rs) includes `mostro_info: Option<MostroInstanceInfo>` so Enter/spawn paths can pass the same snapshot into async work without re-fetching relays per message.
 - [`send_dm`](../src/util/dm_utils/mod.rs) takes `mostro_instance: Option<&MostroInstanceInfo>` and computes `pow = nostr_pow_from_instance(mostro_instance)` once per send.
 
-If instance info has not been loaded yet (e.g. slow startup), PoW may be **0** until a successful fetch or manual refresh (Mostro Info tab / background refresh tasks). Users may see rejects from strict instances until 38385 is cached.
+If instance info has not been loaded yet (e.g. slow startup), PoW may be **0** and transport defaults to **GiftWrap** until a successful fetch or manual refresh (Mostro Info tab / background refresh tasks). Users may see rejects from strict instances until 38385 is cached.
+
+## Protocol v2 (NIP-44 direct) — PoW note
+
+On v2 nodes, PoW applies to the **signed kind-14** event (same `WrapOptions.pow` path in `mostro_core::transport::wrap_message_with`). Mostrix has not switched `send_dm` to that helper yet; see [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) and the protocol v2 plan in [docs/README.md](README.md#protocol-v2-nip-44--in-progress). First-contact actions may need higher PoW than instance `pow` (`pow_first_contact` on the daemon — not advertised in 38385 today).
 
 ## Gift Wrap (NIP-59 / kind 1059)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 
 - **Startup & Configuration**: [STARTUP_AND_CONFIG.md](STARTUP_AND_CONFIG.md) — Boot sequence, settings (`blossom_servers`), background tasks, DM router wiring, reconnect; main loop **drains save/send-attachment and operation-result channels before draw** (150 ms refresh)
 - **DM listener & router**: [DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md) — `listen_for_order_messages`, TrackOrder vs waiter, startup `fetch_events` replay, in-memory `OrderMessage` list; **`Action::CantDo`** ignored in `handle_trade_dm_for_order` (errors use waiter / `OperationResult`, not Messages upserts)
-- **Message Flow & Protocol**: [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) — How Mostrix talks to Mostro over Nostr (orders, GiftWrap, restarts, cooperative cancel / `TradeClosed`); **maker bond** (`send_new_order` → `PayBondInvoice` / `PaymentRequestRequired`, deferred `NewOrder` after payment); **My Trades user order chat** relay sync, own-message echo skip, attachment receive/save, **outbound send** (Ctrl+O picker, trade-key Blossom auth, mobile-compatible wire JSON, upload-then-send retry / **Ctrl+Shift+O**, `pending_order_attachment_sends`), **JSON transcript persistence** (Ctrl+S after restart)
-- **PoW & outbound events**: [POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md) — Instance `pow` (kind 38385), `nostr_pow_from_instance`, Gift Wrap outer mining (`gift_wrap_from_seal_with_pow`)
+- **Message Flow & Protocol**: [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) — How Mostrix talks to Mostro over Nostr (orders, GiftWrap, restarts, cooperative cancel / `TradeClosed`); **protocol v2 discovery** (`protocol_version` on kind 38385 → `AppState.transport`; wire cutover in progress — see [Protocol v2 (NIP-44)](#protocol-v2-nip-44-in-progress)); **maker bond** (`send_new_order` → `PayBondInvoice` / `PaymentRequestRequired`, deferred `NewOrder` after payment); **My Trades user order chat** relay sync, own-message echo skip, attachment receive/save, **outbound send** (Ctrl+O picker, trade-key Blossom auth, mobile-compatible wire JSON, upload-then-send retry / **Ctrl+Shift+O**, `pending_order_attachment_sends`), **JSON transcript persistence** (Ctrl+S after restart)
+- **PoW & outbound events**: [POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md) — Instance `pow` (kind 38385), `nostr_pow_from_instance`, Gift Wrap outer mining (`gift_wrap_from_seal_with_pow`); v2 will apply PoW on signed kind-14 (see protocol v2 section in MESSAGE_FLOW)
 - **Database**: [DATABASE.md](DATABASE.md) — SQLite schema, `orders` / `users` / `admin_disputes`, migrations; **relay → SQLite reconcile** for terminal order statuses (`relay_order_db_reconcile.rs`)
 - **Key Management**: [KEY_MANAGEMENT.md](KEY_MANAGEMENT.md) — Deterministic derivation (NIP-06 path), identity vs trade keys
 
@@ -37,4 +37,15 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 ## Implementation plans (AI / contributors)
 
 - Tracked Markdown plans for larger features live under **[`.cursor/plans/`](../.cursor/plans/README.md)** (git-tracked; see root `.gitignore` exceptions). Use them to capture design decisions and link to `src/` paths for codegen and reviews. Example: [admin dispute bond slash](../.cursor/plans/admin_dispute_bond_slash.plan.md). **My Trades attachments**: receive/save, JSON transcripts, outbound send (encrypt → Blossom → DM) — see [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md).
+
+## Protocol v2 (NIP-44) — in progress
+
+Mostrix is gaining **dual-transport** support for Mostro **protocol DMs** (not P2P order chat or admin dispute chat — those stay on GiftWrap).
+
+| Status | What |
+|--------|------|
+| **Done** | `mostro-core` **0.13.0**; parse `protocol_version` (`"1"` / `"2"`) from kind **38385**; [`transport_from_instance`](../src/util/mostro_info.rs); [`AppState.transport`](../src/ui/app_state.rs) via [`set_mostro_info`](../src/ui/app_state.rs); Mostro Info tab shows protocol version + wire transport |
+| **Pending** | `wrap_message_with` / `unwrap_incoming` in `send_dm` and DM listener; transport-aware relay filters (v2: `.author(mostro).pubkey(trade_key).kind(14)`); await instance info before spawning DM listener |
+
+Design reference: [`.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md`](../.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md). Until cutover, **all trade DMs still use GiftWrap on the wire** even when the instance advertises `protocol_version: "2"`.
 

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -132,6 +132,16 @@ pub struct Settings {
 
 Proof-of-work for published events is taken from the Mostro instance status event (kind 38385, tag `pow`), not from `settings.toml`.
 
+### Mostro instance info (kind 38385)
+
+Background and manual refresh (Mostro Info tab → Enter) fetch the daemon status event and update UI state:
+
+- **`AppState.mostro_info`**: parsed tags (`pow`, `bond_enabled`, `protocol_version`, LND metadata, …) — see [`mostro_info_from_tags`](../src/util/mostro_info.rs).
+- **`AppState.transport`**: resolved wire transport for **protocol DMs** via [`transport_from_instance`](../src/util/mostro_info.rs). Updated only through [`AppState.set_mostro_info`](../src/ui/app_state.rs) (main loop `MostroInfoFetchResult`, reconnect, invalid-pubkey clear).
+- **Startup today**: instance info may still load *after* the DM listener spawns (`spawn_refresh_mostro_info_task` is async). Protocol v2 work will **await** instance info before starting the listener so `transport` is known at subscribe time (see [docs/README.md — Protocol v2](README.md#protocol-v2-nip-44--in-progress)).
+
+Displayed on the **Mostro Info** tab: protocol version (`1` / `2` / unknown) and wire transport label (GiftWrap vs NIP-44 direct).
+
 ## Nostr & Background Tasks
 
 ### Nostr Client Connection

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,16 +474,16 @@ async fn main() -> Result<(), anyhow::Error> {
                 if let Some(res) = mostro_info_result {
                     match res {
                         MostroInfoFetchResult::Ok { info, message } => {
-                            app.mostro_info = *info;
+                            app.set_mostro_info(*info);
                             app.mode = crate::ui::UiMode::operation_result(
                                 crate::ui::OperationResult::Info(message),
                             );
                         }
                         MostroInfoFetchResult::Applied { info } => {
-                            app.mostro_info = *info;
+                            app.set_mostro_info(*info);
                         }
                         MostroInfoFetchResult::Err(e) => {
-                            app.mostro_info = None;
+                            app.set_mostro_info(None);
                             app.mode = crate::ui::UiMode::operation_result(
                                 crate::ui::OperationResult::Error(e),
                             );

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use uuid::Uuid;
 
-use mostro_core::prelude::Action;
+use mostro_core::prelude::{Action, Transport};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::models::AdminDispute;
@@ -20,7 +20,7 @@ use crate::ui::orders::{
     MessageViewState, OperationResult, OrderChatStaticHeader, OrderMessage, RatingOrderState,
 };
 use crate::ui::user_state::UserMode;
-use crate::util::MostroInstanceInfo;
+use crate::util::{transport_from_instance, MostroInstanceInfo};
 use nostr_sdk::Keys;
 
 #[derive(Debug)]
@@ -236,6 +236,8 @@ pub struct AppState {
     pub currencies_filter: Vec<String>,
     /// Cached Mostro instance info (kind 38385 event), if available.
     pub mostro_info: Option<MostroInstanceInfo>,
+    /// Wire transport resolved from [`Self::mostro_info`] (`protocol_version` tag).
+    pub transport: Transport,
     /// Non-blocking overlay shown when relays are unreachable.
     pub offline_overlay_message: Option<String>,
     /// True only when BackupNewKeys was opened after runtime key rotation.
@@ -311,6 +313,7 @@ impl AppState {
             pending_admin_disputes_reload: false,
             currencies_filter: Vec::new(),
             mostro_info: None,
+            transport: Transport::default(),
             offline_overlay_message: None,
             backup_requires_restart: false,
             pending_key_reload: false,
@@ -318,6 +321,12 @@ impl AppState {
             pending_post_take_operation_result: None,
             fatal_exit_on_close: false,
         }
+    }
+
+    /// Replace cached instance info and keep [`Self::transport`] in sync.
+    pub fn set_mostro_info(&mut self, info: Option<MostroInstanceInfo>) {
+        self.transport = transport_from_instance(info.as_ref());
+        self.mostro_info = info;
     }
 
     /// Securely wipe all observer inputs and fetched content.

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -617,7 +617,7 @@ pub async fn reload_runtime_session_after_reconnect(
     };
     match fetch_mostro_instance_info(ctx.client, mostro_pubkey).await {
         Ok(Some(info)) => {
-            ctx.app.mostro_info = Some(info);
+            ctx.app.set_mostro_info(Some(info));
         }
         Ok(None) => {
             // Keep prior info if any; not an error.

--- a/src/ui/key_handler/confirmation.rs
+++ b/src/ui/key_handler/confirmation.rs
@@ -126,7 +126,7 @@ pub fn handle_confirm_key(
                 Ok(pk) => pk,
                 Err(e) => {
                     log::error!("Invalid pubkey after confirmation: {}", e);
-                    app.mostro_info = None;
+                    app.set_mostro_info(None);
                     return true;
                 }
             };

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -4,7 +4,9 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
-use crate::util::{format_instance_info_age, MostroInstanceInfo};
+use crate::util::{
+    format_instance_info_age, transport_from_instance, MostroInstanceInfo, Transport,
+};
 
 pub fn render_mostro_info_tab(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     let block = Block::default()
@@ -84,6 +86,16 @@ fn build_info_lines(info: &MostroInstanceInfo) -> Vec<Line<'static>> {
         &mut lines,
         "Github commit hash",
         info.mostro_commit_hash.as_deref().unwrap_or("unknown"),
+    );
+    let protocol_version = match info.protocol_version {
+        Some(v) => v.to_string(),
+        None => "unknown".to_string(),
+    };
+    push_kv(&mut lines, "Protocol version", &protocol_version);
+    push_kv(
+        &mut lines,
+        "Wire transport",
+        transport_display_label(transport_from_instance(Some(info))),
     );
     push_opt_i64(&mut lines, "Max order amount (sats)", info.max_order_amount);
     push_opt_i64(&mut lines, "Min order amount (sats)", info.min_order_amount);
@@ -168,6 +180,13 @@ fn build_info_lines(info: &MostroInstanceInfo) -> Vec<Line<'static>> {
     )));
 
     lines
+}
+
+fn transport_display_label(transport: Transport) -> &'static str {
+    match transport {
+        Transport::GiftWrap => "GiftWrap (NIP-59)",
+        Transport::Nip44Direct => "NIP-44 direct",
+    }
 }
 
 fn section_title(title: &str) -> Line<'static> {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -38,10 +38,11 @@ pub use filters::{
     create_filter, create_mostro_list_fetch_filter, filter_giftwrap_to_recipient,
     MOSTRO_LIST_FETCH_EVENT_LIMIT,
 };
+pub use mostro_core::prelude::{unwrap_incoming, wrap_message_with, Transport};
 pub use mostro_info::{
     fetch_mostro_instance_info, fetch_mostro_instance_info_from_settings, format_instance_info_age,
-    instance_bonds_enabled, mostro_info_from_tags, nostr_pow_from_instance, MostroInstanceInfo,
-    MOSTRO_INSTANCE_INFO_KIND,
+    instance_bonds_enabled, mostro_info_from_tags, nostr_pow_from_instance,
+    transport_from_instance, MostroInstanceInfo, MOSTRO_INSTANCE_INFO_KIND,
 };
 pub use network::{any_relay_reachable, connect_client_safely};
 pub use order_utils::{fetch_events_list, get_disputes, get_orders, send_new_order, take_order};

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -1,6 +1,7 @@
 use crate::settings::load_settings_from_disk;
 use crate::util::dm_utils::FETCH_EVENTS_TIMEOUT;
 use anyhow::{anyhow, Result};
+use mostro_core::prelude::Transport;
 use nostr_sdk::prelude::*;
 use std::str::FromStr;
 
@@ -44,6 +45,8 @@ pub struct MostroInstanceInfo {
     pub max_orders_per_response: Option<u32>,
     pub fee: Option<f64>,
     pub pow: Option<u32>,
+    /// Wire transport version from kind-38385 tag `protocol_version` (`"1"` / `"2"`).
+    pub protocol_version: Option<u8>,
     /// Anti-abuse bond feature flag from kind-38385 tag `bond_enabled` (`"true"` / `"false"`).
     pub bond_enabled: Option<bool>,
     pub hold_invoice_expiration_window: Option<u64>,
@@ -80,6 +83,10 @@ impl MostroInstanceInfo {
         value.parse::<u32>().ok()
     }
 
+    fn parse_u8(value: &str) -> Option<u8> {
+        value.parse::<u8>().ok()
+    }
+
     fn parse_f64(value: &str) -> Option<f64> {
         value.parse::<f64>().ok()
     }
@@ -109,6 +116,16 @@ pub fn nostr_pow_from_instance(instance: Option<&MostroInstanceInfo>) -> u8 {
 /// until the daemon explicitly advertises `"true"`.
 pub fn instance_bonds_enabled(instance: Option<&MostroInstanceInfo>) -> bool {
     instance.and_then(|i| i.bond_enabled) == Some(true)
+}
+
+/// Resolve the Mostro protocol wire transport from cached instance info.
+///
+/// Missing or unknown `protocol_version` defaults to legacy v1 GiftWrap.
+pub fn transport_from_instance(info: Option<&MostroInstanceInfo>) -> Transport {
+    match info.and_then(|i| i.protocol_version) {
+        Some(2) => Transport::Nip44Direct,
+        _ => Transport::GiftWrap,
+    }
 }
 
 fn parse_bond_enabled(value: &str) -> Option<bool> {
@@ -165,6 +182,9 @@ pub fn mostro_info_from_tags(tags: Tags) -> Result<MostroInstanceInfo> {
             }
             "pow" => {
                 info.pow = MostroInstanceInfo::parse_u32(value);
+            }
+            "protocol_version" => {
+                info.protocol_version = MostroInstanceInfo::parse_u8(value);
             }
             "bond_enabled" => {
                 info.bond_enabled = parse_bond_enabled(value);
@@ -252,6 +272,7 @@ pub async fn fetch_mostro_instance_info_from_settings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mostro_core::prelude::Transport;
     use nostr_sdk::prelude::{Tag, Tags};
 
     #[test]
@@ -392,6 +413,54 @@ mod tests {
                 ..Default::default()
             })),
             u8::MAX
+        );
+    }
+
+    #[test]
+    fn parse_protocol_version_from_tags() {
+        let mut tags = Tags::new();
+        tags.push(Tag::parse(["protocol_version", "2"]).unwrap());
+        let result = mostro_info_from_tags(tags).unwrap();
+        assert_eq!(result.protocol_version, Some(2));
+
+        let mut tags = Tags::new();
+        tags.push(Tag::parse(["protocol_version", "1"]).unwrap());
+        let result = mostro_info_from_tags(tags).unwrap();
+        assert_eq!(result.protocol_version, Some(1));
+
+        let mut tags = Tags::new();
+        tags.push(Tag::parse(["protocol_version", "bad"]).unwrap());
+        let result = mostro_info_from_tags(tags).unwrap();
+        assert!(result.protocol_version.is_none());
+    }
+
+    #[test]
+    fn transport_from_instance_resolves_protocol_version() {
+        assert_eq!(transport_from_instance(None), Transport::GiftWrap);
+        assert_eq!(
+            transport_from_instance(Some(&MostroInstanceInfo::default())),
+            Transport::GiftWrap
+        );
+        assert_eq!(
+            transport_from_instance(Some(&MostroInstanceInfo {
+                protocol_version: Some(1),
+                ..Default::default()
+            })),
+            Transport::GiftWrap
+        );
+        assert_eq!(
+            transport_from_instance(Some(&MostroInstanceInfo {
+                protocol_version: Some(2),
+                ..Default::default()
+            })),
+            Transport::Nip44Direct
+        );
+        assert_eq!(
+            transport_from_instance(Some(&MostroInstanceInfo {
+                protocol_version: Some(99),
+                ..Default::default()
+            })),
+            Transport::GiftWrap
         );
     }
 


### PR DESCRIPTION
## Summary

First slice of **protocol v2 (NIP-44 direct messages)** support — discovery and dependency groundwork only. Trade DMs still use GiftWrap on the wire until follow-up PRs land the listener and `send_dm` cutover.

- Bump `mostro-core` **0.12.1 → 0.13.0** and re-export `Transport`, `wrap_message_with`, `unwrap_incoming`
- Parse `protocol_version` (`"1"` / `"2"`) from Mostro instance info (kind 38385)
- Add `transport_from_instance()` and keep `AppState.transport` in sync via `set_mostro_info()`
- Show protocol version and wire transport on the **Mostro Info** tab
- Unit tests for tag parsing and transport resolution
- Update contributor docs with v2 status (done vs pending)

## Context

Mostro v2 nodes advertise `protocol_version: "2"` on instance info. Mostrix needs to auto-select GiftWrap vs NIP-44 direct for **protocol DMs** (P2P order chat and admin dispute chat stay on GiftWrap). This PR wires discovery and UI; steps 3–7 in `.cursor/plans/protocol_v2_nip-44_ca93af46.plan.md` handle filters, `send_dm`, and the DM listener.

## Breaking changes

None — behavior unchanged on the wire (still v1 GiftWrap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mostro Info tab now displays the connected instance's protocol version and resolved wire transport type.

* **Documentation**
  * Expanded documentation to explain Protocol v2 (NIP-44 direct) dual-transport support rolling out, including message flow, state synchronization, and proof-of-work handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->