### PR TITLE
feat(protocol): unify inbound DM parse on unwrap_incoming (v2 step 5)

### DIFF
--- a/docs/DM_LISTENER_FLOW.md
+++ b/docs/DM_LISTENER_FLOW.md
@@ -5,7 +5,7 @@ This document explains the runtime flow inside `listen_for_order_messages` (in `
 - how the in-memory **message list** (`Vec<OrderMessage>`) is created/updated
 - how “preferences”/routing concepts work: **TrackOrder**, **Waiter**, **Database**, **Action**, **Status**, notifications, and terminal cleanup
 
-> **Protocol v2 (in progress):** Filters use [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (v2 clamped to GiftWrap until inbound step 5–6). Outbound [`send_dm`](../src/util/dm_utils/mod.rs) uses `wrap_message_with`. See [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
+> **Protocol v2 (in progress):** Filters use [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (v2 clamped to GiftWrap until step 6). Outbound [`send_dm`](../src/util/dm_utils/mod.rs) uses `wrap_message_with`; parse/replay uses [`unwrap_incoming`](../src/util/mod.rs). See [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
 
 ## Big picture
 
@@ -65,7 +65,7 @@ Relay subscriptions alone often **do not** deliver enough stored history into th
 
 - Takes a **`DmListenerStartupReplay`** snapshot (`client`, `mostro_pubkey`, `transport`, `pool`, `user`, messages, notification maps, subscription maps).
 - For each startup order with a known subscription id, **queries relays** with `client.fetch_events` using `dm_listener_subscribe_transport(transport)` + [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + `since` + limit 100 (12-hour lookback — `STARTUP_TRADE_DM_LOOKBACK_SECS` / `STARTUP_TRADE_DM_FETCH_LIMIT`).
-- Within that fetched window, decrypts each event with `unwrap_message` (GiftWrap only today) and parses with **`parse_dm_events_single`**, then picks the **single** parsed triple **`(Message, rumor created_at, sender)`** whose **rumor timestamp is greatest** (tie-break: Nostr event id). Envelope order can disagree with rumor time; replaying the full batch in sort order could hydrate an **older** trade step, so only this **newest-rumor** line is replayed.
+- Within that fetched window, decrypts each event with [`unwrap_incoming`](../src/util/mod.rs) and parses with **`parse_dm_events_single`**, then picks the **single** parsed triple **`(Message, rumor created_at, sender)`** whose **rumor timestamp is greatest** (tie-break: Nostr event id). Envelope order can disagree with rumor time; replaying the full batch in sort order could hydrate an **older** trade step, so only this **newest-rumor** line is replayed.
 - Dispatches **`dispatch_giftwrap_batch(vec![freshest], …, notify: false)`** — i.e. one message per order. The **`notify`** flag is passed through to **`handle_trade_dm_for_order`** so startup replay does not bump the unread badge or re-trigger invoice popups (`notify: false` here; live relay paths use **`notify: true`**).
 
 **Practical “where to look”**: `fetch_and_replay_startup_trade_dms`, struct **`DmListenerStartupReplay`**, **`dispatch_giftwrap_batch`** (batch of one at startup), and **`notify`** on **`handle_trade_dm_for_order`** / **`dispatch_giftwrap_batch`** in `src/util/dm_utils/mod.rs`.

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -35,14 +35,14 @@ Mostro daemons advertise wire format on the **instance status** event (kind **38
 | v1 GiftWrap | `.pubkey(trade_key).kind(1059)` |
 | v2 NIP-44 | `.author(mostro_pubkey).pubkey(trade_key).kind(14)` |
 
-Used by `dm_helpers::ensure_order_dm_subscription`, startup `fetch_and_replay_startup_trade_dms`, and `RegisterWaiter`. Filters pass through [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (**v2 clamped to GiftWrap** until inbound steps 5–6).
+Used by `dm_helpers::ensure_order_dm_subscription`, startup `fetch_and_replay_startup_trade_dms`, and `RegisterWaiter`. Filters pass through [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (**v2 clamped to GiftWrap** until step 6).
 
-**Still pending:** `unwrap_incoming`, event gate, remove clamp — [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
+**Still pending:** event gate, listener waiter decrypt → `unwrap_incoming`, remove clamp — [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
 
 ### Legacy overview
 
 1. **NIP-59 Gift Wrap (1059)**: Protocol v1 wire format and all P2P chat.
-2. **NIP-44 direct (signed kind 14)**: Protocol v2 for Mostro DMs — **outbound live** via `send_dm`; inbound in progress.
+2. **NIP-44 direct (signed kind 14)**: Protocol v2 for Mostro DMs — **outbound live** via `send_dm`; **parse/replay** via `unwrap_incoming`; live listener subscribe/gate still step 6.
 
 ### Proof-of-work (NIP-13)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,8 +44,8 @@ Mostrix is gaining **dual-transport** support for Mostro **protocol DMs** (not P
 
 | Status | What |
 |--------|------|
-| **Done** | `mostro-core` **0.13.0**; `protocol_version` on kind **38385**; [`transport_from_instance`](../src/util/mostro_info.rs); [`AppState.transport`](../src/ui/app_state.rs); Mostro Info tab; [`filter_protocol_dm_from_mostro`](../src/util/filters.rs); **await instance info** before listener (startup + [`dm_transport_for_mostro`](../src/ui/key_handler/async_tasks.rs) on reload/reconnect); **`send_dm` → `wrap_message_with`** + v2 NIP-40 expiration (30 days) |
-| **Pending** | `unwrap_incoming` in inbound parse; event gate `transport.event_kind()`; remove [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) clamp; restart listener on manual Mostro Info refresh when transport flips |
+| **Done** | `mostro-core` **0.13.0**; `protocol_version` on kind **38385**; [`transport_from_instance`](../src/util/mostro_info.rs); [`AppState.transport`](../src/ui/app_state.rs); Mostro Info tab; [`filter_protocol_dm_from_mostro`](../src/util/filters.rs); **await instance info** before listener (startup + [`dm_transport_for_mostro`](../src/ui/key_handler/async_tasks.rs) on reload/reconnect); **`send_dm` → `wrap_message_with`** + v2 NIP-40 expiration (30 days); **`parse_dm_events` / startup replay / fallback → `unwrap_incoming`** |
+| **Pending** | Event gate `transport.event_kind()`; listener waiter decrypt → `unwrap_incoming`; remove [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) clamp; restart listener on manual Mostro Info refresh when transport flips |
 
-**Asymmetric v2 today:** outbound uses `wrap_message_with` per `protocol_version`; inbound subscribe/fetch are **clamped to GiftWrap** until steps 5–6. v2-only nodes can send but not receive protocol DMs yet.
+**Asymmetric v2 today:** outbound and **parse** paths support both transports; inbound subscribe/fetch are **clamped to GiftWrap** and the live listener still gates on kind **1059** until step 6. v2-only nodes can send but will not receive protocol DMs until step 6.
 

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -282,16 +282,12 @@ where
     Ok(events)
 }
 
-/// Parse DM events to extract Messages
+/// Parse DM events to extract Messages (v1 GiftWrap and v2 kind 14 via [`unwrap_incoming`]).
 pub async fn parse_dm_events(
     events: Events,
     pubkey: &Keys,
     since: Option<&i64>,
 ) -> Vec<(Message, i64, PublicKey)> {
-    use base64::engine::general_purpose;
-    use base64::Engine;
-    use nip44::v2::{decrypt_to_bytes, ConversationKey};
-
     let mut id_set = HashSet::<EventId>::new();
     let mut direct_messages: Vec<(Message, i64, PublicKey)> = Vec::new();
 
@@ -301,49 +297,13 @@ pub async fn parse_dm_events(
             continue;
         }
 
-        let (created_at, message, sender) = match dm.kind {
-            nostr_sdk::Kind::GiftWrap => match unwrap_message(dm, pubkey).await {
-                Ok(None) => continue,
-                Err(e) => {
-                    log::warn!("Could not unwrap gift wrap (event {}): {}", dm.id, e);
-                    continue;
-                }
-                Ok(Some(u)) => (u.created_at, u.message, u.sender),
-            },
-            nostr_sdk::Kind::PrivateDirectMessage => {
-                let ck = if let Ok(ck) = ConversationKey::derive(pubkey.secret_key(), &dm.pubkey) {
-                    ck
-                } else {
-                    continue;
-                };
-                let b64decoded_content =
-                    match general_purpose::STANDARD.decode(dm.content.as_bytes()) {
-                        Ok(b64decoded_content) => b64decoded_content,
-                        Err(_) => {
-                            continue;
-                        }
-                    };
-                let unencrypted_content = match decrypt_to_bytes(&ck, &b64decoded_content) {
-                    Ok(bytes) => bytes,
-                    Err(_) => {
-                        continue;
-                    }
-                };
-                let message_str = match String::from_utf8(unencrypted_content) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        continue;
-                    }
-                };
-                let message = match Message::from_json(&message_str) {
-                    Ok(m) => m,
-                    Err(_) => {
-                        continue;
-                    }
-                };
-                (dm.created_at, message, dm.pubkey)
+        let (created_at, message, sender) = match unwrap_incoming(dm, pubkey).await {
+            Ok(None) => continue,
+            Err(e) => {
+                log::warn!("Could not unwrap protocol DM (event {}): {}", dm.id, e);
+                continue;
             }
-            _ => continue,
+            Ok(Some(u)) => (u.created_at, u.message, u.sender),
         };
 
         // Check if the message is older than the since time if it is, skip it
@@ -363,9 +323,9 @@ pub async fn parse_dm_events(
     direct_messages
 }
 
-/// Parse one GiftWrap [`Event`] with the trade key (`since: None`). Shared by relay notifications and startup replay.
+/// Parse one protocol DM [`Event`] with the trade key (`since: None`). Shared by relay notifications and startup replay.
 ///
-/// When `pre_unwrapped` is set (e.g. after a successful `unwrap_message`), skips a second unwrap.
+/// When `pre_unwrapped` is set (e.g. after a successful [`unwrap_incoming`]), skips a second unwrap.
 async fn parse_dm_events_single(
     event: &Event,
     trade_keys: &Keys,
@@ -1264,12 +1224,12 @@ async fn fetch_and_replay_startup_trade_dms(
 
         let mut best: Option<(i64, EventId, (Message, i64, PublicKey))> = None;
         for event in &event_list {
-            let unwrapped = match unwrap_message(event, &trade_keys).await {
+            let unwrapped = match unwrap_incoming(event, &trade_keys).await {
                 Ok(Some(u)) => u,
                 Ok(None) => continue,
                 Err(e) => {
                     log::warn!(
-                        "Startup DM replay: unwrap_message failed (event {}): {}",
+                        "Startup DM replay: unwrap_incoming failed (event {}): {}",
                         event.id,
                         e
                     );
@@ -1413,7 +1373,7 @@ async fn resolve_order_for_event(
             Ok(k) => k,
             Err(_) => continue,
         };
-        match unwrap_message(event, &trade_keys).await {
+        match unwrap_incoming(event, &trade_keys).await {
             Ok(Some(unwrapped)) => {
                 let duration_ms = started.elapsed().as_millis() as u64;
                 GIFTWRAP_FALLBACK_LAST_DURATION_MS.store(duration_ms, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

Protocol v2 **step 5** — unify inbound Mostro protocol DM parsing on `mostro-core::unwrap_incoming`.

- Refactor [`parse_dm_events`](src/util/dm_utils/mod.rs) to call `unwrap_incoming` for all events (GiftWrap + signed kind 14)
- Remove the broken legacy kind-14 branch (raw NIP-44 decrypt of bare `Message` JSON — incorrect v2 wire format)
- Update startup replay (`fetch_and_replay_startup_trade_dms`) and unknown-subscription fallback (`resolve_order_for_event`) to use `unwrap_incoming`
- Update contributor docs for asymmetric v2 state: parse/replay ready; live listener still gates on kind 1059 until step 6

Builds on #88 (outbound `wrap_message_with`), #87 (transport filters), #86 (transport discovery).

## Context

| Layer | v1 | v2 (after this PR) |
|-------|----|--------------------|
| **Outbound** | GiftWrap | kind 14 + identity proof |
| **Parse** (`parse_dm_events`, replay, fallback) | `unwrap_incoming` → GiftWrap path | `unwrap_incoming` → kind 14 path |
| **Live listener** | kind 1059 gate + GiftWrap subscribe clamp | unchanged — **step 6** |

v2 nodes still cannot **receive** live protocol DMs until step 6 removes the subscribe clamp and transport-aware event gate. `wait_for_dm` responses will decode correctly once kind-14 events reach the client.

## Breaking changes

None for v1 nodes (`unwrap_incoming` delegates to the existing GiftWrap path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated protocol documentation to reflect current Direct Message handling flow and transition details between protocol versions.

* **Refactor**
  * Improved internal Direct Message parsing to use unified decryption approach, supporting both v1 and v2 message formats with better fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->