### PR TITLE
feat(protocol): transport-aware DM listener for v2 inbound (step 6)

### DIFF
--- a/docs/DM_LISTENER_FLOW.md
+++ b/docs/DM_LISTENER_FLOW.md
@@ -5,7 +5,7 @@ This document explains the runtime flow inside `listen_for_order_messages` (in `
 - how the in-memory **message list** (`Vec<OrderMessage>`) is created/updated
 - how “preferences”/routing concepts work: **TrackOrder**, **Waiter**, **Database**, **Action**, **Status**, notifications, and terminal cleanup
 
-> **Protocol v2 (in progress):** Filters use [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (v2 clamped to GiftWrap until step 6). Outbound [`send_dm`](../src/util/dm_utils/mod.rs) uses `wrap_message_with`; parse/replay uses [`unwrap_incoming`](../src/util/mod.rs). See [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
+> **Protocol v2:** Filters use [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) per resolved transport. Outbound [`send_dm`](../src/util/dm_utils/mod.rs) uses `wrap_message_with`; inbound parse and listener decrypt use [`unwrap_incoming`](../src/util/mod.rs). Event gate: `event.kind == transport.event_kind()`. See [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
 
 ## Big picture
 
@@ -29,7 +29,7 @@ Mostrix has a **single background task** that:
   Lets TrackOrder “rebind” a pubkey that was subscribed earlier by a waiter without subscribing twice.
 
 - **`pending_waiters: Vec<PendingDmWaiter>`**  
-  Each waiter is a oneshot sender plus the `trade_keys` to test whether the incoming GiftWrap can be decrypted for that operation.
+  Each waiter is a oneshot sender plus the `trade_keys` to test whether the incoming protocol DM can be decrypted for that operation.
 
 - **`active_order_trade_indices: Arc<Mutex<HashMap<Uuid, i64>>>`** *(shared with the rest of the app)*  
   Tracks which orders are currently “active” and which `trade_index` (hence which trade key) belongs to each `order_id`.
@@ -53,7 +53,7 @@ The in-memory **Messages** list (`Vec<OrderMessage>`) is **not** persisted. Only
 `listen_for_order_messages(client, mostro_pubkey, transport, …)` clones the active-order map and, for each `(order_id, trade_index)`:
 
 1. derives `trade_keys` from the persisted `User` seed + trade index
-2. subscribes via `dm_helpers::ensure_order_dm_subscription` (filter = `filter_protocol_dm_from_mostro` → `dm_listener_subscribe_transport`) with a mode from `DmSubscriptionMode`:
+2. subscribes via `dm_helpers::ensure_order_dm_subscription` (filter = `filter_protocol_dm_from_mostro(transport, …)`) with a mode from `DmSubscriptionMode`:
    - **`StartupCatchUp`** (no `last_seen_dm_ts` yet): latest retained event (`limit(1)`) — tight catch-up
    - **`StartupSince(ts)`** (cursor present): `since(ts)` for incremental subscription
    - **`LiveOnly`** (used after `TrackOrder` during live flows, e.g. take-order): **`.limit(0)`** live stream — **not** `.since(now)`, so Same-second Mostro replies are not dropped when `take_order` sends an early `TrackOrder` before `wait_for_dm` (the pubkey is already subscribed once; a second waiter subscription is skipped)
@@ -64,7 +64,7 @@ The in-memory **Messages** list (`Vec<OrderMessage>`) is **not** persisted. Only
 Relay subscriptions alone often **do not** deliver enough stored history into the notification stream to refill the UI. Immediately after the bootstrap `subscribe` loop, the listener runs **`fetch_and_replay_startup_trade_dms`**:
 
 - Takes a **`DmListenerStartupReplay`** snapshot (`client`, `mostro_pubkey`, `transport`, `pool`, `user`, messages, notification maps, subscription maps).
-- For each startup order with a known subscription id, **queries relays** with `client.fetch_events` using `dm_listener_subscribe_transport(transport)` + [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + `since` + limit 100 (12-hour lookback — `STARTUP_TRADE_DM_LOOKBACK_SECS` / `STARTUP_TRADE_DM_FETCH_LIMIT`).
+- For each startup order with a known subscription id, **queries relays** with `client.fetch_events` using [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) + `since` + limit 100 (12-hour lookback — `STARTUP_TRADE_DM_LOOKBACK_SECS` / `STARTUP_TRADE_DM_FETCH_LIMIT`).
 - Within that fetched window, decrypts each event with [`unwrap_incoming`](../src/util/mod.rs) and parses with **`parse_dm_events_single`**, then picks the **single** parsed triple **`(Message, rumor created_at, sender)`** whose **rumor timestamp is greatest** (tie-break: Nostr event id). Envelope order can disagree with rumor time; replaying the full batch in sort order could hydrate an **older** trade step, so only this **newest-rumor** line is replayed.
 - Dispatches **`dispatch_giftwrap_batch(vec![freshest], …, notify: false)`** — i.e. one message per order. The **`notify`** flag is passed through to **`handle_trade_dm_for_order`** so startup replay does not bump the unread badge or re-trigger invoice popups (`notify: false` here; live relay paths use **`notify: true`**).
 
@@ -95,7 +95,7 @@ Use case: “I’m about to send a request DM; wait for the first decryptable re
 What happens:
 
 - Waiters are bounded (`MAX_PENDING_WAITERS`), and periodically garbage-collected (drops closed oneshots).
-- If this trade pubkey is not yet subscribed, the listener subscribes with `dm_listener_subscribe_transport(transport)` + `filter_protocol_dm_from_mostro(…).limit(0)` and records the `SubscriptionId` in `pubkey_to_subscription`.
+- If this trade pubkey is not yet subscribed, the listener subscribes with `filter_protocol_dm_from_mostro(transport, …).limit(0)` and records the `SubscriptionId` in `pubkey_to_subscription`.
 - The waiter subscription uses a **live-only** filter (`.limit(0)`), which avoids
   replay backlog and prevents missing immediate responses due to same-second `since(now)` cutoff.
 - The waiter is pushed into `pending_waiters`.
@@ -104,7 +104,7 @@ What happens:
 
 ## Incoming protocol DM event routing (the heart of the flow)
 
-When a relay event arrives (`RelayPoolNotification::Event`) and `event.kind == GiftWrap` *(v2: will use `transport.event_kind()` — step 6)*:
+When a relay event arrives (`RelayPoolNotification::Event`) and `event.kind == transport.event_kind()`:
 
 ### Step A — satisfy pending waiters first
 
@@ -145,7 +145,7 @@ For the tracked order (or fallback-resolved order), the listener:
 `parse_dm_events` returns a sorted list:
 
 - **dedup**: drops duplicate Nostr event IDs
-- **decrypt**: unwraps GiftWrap (NIP-59) and parses JSON into `mostro_core::Message`
+- **decrypt**: [`unwrap_incoming`](../src/util/mod.rs) (GiftWrap or kind 14) and parses JSON into `mostro_core::Message`
 - **sort**: ascending by rumor created-at timestamp (oldest → newest)
 
 ### 2) Dispatch each parsed trade DM into the UI/DB pipeline
@@ -281,7 +281,7 @@ flowchart TD
   CMD -->|TrackOrder| TO[Update active_order_trade_indices; ensure subscription; bind subscription_id -> order]
   CMD -->|RegisterWaiter| W[Ensure waiter pubkey subscription; push PendingDmWaiter]
 
-  D -->|relay event| E[GiftWrap event arrives]
+  D -->|relay event| E[protocol DM event arrives]
   E --> WA[Try match pending waiters (decrypt check)]
   WA --> RB{subscription_id mapped?}
   RB -->|yes| FAST[Derive trade_keys; parse_dm_events; dispatch batch]

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -12,7 +12,7 @@ Mostrix uses Nostr transports for two distinct purposes:
 
 | Traffic | Transport | Notes |
 |---------|-----------|--------|
-| **Mostro protocol DMs** (orders, take, pay, release, admin actions to daemon) | **Dual transport** via [`send_dm`](../src/util/dm_utils/mod.rs) → [`wrap_message_with`](../src/util/mod.rs): v1 GiftWrap (1059) or v2 signed kind 14 | Selected from instance `protocol_version` on kind 38385; **inbound** still GiftWrap-only until steps 5–6 |
+| **Mostro protocol DMs** (orders, take, pay, release, admin actions to daemon) | **Dual transport** via [`send_dm`](../src/util/dm_utils/mod.rs) → [`wrap_message_with`](../src/util/mod.rs): v1 GiftWrap (1059) or v2 signed kind 14 | Selected from instance `protocol_version` on kind 38385 (inbound + outbound) |
 | **P2P order chat** (My Trades) and **admin dispute chat** | NIP-59 GiftWrap via `mostro_core::chat` | Unchanged by protocol v2; shared ECDH keys |
 
 ### Protocol v2 discovery, outbound send, and subscriptions (partial)
@@ -35,14 +35,12 @@ Mostro daemons advertise wire format on the **instance status** event (kind **38
 | v1 GiftWrap | `.pubkey(trade_key).kind(1059)` |
 | v2 NIP-44 | `.author(mostro_pubkey).pubkey(trade_key).kind(14)` |
 
-Used by `dm_helpers::ensure_order_dm_subscription`, startup `fetch_and_replay_startup_trade_dms`, and `RegisterWaiter`. Filters pass through [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) (**v2 clamped to GiftWrap** until step 6).
-
-**Still pending:** event gate, listener waiter decrypt → `unwrap_incoming`, remove clamp — [Protocol v2](README.md#protocol-v2-nip-44-in-progress).
+Used by `dm_helpers::ensure_order_dm_subscription`, startup `fetch_and_replay_startup_trade_dms`, and `RegisterWaiter` via [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) with the resolved `transport`.
 
 ### Legacy overview
 
 1. **NIP-59 Gift Wrap (1059)**: Protocol v1 wire format and all P2P chat.
-2. **NIP-44 direct (signed kind 14)**: Protocol v2 for Mostro DMs — **outbound live** via `send_dm`; **parse/replay** via `unwrap_incoming`; live listener subscribe/gate still step 6.
+2. **NIP-44 direct (signed kind 14)**: Protocol v2 for Mostro DMs — inbound and outbound via dual transport helpers.
 
 ### Proof-of-work (NIP-13)
 
@@ -171,10 +169,10 @@ The `wait_for_dm` function now uses the shared DM router:
 1. **Registers a waiter** (`RegisterWaiter`) for the specific `trade_keys`
 2. **Sends the message** after waiter registration
 3. **Waits up to 15 seconds** (`FETCH_EVENTS_TIMEOUT`) on a oneshot response channel
-4. The background DM listener decrypt-checks incoming protocol DM events against pending waiters (**GiftWrap only today**; v2 inbound pending) and delivers the first match to `wait_for_dm`
+4. The background DM listener decrypt-checks incoming protocol DM events (GiftWrap or kind 14 per transport) against pending waiters and delivers the first match to `wait_for_dm`
 
 Waiter subscription detail:
-- `RegisterWaiter` uses [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) with `.limit(0)` (live-only), passed through `dm_listener_subscribe_transport` (v2 clamped to GiftWrap until step 6)
+- `RegisterWaiter` uses [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) with `.limit(0)` (live-only)
 
 ### 6. Parsing and Handling Response
 **Source**: [`src/util/order_utils/send_new_order.rs`](../src/util/order_utils/send_new_order.rs)
@@ -283,11 +281,11 @@ sequenceDiagram
     participant UI
 
     Cmd->>Router: TrackOrder(order_id, trade_index)
-    Router->>Relays: subscribe protocol DM filter (trade key; v2 clamp → GiftWrap until step 6)
+    Router->>Relays: subscribe protocol DM filter (transport-aware)
     Cmd->>Router: RegisterWaiter(trade_keys, response_tx)
     Router->>Relays: (if needed) subscribe waiter pubkey
     Relays-->>Router: RelayPoolNotification::Event(protocol DM)
-    Router->>Router: Gate: GiftWrap only today; try waiter decrypt match
+    Router->>Router: Gate: event.kind == transport.event_kind(); try waiter decrypt match
     alt waiter matched
         Router-->>Cmd: oneshot response_tx.send(event)
     end
@@ -312,7 +310,7 @@ pub async fn listen_for_order_messages(
 
 This task:
 1. Maintains a command-driven subscription router (`TrackOrder` + `RegisterWaiter`) using [`filter_protocol_dm_from_mostro`](../src/util/filters.rs) for subscribe/replay/waiter filters
-2. Consumes `client.notifications()` and handles protocol DM events as they arrive (**event kind gate still GiftWrap-only** until step 6)
+2. Consumes `client.notifications()` and handles protocol DM events matching `transport.event_kind()`
 3. Routes events by known `subscription_id` to `(order_id, trade_index)`
 4. Falls back to decrypting against active tracked trade keys when `subscription_id` is unknown
 5. Parses/decrypts with `parse_dm_events`, updates order state, and emits UI notifications

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 ## Core runtime & data
 
 - **Startup & Configuration**: [STARTUP_AND_CONFIG.md](STARTUP_AND_CONFIG.md) — Boot sequence, settings (`blossom_servers`), background tasks, DM router wiring, reconnect; main loop **drains save/send-attachment and operation-result channels before draw** (150 ms refresh)
-- **DM listener & router**: [DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md) — `listen_for_order_messages`; subscribe clamp (`dm_listener_subscribe_transport`); outbound `send_dm` uses `wrap_message_with`; inbound event gate still kind 1059 until step 6
+- **DM listener & router**: [DM_LISTENER_FLOW.md](DM_LISTENER_FLOW.md) — `listen_for_order_messages`; transport-aware subscribe (`filter_protocol_dm_from_mostro`) and event gate (`transport.event_kind()`); outbound `send_dm` uses `wrap_message_with`; inbound parse uses `unwrap_incoming`
 - **Message Flow & Protocol**: [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md) — How Mostrix talks to Mostro over Nostr (orders, protocol DMs, restarts, cooperative cancel / `TradeClosed`); **protocol v2** (`protocol_version` → outbound `wrap_message_with`; inbound still partial — see [Protocol v2 (NIP-44)](#protocol-v2-nip-44-in-progress)); **maker bond** (`send_new_order` → `PayBondInvoice` / `PaymentRequestRequired`, deferred `NewOrder` after payment); **My Trades user order chat** relay sync, own-message echo skip, attachment receive/save, **outbound send** (Ctrl+O picker, trade-key Blossom auth, mobile-compatible wire JSON, upload-then-send retry / **Ctrl+Shift+O**, `pending_order_attachment_sends`), **JSON transcript persistence** (Ctrl+S after restart)
 - **PoW & outbound events**: [POW_AND_OUTBOUND_EVENTS.md](POW_AND_OUTBOUND_EVENTS.md) — Instance `pow` (kind 38385), `nostr_pow_from_instance`, [`send_dm`](../src/util/dm_utils/mod.rs) → [`wrap_message_with`](../src/util/mod.rs) (GiftWrap outer PoW or v2 signed kind-14)
 - **Database**: [DATABASE.md](DATABASE.md) — SQLite schema, `orders` / `users` / `admin_disputes`, migrations; **relay → SQLite reconcile** for terminal order statuses (`relay_order_db_reconcile.rs`)
@@ -38,14 +38,13 @@ Index of architecture and feature guides for the Mostrix TUI client. The [root R
 
 - Tracked Markdown plans for larger features live under **[`.cursor/plans/`](../.cursor/plans/README.md)** (git-tracked; see root `.gitignore` exceptions). Use them to capture design decisions and link to `src/` paths for codegen and reviews. Example: [admin dispute bond slash](../.cursor/plans/admin_dispute_bond_slash.plan.md). **My Trades attachments**: receive/save, JSON transcripts, outbound send (encrypt → Blossom → DM) — see [MESSAGE_FLOW_AND_PROTOCOL.md](MESSAGE_FLOW_AND_PROTOCOL.md).
 
-## Protocol v2 (NIP-44) — in progress
+## Protocol v2 (NIP-44) — protocol DMs complete
 
 Mostrix is gaining **dual-transport** support for Mostro **protocol DMs** (not P2P order chat or admin dispute chat — those stay on GiftWrap).
 
 | Status | What |
 |--------|------|
-| **Done** | `mostro-core` **0.13.0**; `protocol_version` on kind **38385**; [`transport_from_instance`](../src/util/mostro_info.rs); [`AppState.transport`](../src/ui/app_state.rs); Mostro Info tab; [`filter_protocol_dm_from_mostro`](../src/util/filters.rs); **await instance info** before listener (startup + [`dm_transport_for_mostro`](../src/ui/key_handler/async_tasks.rs) on reload/reconnect); **`send_dm` → `wrap_message_with`** + v2 NIP-40 expiration (30 days); **`parse_dm_events` / startup replay / fallback → `unwrap_incoming`** |
-| **Pending** | Event gate `transport.event_kind()`; listener waiter decrypt → `unwrap_incoming`; remove [`dm_listener_subscribe_transport`](../src/util/dm_utils/mod.rs) clamp; restart listener on manual Mostro Info refresh when transport flips |
+| **Done** | `mostro-core` **0.13.0**; `protocol_version` on kind **38385**; [`transport_from_instance`](../src/util/mostro_info.rs); [`AppState.transport`](../src/ui/app_state.rs); Mostro Info tab; [`filter_protocol_dm_from_mostro`](../src/util/filters.rs); **await instance info** before listener (startup + [`dm_transport_for_mostro`](../src/ui/key_handler/async_tasks.rs) on reload/reconnect); **`send_dm` → `wrap_message_with`**; **`parse_dm_events` / listener → `unwrap_incoming`**; transport-aware subscribe + event gate; [`respawn_trade_dm_listener`](../src/ui/key_handler/async_tasks.rs) on manual info refresh when transport flips |
 
-**Asymmetric v2 today:** outbound and **parse** paths support both transports; inbound subscribe/fetch are **clamped to GiftWrap** and the live listener still gates on kind **1059** until step 6. v2-only nodes can send but will not receive protocol DMs until step 6.
+**v2 end-to-end:** Mostrix auto-selects wire transport from instance info for both outbound and inbound protocol DMs. P2P order chat and admin dispute chat remain GiftWrap-only.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ use crate::ui::helpers::{
 };
 use crate::ui::key_handler::{
     apply_pending_runtime_reloads, create_app_channels, handle_key_event,
-    handle_mouse_invoice_paste_fallback, reload_runtime_session_after_reconnect, AppChannels,
-    RuntimeReconnectContext,
+    handle_mouse_invoice_paste_fallback, reload_runtime_session_after_reconnect,
+    respawn_trade_dm_listener, AppChannels, RuntimeReconnectContext,
 };
 use crate::ui::{LnAddressVerifyResult, MostroInfoFetchResult, OperationResult};
 use crate::util::{
@@ -474,7 +474,31 @@ async fn main() -> Result<(), anyhow::Error> {
                 if let Some(res) = mostro_info_result {
                     match res {
                         MostroInfoFetchResult::Ok { info, message } => {
+                            let old_transport = app.transport;
                             app.set_mostro_info(*info);
+                            if old_transport != app.transport {
+                                log::warn!(
+                                    "Mostro protocol transport changed {:?} -> {:?}; restarting DM listener",
+                                    old_transport,
+                                    app.transport
+                                );
+                                if let Err(e) = respawn_trade_dm_listener(
+                                    &mut app,
+                                    &client,
+                                    mostro_pubkey,
+                                    &pool,
+                                    &mut message_listener_handle,
+                                    &message_notification_tx,
+                                    &mut dm_subscription_tx,
+                                    "Mostro info refresh",
+                                )
+                                .await
+                                {
+                                    log::error!(
+                                        "Failed to restart DM listener after transport change: {e}"
+                                    );
+                                }
+                            }
                             app.mode = crate::ui::UiMode::operation_result(
                                 crate::ui::OperationResult::Info(message),
                             );

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -178,6 +178,9 @@ pub async fn respawn_trade_dm_listener(
     log_context: &str,
 ) -> Result<(), String> {
     message_listener_handle.abort();
+    // Await the old task before draining subs so it cannot register new ids after take().
+    let old_listener = std::mem::replace(message_listener_handle, tokio::spawn(async {}));
+    let _ = old_listener.await;
     // DM listener subs only — `Client` is shared with order/dispute fetch schedulers.
     unsubscribe_dm_listener_subscriptions(client).await;
 

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -14,8 +14,8 @@ use crate::util::listen_for_order_messages;
 use crate::util::order_utils::spawn_fetch_scheduler_loops;
 use crate::util::{
     any_relay_reachable, catch_unwind_request_fatal_restart, connect_client_safely,
-    hydrate_startup_active_order_dm_state, set_dm_router_cmd_tx, OrderDmSubscriptionCmd,
-    StartupDmHydration,
+    hydrate_startup_active_order_dm_state, set_dm_router_cmd_tx,
+    unsubscribe_dm_listener_subscriptions, OrderDmSubscriptionCmd, StartupDmHydration,
 };
 use mostro_core::prelude::{Dispute, SmallOrder, Transport};
 use nostr_sdk::prelude::{Client, Keys, PublicKey};
@@ -178,7 +178,8 @@ pub async fn respawn_trade_dm_listener(
     log_context: &str,
 ) -> Result<(), String> {
     message_listener_handle.abort();
-    client.unsubscribe_all().await;
+    // DM listener subs only — `Client` is shared with order/dispute fetch schedulers.
+    unsubscribe_dm_listener_subscriptions(client).await;
 
     let startup_dm_hydration = match hydrate_startup_active_order_dm_state(pool).await {
         Ok(h) => h,

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -165,6 +165,68 @@ async fn dm_transport_for_mostro(
     }
 }
 
+/// Abort and respawn the trade DM listener (e.g. after `protocol_version` / transport changes).
+#[allow(clippy::too_many_arguments)]
+pub async fn respawn_trade_dm_listener(
+    app: &mut AppState,
+    client: &Client,
+    mostro_pubkey: PublicKey,
+    pool: &SqlitePool,
+    message_listener_handle: &mut JoinHandle<()>,
+    message_notification_tx: &UnboundedSender<MessageNotification>,
+    dm_subscription_tx: &mut UnboundedSender<OrderDmSubscriptionCmd>,
+    log_context: &str,
+) -> Result<(), String> {
+    message_listener_handle.abort();
+    client.unsubscribe_all().await;
+
+    let startup_dm_hydration = match hydrate_startup_active_order_dm_state(pool).await {
+        Ok(h) => h,
+        Err(e) => {
+            log::warn!("{log_context}: failed to hydrate startup active order DM state: {e}");
+            StartupDmHydration::empty()
+        }
+    };
+    if let Ok(mut indices) = app.active_order_trade_indices.lock() {
+        *indices = startup_dm_hydration.active_order_trade_indices.clone();
+    }
+    app.startup_popup_floor_ts = startup_dm_hydration.order_last_seen_dm_ts.clone();
+
+    let client_for_messages = client.clone();
+    let pool_for_messages = pool.clone();
+    let active_order_trade_indices_clone = Arc::clone(&app.active_order_trade_indices);
+    let order_last_seen_dm_ts_clone = startup_dm_hydration.order_last_seen_dm_ts.clone();
+    let messages_clone = Arc::clone(&app.messages);
+    let message_notification_tx_clone = message_notification_tx.clone();
+    let pending_notifications_clone = Arc::clone(&app.pending_notifications);
+    let dropped_user_history_clone = Arc::clone(&app.dropped_user_history_order_ids);
+    let (new_dm_tx, new_dm_rx) = tokio::sync::mpsc::unbounded_channel::<OrderDmSubscriptionCmd>();
+    *dm_subscription_tx = new_dm_tx;
+    set_dm_router_cmd_tx(dm_subscription_tx.clone()).map_err(|msg| msg.to_string())?;
+
+    let dm_transport = app.transport;
+    *message_listener_handle = tokio::spawn(async move {
+        catch_unwind_request_fatal_restart("trade DM listener", async move {
+            listen_for_order_messages(
+                client_for_messages,
+                mostro_pubkey,
+                dm_transport,
+                pool_for_messages,
+                active_order_trade_indices_clone,
+                order_last_seen_dm_ts_clone,
+                messages_clone,
+                message_notification_tx_clone,
+                pending_notifications_clone,
+                dropped_user_history_clone,
+                new_dm_rx,
+            )
+            .await;
+        })
+        .await;
+    });
+    Ok(())
+}
+
 /// Reload Nostr client, Mostro pubkey, and message listener after the user persisted new keys
 /// (`pending_key_reload`). Updates `app` and shared runtime state on success; sets an error
 /// [`OperationResult`] on failure.

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -76,8 +76,8 @@ fn is_terminal_order_status(status: Option<Status>) -> bool {
 // Re-export public functions
 pub use async_tasks::{
     apply_pending_fetch_scheduler_reload, apply_pending_key_reload, apply_pending_runtime_reloads,
-    create_app_channels, reload_runtime_session_after_reconnect, spawn_refresh_mostro_info_task,
-    AppChannels, RuntimeReconnectContext,
+    create_app_channels, reload_runtime_session_after_reconnect, respawn_trade_dm_listener,
+    spawn_refresh_mostro_info_task, AppChannels, RuntimeReconnectContext,
 };
 pub use confirmation::{handle_cancel_key, handle_confirm_key};
 pub use enter_handlers::handle_enter_key;

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -79,7 +79,8 @@ pub(crate) async fn ensure_order_dm_subscription(
                 );
             }
             pubkey_to_subscription.insert(trade_pubkey, sub_id.clone());
-            subscription_to_order.insert(sub_id, (options.order_id, options.trade_index));
+            subscription_to_order.insert(sub_id.clone(), (options.order_id, options.trade_index));
+            super::register_dm_listener_subscription(sub_id);
             true
         }
         Err(e) => {

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -51,11 +51,7 @@ pub(crate) async fn ensure_order_dm_subscription(
             trade_pubkey
         );
     }
-    let base = filter_protocol_dm_from_mostro(
-        super::dm_listener_subscribe_transport(transport),
-        mostro_pubkey,
-        trade_pubkey,
-    );
+    let base = filter_protocol_dm_from_mostro(transport, mostro_pubkey, trade_pubkey);
     let filter = match options.mode {
         DmSubscriptionMode::StartupCatchUp => base.limit(1),
         DmSubscriptionMode::StartupSince(ts) => {

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -70,6 +70,34 @@ pub type OrderDmSubscriptionCmd = DmRouterCmd;
 
 static DM_ROUTER_CMD_TX: Mutex<Option<mpsc::UnboundedSender<DmRouterCmd>>> = Mutex::new(None);
 
+/// Relay subscription ids owned by the trade DM listener (not order/dispute schedulers).
+static DM_LISTENER_SUBSCRIPTION_IDS: Mutex<Vec<SubscriptionId>> = Mutex::new(Vec::new());
+
+pub(crate) fn register_dm_listener_subscription(id: SubscriptionId) {
+    if let Ok(mut guard) = DM_LISTENER_SUBSCRIPTION_IDS.lock() {
+        if !guard.iter().any(|existing| existing == &id) {
+            guard.push(id);
+        }
+    }
+}
+
+pub(crate) fn unregister_dm_listener_subscription(id: &SubscriptionId) {
+    if let Ok(mut guard) = DM_LISTENER_SUBSCRIPTION_IDS.lock() {
+        guard.retain(|existing| existing != id);
+    }
+}
+
+/// Unsubscribe only DM-listener relay subscriptions; leaves order/dispute scheduler subs intact.
+pub async fn unsubscribe_dm_listener_subscriptions(client: &Client) {
+    let ids: Vec<SubscriptionId> = DM_LISTENER_SUBSCRIPTION_IDS
+        .lock()
+        .map(|mut guard| std::mem::take(&mut *guard))
+        .unwrap_or_default();
+    for id in ids {
+        client.unsubscribe(&id).await;
+    }
+}
+
 /// Cumulative count of GiftWrap routes that ran the linear active-order decrypt fallback
 /// (`resolve_order_for_event`). Useful for monitoring how often the O(n) path runs.
 static GIFTWRAP_FALLBACK_DECRYPT_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -1065,6 +1093,7 @@ async fn dispatch_giftwrap_batch(
                         subscribed_pubkeys.remove(&keys.public_key());
                     }
                     subscription_to_order.remove(subscription_id);
+                    unregister_dm_listener_subscription(subscription_id);
                     client.unsubscribe(subscription_id).await;
                     break;
                 }
@@ -1609,6 +1638,7 @@ pub async fn listen_for_order_messages(
                                     // Remember the subscription id so a later TrackOrder can
                                     // rebind this pubkey to a concrete order_id without requiring
                                     // a second relay subscription.
+                                    register_dm_listener_subscription(output.val.clone());
                                     pubkey_to_subscription.insert(waiter_pubkey, output.val);
                                 }
                                 Err(e) => {

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -19,7 +19,7 @@ use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc::UnboundedSender;
@@ -52,22 +52,6 @@ fn default_dm_expiration() -> Timestamp {
             .as_secs()
             .saturating_add(DEFAULT_DM_EXPIRATION_DAYS * 24 * 60 * 60),
     )
-}
-
-static DM_V2_SUBSCRIBE_CLAMP_LOGGED: AtomicBool = AtomicBool::new(false);
-
-/// Subscribe/fetch transport until inbound kind-14 routing uses [`unwrap_incoming`].
-fn dm_listener_subscribe_transport(transport: Transport) -> Transport {
-    if transport == Transport::Nip44Direct {
-        if !DM_V2_SUBSCRIBE_CLAMP_LOGGED.swap(true, Ordering::Relaxed) {
-            log::warn!(
-                "Mostro advertises protocol v2 (NIP-44); DM listener subscribe/fetch still uses GiftWrap until inbound unwrap_incoming is wired"
-            );
-        }
-        Transport::GiftWrap
-    } else {
-        transport
-    }
 }
 
 #[derive(Debug)]
@@ -1192,13 +1176,9 @@ async fn fetch_and_replay_startup_trade_dms(
             .unwrap_or(lookback_start);
         let since_ts = combined_since.saturating_sub(STARTUP_GIFTWRAP_ENVELOPE_SKEW_SECS);
 
-        let filter = filter_protocol_dm_from_mostro(
-            dm_listener_subscribe_transport(transport),
-            mostro_pubkey,
-            pubkey,
-        )
-        .since(Timestamp::from(since_ts))
-        .limit(STARTUP_TRADE_DM_FETCH_LIMIT);
+        let filter = filter_protocol_dm_from_mostro(transport, mostro_pubkey, pubkey)
+            .since(Timestamp::from(since_ts))
+            .limit(STARTUP_TRADE_DM_FETCH_LIMIT);
 
         let events = match client.fetch_events(filter, FETCH_EVENTS_TIMEOUT).await {
             Ok(e) => e,
@@ -1266,7 +1246,7 @@ async fn fetch_and_replay_startup_trade_dms(
         };
 
         log::info!(
-            "Startup DM replay: order_id={} trade_index={} fetched {} GiftWrap event(s); hydrating newest rumor ts={}",
+            "Startup DM replay: order_id={} trade_index={} fetched {} protocol DM event(s); hydrating newest rumor ts={}",
             order_id,
             trade_index,
             fetched_n,
@@ -1395,15 +1375,15 @@ async fn resolve_order_for_event(
     None
 }
 
-/// Background DM router for GiftWrap events.
+/// Background DM router for Mostro protocol DM events (GiftWrap or signed kind 14).
 ///
 /// Responsibilities:
 /// - maintain relay subscriptions for tracked orders (`TrackOrder`) and temporary
 ///   request/response waiters (`RegisterWaiter` / `wait_for_dm`)
-/// - route each incoming GiftWrap through two complementary paths:
+/// - route each incoming protocol DM through two complementary paths:
 ///   1) waiter path: satisfy in-flight `wait_for_dm` calls
 ///   2) tracked-order path: parse and dispatch updates to the order/UI pipeline
-/// - reuse decryptability checks across both paths for the same incoming GiftWrap
+/// - reuse decryptability checks across both paths for the same incoming event
 ///   and trade pubkey (`HashMap<PublicKey, bool>` scoped to one notification; the
 ///   unknown-subscription fallback reuses the `UnwrappedMessage` from `resolve_order_for_event`
 ///   so it does not unwrap twice there)
@@ -1619,7 +1599,7 @@ pub async fn listen_for_order_messages(
                         let waiter_pubkey = trade_keys.public_key();
                         if subscribed_pubkeys.insert(waiter_pubkey) {
                             let filter = filter_protocol_dm_from_mostro(
-                                dm_listener_subscribe_transport(transport),
+                                transport,
                                 mostro_pubkey,
                                 waiter_pubkey,
                             )
@@ -1673,15 +1653,16 @@ pub async fn listen_for_order_messages(
                 } = notification
                 {
                     let event = *event;
-                    if event.kind != nostr_sdk::Kind::GiftWrap {
+                    let expected_kind = transport.event_kind();
+                    if event.kind != expected_kind {
                         continue;
                     }
-                    // One GiftWrap event can be consumed by:
+                    // One protocol DM event can be consumed by:
                     // 1) request/response waiters (`wait_for_dm`) and
                     // 2) tracked order subscriptions (UI/order state pipeline).
-                    // Shared cache for this single incoming GiftWrap: decryptability is keyed only
+                    // Shared cache for this single incoming event: decryptability is keyed only
                     // by trade pubkey; `event.id` is fixed for the whole handler block.
-                    // This avoids duplicate `unwrap_message` calls between waiter and tracked paths.
+                    // This avoids duplicate `unwrap_incoming` calls between waiter and tracked paths.
                     let mut rumor_cache: HashMap<PublicKey, bool> = HashMap::new();
 
                     if !pending_waiters.is_empty() {
@@ -1689,7 +1670,7 @@ pub async fn listen_for_order_messages(
                             Vec::with_capacity(pending_waiters.len());
                         // Try to satisfy in-flight `wait_for_dm` calls first.
                         // Non-matching waiters are re-queued and will be checked again on the
-                        // next GiftWrap event.
+                        // next protocol DM event.
                         for waiter in pending_waiters.drain(..) {
                             // Drop promptly when wait_for_dm timed out (receiver gone); no decrypt.
                             if waiter.response_tx.is_closed() {
@@ -1700,7 +1681,7 @@ pub async fn listen_for_order_messages(
                                 *boolean
                             } else {
                                 let ok = matches!(
-                                    unwrap_message(&event, &waiter.trade_keys).await,
+                                    unwrap_incoming(&event, &waiter.trade_keys).await,
                                     Ok(Some(_))
                                 );
                                 rumor_cache.insert(key, ok);
@@ -1720,7 +1701,7 @@ pub async fn listen_for_order_messages(
 
                     if let Some((order_id, trade_index)) = subscription_to_order.get(&subscription_id).copied() {
                         log::info!(
-                            "[dm_listener] Routed GiftWrap by subscription_id={} to order_id={}, trade_index={}",
+                            "[dm_listener] Routed protocol DM by subscription_id={} to order_id={}, trade_index={}",
                             subscription_id,
                             order_id,
                             trade_index
@@ -1746,7 +1727,7 @@ pub async fn listen_for_order_messages(
                             *boolean
                         } else {
                             let ok = matches!(
-                                unwrap_message(&event, &trade_keys).await,
+                                unwrap_incoming(&event, &trade_keys).await,
                                 Ok(Some(_))
                             );
                             rumor_cache.insert(key, ok);
@@ -1801,7 +1782,7 @@ pub async fn listen_for_order_messages(
                             continue;
                         }
                         log::info!(
-                            "[dm_listener] Routed GiftWrap by active-order key for unknown subscription_id={} to order_id={}, trade_index={}",
+                            "[dm_listener] Routed protocol DM by active-order key for unknown subscription_id={} to order_id={}, trade_index={}",
                             subscription_id,
                             order_id,
                             trade_index

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -24,7 +24,8 @@ pub use dm_utils::{
     handle_message_notification, handle_operation_result, hydrate_startup_active_order_dm_state,
     listen_for_order_messages, parse_dm_events, seed_admin_chat_last_seen, send_dm,
     set_dm_router_cmd_tx, set_order_result_tx, try_notify_my_trades_maker_book_changed,
-    wait_for_dm, OrderDmSubscriptionCmd, StartupDmHydration, FETCH_EVENTS_TIMEOUT,
+    unsubscribe_dm_listener_subscriptions, wait_for_dm, OrderDmSubscriptionCmd, StartupDmHydration,
+    FETCH_EVENTS_TIMEOUT,
 };
 pub use fatal::{
     catch_unwind_request_fatal_restart, fatal_requested, install_background_panic_hook,


### PR DESCRIPTION
## Summary

Protocol v2 **step 6** — complete inbound cutover for Mostro protocol DMs. v2 nodes can now **receive** live protocol traffic end-to-end.

- Remove `dm_listener_subscribe_transport` GiftWrap clamp; subscribe/replay/waiter filters use `filter_protocol_dm_from_mostro(transport, …)` directly
- Event gate: accept `event.kind == transport.event_kind()` (1059 v1 / 14 v2) instead of hardcoded GiftWrap
- Listener waiter + tracked paths: `unwrap_incoming` (builds on #89)
- Add `respawn_trade_dm_listener` — restarts DM listener when manual Mostro Info refresh changes `app.transport`
- Update contributor docs: protocol v2 DMs complete; P2P/admin chat unchanged (GiftWrap)

Builds on #89 (parse/replay `unwrap_incoming`), #88 (outbound), #87 (filters), #86 (transport discovery).

## Context

| Layer | v1 | v2 (this PR) |
|-------|----|--------------|
| Subscribe | `.pubkey(trade).kind(1059)` | `.author(mostro).pubkey(trade).kind(14)` |
| Event gate | GiftWrap | kind 14 |
| Decrypt | `unwrap_incoming` | `unwrap_incoming` |

## Breaking changes

None for v1 nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended DM handling to support Protocol v2 (NIP-44) as transport-aware routing for both GiftWrap and signed kind-14 messages.
  * Added automatic restart of the trade DM listener when the active transport changes.
  * Improved DM listener subscription tracking and cleanup, including targeted unsubscription of listener-owned subscriptions.
* **Documentation**
  * Updated DM/message flow docs to reflect Protocol v2 dual-transport behavior and completed support status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->