### PR TITLE
fix(ui): auto-scroll dispute chat to bottom on tab return and party switch in dispute management

### DIFF
--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -537,6 +537,7 @@ fn handle_tab_switch(app: &mut AppState, prev_tab: Tab) {
             // Already on Disputes in Progress tab, do nothing
         } else {
             app.mode = UiMode::AdminMode(AdminMode::ManagingDispute);
+            app.admin_chat_scroll_tracker = None;
         }
     } else if let Tab::Admin(AdminTab::DisputesInProgress) = prev_tab {
         // Switching away from Disputes in Progress tab, reset to Normal mode
@@ -562,6 +563,7 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                 };
                 // Reset scroll/selection when switching parties (will be set in render)
                 app.admin_chat_selected_message_idx = None;
+                app.admin_chat_scroll_tracker = None;
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.next(form.use_range);
             }
@@ -574,6 +576,7 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                 };
                 // Reset scroll/selection when switching parties (will be set in render)
                 app.admin_chat_selected_message_idx = None;
+                app.admin_chat_scroll_tracker = None;
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.prev(form.use_range);
             }

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -553,11 +553,20 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
 
             if visible_count > 0 {
                 let current_key = (dispute_id_key.clone(), app.active_chat_party);
-                if let Some((ref d, ref p, last_count)) = app.admin_chat_scroll_tracker {
-                    if *d == current_key.0 && *p == current_key.1 && visible_count > last_count {
-                        app.admin_chat_scrollview_state.scroll_to_bottom();
-                        app.admin_chat_selected_message_idx = Some(visible_count.saturating_sub(1));
+                let should_scroll = match &app.admin_chat_scroll_tracker {
+                    None => true,
+                    Some((d, p, last_count)) => {
+                        *d == current_key.0 && *p == current_key.1 && visible_count > *last_count
                     }
+                };
+                // if should_scroll {
+                //     app.admin_chat_scrollview_state.scroll_to_bottom();
+                //     app.admin_chat_selected_message_idx = Some(visible_count.saturating_sub(1));
+                // }
+                if should_scroll {
+                    app.admin_chat_scrollview_state = Default::default();
+                    app.admin_chat_scrollview_state.scroll_to_bottom();
+                    app.admin_chat_selected_message_idx = Some(visible_count.saturating_sub(1));
                 }
                 app.admin_chat_scroll_tracker =
                     Some((dispute_id_key.clone(), app.active_chat_party, visible_count));
@@ -595,13 +604,10 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
             let inner_area = chat_block.inner(chat_area);
             f.render_widget(chat_block, chat_area);
 
-            let mut scroll_view = ScrollView::new(Size::new(
-                content.content_width,
-                content.content_height.max(1),
-            ))
-            .vertical_scrollbar_visibility(ScrollbarVisibility::Always);
-            let content_rect =
-                Rect::new(0, 0, content.content_width, content.content_height.max(1));
+            let display_height = content.content_height.saturating_sub(1).max(1);
+            let mut scroll_view = ScrollView::new(Size::new(content.content_width, display_height))
+                .vertical_scrollbar_visibility(ScrollbarVisibility::Always);
+            let content_rect = Rect::new(0, 0, content.content_width, display_height);
             scroll_view.render_widget(
                 Paragraph::new(content.lines).wrap(ratatui::widgets::Wrap { trim: true }),
                 content_rect,

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -556,13 +556,13 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                 let should_scroll = match &app.admin_chat_scroll_tracker {
                     None => true,
                     Some((d, p, last_count)) => {
-                        *d == current_key.0 && *p == current_key.1 && visible_count > *last_count
+                        if *d != current_key.0 {
+                            true
+                        } else {
+                            *p == current_key.1 && visible_count > *last_count
+                        }
                     }
                 };
-                // if should_scroll {
-                //     app.admin_chat_scrollview_state.scroll_to_bottom();
-                //     app.admin_chat_selected_message_idx = Some(visible_count.saturating_sub(1));
-                // }
                 if should_scroll {
                     app.admin_chat_scrollview_state = Default::default();
                     app.admin_chat_scrollview_state.scroll_to_bottom();


### PR DESCRIPTION
## Summary

Fixes #46 — dispute chat did not scroll to the latest messages when returning to the Disputes Management tab.

While investigating, two additional scroll gaps were found and fixed in the same area:

- When returning to the **Disputes Management tab** from another tab, the chat pane now automatically scrolls to the most recent message
- When switching between **Buyer and Seller** party views (Tab key), the chat now scrolls to the most recent message for the selected party
- When switching between **disputes in the sidebar** while staying on the tab, the chat now scrolls to the most recent message of the selected dispute

## Root cause

`admin_chat_scroll_tracker` was never reset when re-entering the tab or switching parties/disputes, so the scroll logic never saw a `None` tracker and never triggered `scroll_to_bottom()`. Additionally, `ScrollViewState` retained stale content dimensions from the previous render, causing `scroll_to_bottom()` to land at the wrong offset.

## Changes

- `src/ui/key_handler/navigation.rs` — reset `admin_chat_scroll_tracker` to `None` on tab return (`handle_tab_switch`) and on party switch (`handle_tab_navigation`)
- `src/ui/tabs/disputes_in_progress_tab.rs` — handle `None` tracker as "always scroll"; reset `ScrollViewState` before calling `scroll_to_bottom()` to clear stale content dimensions; scroll to bottom when a different dispute is selected in the sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic scrolling in the admin dispute chat when switching disputes, chat parties, or receiving new messages.
  * Preserved the selected message position when the chat scrolls to the latest content.
  * Adjusted chat viewport sizing to prevent display and scrolling issues in compact views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->