### PR TITLE
feat(ui): Messages tab UX restyle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## UI / TUI guidelines
+
+- **Always design TUI panels to degrade gracefully on narrow terminals.** When
+  horizontal space is limited, prefer a simpler, still-readable layout over
+  decoration (readability over beauty on small screens). Concretely: drop or
+  wrap secondary decoration, collapse multi-column layouts into a single column,
+  and keep the essential information visible rather than clipping it off-screen.
+  The Messages tab (`src/ui/tabs/message_flow_tab.rs`) is the reference example —
+  it switches between full and compact layouts via width helpers
+  (`use_full_progress`, `use_two_column_trade`) and reserves extra height for
+  wrapped text on narrow panels.
+
+## Build / test
+
+Standard Cargo workflow (toolchain pinned in `rust-toolchain.toml`):
+
+- Build: `cargo build`
+- Lint: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`
+- Test: `cargo test --all-features`
+
+TUI render logic can be verified deterministically in unit tests with
+`ratatui::backend::TestBackend` (render a widget to a fixed-size buffer and
+assert on the output) — no live relay/Lightning needed.

--- a/src/ui/helpers/ascii_art.rs
+++ b/src/ui/helpers/ascii_art.rs
@@ -2,6 +2,19 @@ use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+/// Empty-mailbox art for the Messages tab empty state. All lines share the same
+/// visual width so [`render_centered_lines`] keeps the shape aligned when it
+/// centers each row independently.
+pub const MAILBOX_EMPTY_ART: &[&str] = &[
+    "   ╭──────────────╮   ",
+    "   │  ╲        ╱  │   ",
+    "   │   (empty)    │   ",
+    "   │              │   ",
+    "   ╰──────┬┬──────╯   ",
+    "          ││          ",
+    "          ││          ",
+];
+
 /// Renders each line centered horizontally within `area`, one row per line.
 pub fn render_centered_lines<F>(f: &mut ratatui::Frame, area: Rect, lines: &[&str], style_line: F)
 where
@@ -39,5 +52,24 @@ where
         };
 
         f.render_widget(Paragraph::new(Line::from(style_line(line))), centered_rect);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mailbox_art_lines_share_width() {
+        // Equal widths keep the shape aligned when each row is centered independently.
+        let widths: Vec<usize> = MAILBOX_EMPTY_ART
+            .iter()
+            .map(|l| l.chars().count())
+            .collect();
+        assert!(!widths.is_empty());
+        assert!(
+            widths.iter().all(|&w| w == widths[0]),
+            "mailbox art rows must share a width, got {widths:?}"
+        );
     }
 }

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -8,7 +8,7 @@ mod layout;
 mod order_chat_projection;
 mod startup;
 
-pub use ascii_art::render_centered_lines;
+pub use ascii_art::{render_centered_lines, MAILBOX_EMPTY_ART};
 
 pub(crate) use attachments::try_parse_attachment_message;
 pub use attachments::{

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -6,6 +6,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 
+use mostro_core::prelude::{Payload, SmallOrder};
+
 use crate::ui::helpers;
 use crate::ui::orders::{
     listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
@@ -188,38 +190,20 @@ fn build_sidebar_items(
 }
 
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
+    // Panel order mirrors the target mockup: header, progress stepper, TRADE
+    // snapshot (fills the space the old numbered timeline wasted), then STATUS.
     let right_chunks = Layout::new(
         Direction::Vertical,
         [
-            Constraint::Length(3),
+            Constraint::Length(4),
             Constraint::Length(7),
-            Constraint::Length(3),
             Constraint::Min(0),
+            Constraint::Length(3),
         ],
     )
     .split(area);
 
-    let order_id = selected_msg
-        .order_id
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| "Unknown order id".to_string());
-    let timestamp = DateTime::<Utc>::from_timestamp(selected_msg.timestamp, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
-        .unwrap_or_else(|| "Unknown time".to_string());
-
-    let header = Paragraph::new(vec![
-        Line::from(Span::styled(
-            format!("Order {order_id}"),
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(format!("Last message at {timestamp}"))),
-    ])
-    .block(
-        Block::default()
-            .title("Selected Trade")
-            .borders(Borders::ALL),
-    );
-    f.render_widget(header, right_chunks[0]);
+    render_header_card(f, right_chunks[0], selected_msg);
 
     let step_labels = listing_timeline_labels(selected_msg);
     render_trade_stepper(
@@ -228,6 +212,8 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
         message_trade_timeline_step(selected_msg),
         &step_labels,
     );
+
+    render_trade_snapshot_card(f, right_chunks[2], selected_msg);
 
     let warning_from_status = message_timeline_warning_for_order_status(selected_msg.order_status);
     let warning_opt = warning_from_status.or_else(|| {
@@ -243,35 +229,208 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
     };
     let state = Paragraph::new(Line::from(Span::styled(warning, warning_style)))
         .alignment(ratatui::layout::Alignment::Center)
-        .block(Block::default().title("State").borders(Borders::ALL));
-    f.render_widget(state, right_chunks[2]);
+        .block(
+            Block::default()
+                .title(" State ")
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+        );
+    f.render_widget(state, right_chunks[3]);
+}
 
-    let action_text = message_action_compact_label_for_message(selected_msg);
-    let details = Paragraph::new(vec![
-        Line::from(Span::styled(
-            "Current action",
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(action_text)),
-        Line::from(Span::raw("")),
-        Line::from(Span::styled(
-            "Trade timeline",
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(format!("1) {}", step_labels[0].as_single_line()))),
-        Line::from(Span::raw(format!("2) {}", step_labels[1].as_single_line()))),
-        Line::from(Span::raw(format!("3) {}", step_labels[2].as_single_line()))),
-        Line::from(Span::raw(format!("4) {}", step_labels[3].as_single_line()))),
-        Line::from(Span::raw(format!("5) {}", step_labels[4].as_single_line()))),
-        Line::from(Span::raw(format!("6) {}", step_labels[5].as_single_line()))),
-    ])
-    .block(
-        Block::default()
-            .title("Timeline Details")
-            .borders(Borders::ALL),
+/// Header card: order id + kind badge + maker/taker role chip, plus the absolute
+/// and relative last-update time.
+fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let kind_label = message_order_kind_label(msg);
+    let (dot, kind_color) = kind_dot(kind_label);
+    let (role_emoji, role_label) = role_chip(msg.is_mine);
+
+    let line1 = Line::from(vec![
+        Span::styled("🧾 Order ", Style::default().fg(Color::Gray)),
+        Span::styled(
+            helpers::short_order_id(msg.order_id),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!("{dot} {kind_label}"),
+            Style::default().fg(kind_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!("{role_emoji} {role_label}"),
+            Style::default().fg(Color::Cyan),
+        ),
+    ]);
+
+    let absolute = DateTime::<Utc>::from_timestamp(msg.timestamp, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let relative = helpers::relative_time_compact(msg.timestamp);
+    let line2 = Line::from(Span::styled(
+        format!("Last update: {absolute} ({relative})"),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    f.render_widget(Paragraph::new(vec![line1, line2]), inner);
+}
+
+/// TRADE snapshot card: two-column receipt of the order payload (fiat, sats,
+/// premium, method, trade index, role). Values gracefully fall back to `—`.
+fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .title(Span::styled(
+            " TRADE ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let inner_kind = msg.message.get_inner_message_kind();
+    let order = match &inner_kind.payload {
+        Some(Payload::Order(order)) => Some(order),
+        _ => None,
+    };
+
+    let (premium, premium_color) = premium_display(order);
+    let (role_emoji, role_label) = role_chip(msg.is_mine);
+    let white = Style::default().fg(Color::White);
+
+    let left = vec![
+        snapshot_field("💰", "Fiat", fiat_display(order), white),
+        snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white),
+        snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white),
+    ];
+    let right = vec![
+        snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color)),
+        snapshot_field("🧾", "Method", method_display(order), white),
+        snapshot_field(
+            role_emoji,
+            "Role",
+            role_label.to_string(),
+            Style::default().fg(Color::Cyan),
+        ),
+    ];
+
+    let cols = Layout::new(
+        Direction::Horizontal,
+        [Constraint::Percentage(50), Constraint::Percentage(50)],
     )
-    .wrap(ratatui::widgets::Wrap { trim: true });
-    f.render_widget(details, right_chunks[3]);
+    .split(inner);
+    f.render_widget(Paragraph::new(left), cols[0]);
+    f.render_widget(Paragraph::new(right), cols[1]);
+}
+
+/// One `emoji label value` row inside the TRADE snapshot card. The leading emoji
+/// stays at the start of the row (kept out of the aligned label/value columns) so
+/// double-width glyphs never break alignment.
+fn snapshot_field(emoji: &str, label: &str, value: String, value_style: Style) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!(" {emoji} "), Style::default().fg(Color::Gray)),
+        Span::styled(format!("{label:<10}"), Style::default().fg(Color::DarkGray)),
+        Span::styled(value, value_style),
+    ])
+}
+
+/// Maker/taker chip from [`OrderMessage::is_mine`] (`is_mine` == "I am the maker").
+fn role_chip(is_mine: Option<bool>) -> (&'static str, &'static str) {
+    match is_mine {
+        Some(true) => ("👤", "Maker"),
+        Some(false) => ("🤝", "Taker"),
+        None => ("❔", "—"),
+    }
+}
+
+/// Fiat amount (or min–max range) with currency code; `—` when no order payload.
+fn fiat_display(order: Option<&SmallOrder>) -> String {
+    let Some(order) = order else {
+        return "—".to_string();
+    };
+    let code = order.fiat_code.trim().to_ascii_uppercase();
+    let value = match (order.min_amount, order.max_amount) {
+        (Some(min), Some(max)) if min > 0 && max > 0 => format!("{min}–{max}"),
+        _ if order.fiat_amount > 0 => order.fiat_amount.to_string(),
+        _ => String::new(),
+    };
+    match (value.is_empty(), code.is_empty()) {
+        (true, true) => "—".to_string(),
+        (true, false) => code,
+        (false, true) => value,
+        (false, false) => format!("{value} {code}"),
+    }
+}
+
+/// Sats for the trade: prefer the message `sat_amount`, then the order amount,
+/// showing `market` for a 0-amount (market-price) order and `—` when unknown.
+fn sats_display(order: Option<&SmallOrder>, sat_amount: Option<i64>) -> String {
+    if let Some(sats) = sat_amount {
+        if sats > 0 {
+            return group_thousands(&sats.to_string());
+        }
+    }
+    match order {
+        Some(order) if order.amount > 0 => group_thousands(&order.amount.to_string()),
+        Some(_) => "market".to_string(),
+        None => "—".to_string(),
+    }
+}
+
+/// Premium string + color: `+p%` green, `p%` red, `0%` gray, `—` when absent.
+fn premium_display(order: Option<&SmallOrder>) -> (String, Color) {
+    match order {
+        None => ("—".to_string(), Color::DarkGray),
+        Some(order) => match order.premium {
+            0 => ("0%".to_string(), Color::Gray),
+            p if p > 0 => (format!("+{p}%"), Color::Green),
+            p => (format!("{p}%"), Color::Red),
+        },
+    }
+}
+
+/// Payment method, or `—` when absent/empty.
+fn method_display(order: Option<&SmallOrder>) -> String {
+    match order {
+        Some(order) if !order.payment_method.trim().is_empty() => {
+            order.payment_method.trim().to_string()
+        }
+        _ => "—".to_string(),
+    }
+}
+
+/// Group an integer string into thousands (e.g. `142857` → `142,857`).
+fn group_thousands(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let (sign, digits) = match trimmed.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", trimmed),
+    };
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return raw.to_string();
+    }
+    let mut out = String::new();
+    let n = digits.len();
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (n - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    format!("{sign}{out}")
 }
 
 fn render_trade_stepper(
@@ -383,5 +542,95 @@ mod sidebar_tests {
         assert_eq!(items[0].height(), 4);
         // Last row: no trailing separator = 3 lines.
         assert_eq!(items[1].height(), 3);
+    }
+}
+
+#[cfg(test)]
+mod trade_snapshot_tests {
+    use super::*;
+    use mostro_core::prelude::SmallOrder;
+
+    fn order(fiat_amount: i64, min: Option<i64>, max: Option<i64>) -> SmallOrder {
+        SmallOrder {
+            fiat_code: "USD".to_string(),
+            fiat_amount,
+            min_amount: min,
+            max_amount: max,
+            amount: 0,
+            premium: 0,
+            payment_method: String::new(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fiat_display_none_is_placeholder() {
+        assert_eq!(fiat_display(None), "—");
+    }
+
+    #[test]
+    fn fiat_display_single_amount_with_code() {
+        assert_eq!(fiat_display(Some(&order(100, None, None))), "100 USD");
+    }
+
+    #[test]
+    fn fiat_display_prefers_min_max_range() {
+        assert_eq!(
+            fiat_display(Some(&order(0, Some(50), Some(200)))),
+            "50–200 USD"
+        );
+    }
+
+    #[test]
+    fn sats_display_prefers_message_sat_amount_grouped() {
+        let mut o = order(100, None, None);
+        o.amount = 5;
+        assert_eq!(sats_display(Some(&o), Some(142_857)), "142,857");
+    }
+
+    #[test]
+    fn sats_display_falls_back_to_order_amount_then_market() {
+        let mut o = order(100, None, None);
+        o.amount = 1_000;
+        assert_eq!(sats_display(Some(&o), None), "1,000");
+        o.amount = 0;
+        assert_eq!(sats_display(Some(&o), None), "market");
+        assert_eq!(sats_display(None, None), "—");
+    }
+
+    #[test]
+    fn premium_display_signs_and_colors() {
+        let mut o = order(100, None, None);
+        o.premium = 2;
+        assert_eq!(premium_display(Some(&o)), ("+2%".to_string(), Color::Green));
+        o.premium = -3;
+        assert_eq!(premium_display(Some(&o)), ("-3%".to_string(), Color::Red));
+        o.premium = 0;
+        assert_eq!(premium_display(Some(&o)), ("0%".to_string(), Color::Gray));
+        assert_eq!(premium_display(None), ("—".to_string(), Color::DarkGray));
+    }
+
+    #[test]
+    fn method_display_trims_and_falls_back() {
+        let mut o = order(100, None, None);
+        o.payment_method = "  SEPA  ".to_string();
+        assert_eq!(method_display(Some(&o)), "SEPA");
+        o.payment_method = "   ".to_string();
+        assert_eq!(method_display(Some(&o)), "—");
+        assert_eq!(method_display(None), "—");
+    }
+
+    #[test]
+    fn role_chip_maps_maker_taker_unknown() {
+        assert_eq!(role_chip(Some(true)), ("👤", "Maker"));
+        assert_eq!(role_chip(Some(false)), ("🤝", "Taker"));
+        assert_eq!(role_chip(None), ("❔", "—"));
+    }
+
+    #[test]
+    fn group_thousands_formats_and_passes_through_non_digits() {
+        assert_eq!(group_thousands("142857"), "142,857");
+        assert_eq!(group_thousands("999"), "999");
+        assert_eq!(group_thousands("market"), "market");
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -285,8 +285,10 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     f.render_widget(Paragraph::new(vec![line1, line2]), inner);
 }
 
-/// TRADE snapshot card: two-column receipt of the order payload (fiat, sats,
-/// premium, method, trade index, role). Values gracefully fall back to `—`.
+/// TRADE snapshot card: a receipt of the order payload (fiat, sats, premium,
+/// method, trade index, role). Values gracefully fall back to `—`. Renders two
+/// columns when there is room, and stacks into a single column on narrow panels
+/// so nothing is squeezed off-screen.
 fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let block = Block::default()
         .title(Span::styled(
@@ -311,29 +313,33 @@ fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMes
     let (role_emoji, role_label) = role_chip(msg.is_mine);
     let white = Style::default().fg(Color::White);
 
-    let left = vec![
-        snapshot_field("💰", "Fiat", fiat_display(order), white),
-        snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white),
-        snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white),
-    ];
-    let right = vec![
-        snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color)),
-        snapshot_field("🧾", "Method", method_display(order), white),
-        snapshot_field(
-            role_emoji,
-            "Role",
-            role_label.to_string(),
-            Style::default().fg(Color::Cyan),
-        ),
-    ];
+    let fiat = snapshot_field("💰", "Fiat", fiat_display(order), white);
+    let sats = snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white);
+    let trade_idx = snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white);
+    let premium = snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color));
+    let method = snapshot_field("🧾", "Method", method_display(order), white);
+    let role = snapshot_field(
+        role_emoji,
+        "Role",
+        role_label.to_string(),
+        Style::default().fg(Color::Cyan),
+    );
 
-    let cols = Layout::new(
-        Direction::Horizontal,
-        [Constraint::Percentage(50), Constraint::Percentage(50)],
-    )
-    .split(inner);
-    f.render_widget(Paragraph::new(left), cols[0]);
-    f.render_widget(Paragraph::new(right), cols[1]);
+    if use_two_column_trade(inner.width) {
+        let cols = Layout::new(
+            Direction::Horizontal,
+            [Constraint::Percentage(50), Constraint::Percentage(50)],
+        )
+        .split(inner);
+        f.render_widget(Paragraph::new(vec![fiat, sats, trade_idx]), cols[0]);
+        f.render_widget(Paragraph::new(vec![premium, method, role]), cols[1]);
+    } else {
+        // Narrow panel: stack every field in one readable column.
+        f.render_widget(
+            Paragraph::new(vec![fiat, sats, premium, method, trade_idx, role]),
+            inner,
+        );
+    }
 }
 
 /// One `emoji label value` row inside the TRADE snapshot card. The leading emoji
@@ -457,47 +463,132 @@ fn render_trade_stepper(
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
-    // Glyph track + labels on the left; progress gauge on the right.
-    let halves = Layout::new(
-        Direction::Horizontal,
-        [Constraint::Min(0), Constraint::Length(20)],
-    )
-    .split(inner);
-
-    let step_columns =
-        Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(halves[0]);
-
-    for (idx, step_label) in steps.iter().enumerate() {
-        let step_number = idx + 1;
-        let (glyph, style) = step_glyph(step_number, current);
-        let width = step_columns[idx].width as usize;
-        let cell = Paragraph::new(vec![
-            glyph_cell_line(width, glyph, style, idx == 0, idx == steps.len() - 1),
-            Line::from(Span::styled(center_in(step_label.top, width), style)),
-            Line::from(Span::styled(center_in(step_label.bottom, width), style)),
-        ]);
-        f.render_widget(cell, step_columns[idx]);
+    if use_full_progress(inner.width) {
+        render_progress_full(f, inner, current, steps);
+    } else {
+        render_progress_compact(f, inner, current, steps);
     }
+}
 
-    let ratio = (current as f64 / steps.len() as f64).clamp(0.0, 1.0);
-    let gauge = LineGauge::default()
+/// Progress gauge widget (`Step N of 6` + `▰▱` bar) shared by both layouts.
+fn progress_gauge(current: usize, total: usize) -> LineGauge<'static> {
+    let ratio = (current as f64 / total as f64).clamp(0.0, 1.0);
+    LineGauge::default()
         .filled_symbol("▰")
         .unfilled_symbol("▱")
         .filled_style(Style::default().fg(PRIMARY_COLOR))
         .unfilled_style(Style::default().fg(Color::DarkGray))
         .ratio(ratio)
         .label(Span::styled(
-            format!("Step {current} of {} ", steps.len()),
+            format!("Step {current} of {total} "),
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
-        ));
-    // Render on the top row of the gauge column, aligned with the glyph track.
+        ))
+}
+
+/// Render the glyph track across `area` as six columns, optionally with the
+/// top/bottom `StepLabel` words centered beneath each glyph.
+fn render_glyph_columns(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+    with_labels: bool,
+) {
+    let step_columns = Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(area);
+    for (idx, step_label) in steps.iter().enumerate() {
+        let (glyph, style) = step_glyph(idx + 1, current);
+        let width = step_columns[idx].width as usize;
+        let mut lines = vec![glyph_cell_line(
+            width,
+            glyph,
+            style,
+            idx == 0,
+            idx == steps.len() - 1,
+        )];
+        if with_labels {
+            lines.push(Line::from(Span::styled(
+                center_in(step_label.top, width),
+                style,
+            )));
+            lines.push(Line::from(Span::styled(
+                center_in(step_label.bottom, width),
+                style,
+            )));
+        }
+        f.render_widget(Paragraph::new(lines), step_columns[idx]);
+    }
+}
+
+/// Wide layout: glyph track + per-step labels on the left, gauge on the right.
+fn render_progress_full(
+    f: &mut ratatui::Frame,
+    inner: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+) {
+    let halves = Layout::new(
+        Direction::Horizontal,
+        [Constraint::Min(0), Constraint::Length(20)],
+    )
+    .split(inner);
+    render_glyph_columns(f, halves[0], current, steps, true);
+    // Gauge on the top row of its column, aligned with the glyph track.
     let gauge_area = Rect {
         height: 1,
         ..halves[1]
     };
-    f.render_widget(gauge, gauge_area);
+    f.render_widget(progress_gauge(current, steps.len()), gauge_area);
+}
+
+/// Narrow layout: drop the six per-step labels (unreadable when cramped) in
+/// favor of a full-width glyph track, a full-width gauge, and a single clear
+/// "current step" line — readability over beauty on small screens.
+fn render_progress_compact(
+    f: &mut ratatui::Frame,
+    inner: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+) {
+    let rows = Layout::new(
+        Direction::Vertical,
+        [
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ],
+    )
+    .split(inner);
+
+    render_glyph_columns(f, rows[0], current, steps, false);
+    f.render_widget(progress_gauge(current, steps.len()), rows[1]);
+
+    let current_label = steps
+        .get(current.saturating_sub(1))
+        .map(|s| s.as_single_line())
+        .unwrap_or_default();
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!("▸ {current_label}"),
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .alignment(ratatui::layout::Alignment::Center),
+        rows[2],
+    );
+}
+
+/// Whether the TRADE card has room for its two-column receipt layout.
+fn use_two_column_trade(inner_width: u16) -> bool {
+    inner_width >= 48
+}
+
+/// Whether the PROGRESS block has room for the full glyph-track + per-step
+/// labels + side gauge layout (else fall back to the compact stacked layout).
+fn use_full_progress(inner_width: u16) -> bool {
+    inner_width >= 68
 }
 
 /// Glyph + style for one step relative to the current step: done (`✔`, green),
@@ -745,6 +836,20 @@ mod stepper_tests {
         assert_eq!(center_in("odd", 6), " odd  ");
         // Longer than width: truncate by char, no panic.
         assert_eq!(center_in("Counterparty", 5), "Count");
+    }
+
+    #[test]
+    fn responsive_thresholds_switch_layouts_by_width() {
+        // TRADE: two columns only when wide enough, else single stacked column.
+        assert!(use_two_column_trade(60));
+        assert!(use_two_column_trade(48));
+        assert!(!use_two_column_trade(47));
+        assert!(!use_two_column_trade(20));
+        // PROGRESS: full labels+gauge only when wide, else compact stacked.
+        assert!(use_full_progress(80));
+        assert!(use_full_progress(68));
+        assert!(!use_full_progress(67));
+        assert!(!use_full_progress(30));
     }
 
     #[test]

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph, Wrap};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -12,7 +12,7 @@ use crate::ui::helpers;
 use crate::ui::orders::{
     listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
     message_order_kind_label, message_timeline_warning, message_timeline_warning_for_order_status,
-    message_trade_timeline_step, FlowStep, StepLabel,
+    message_trade_timeline_step, waiting_phase_description, FlowStep, StepLabel,
 };
 use crate::ui::{OrderMessage, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -191,14 +191,18 @@ fn build_sidebar_items(
 
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
     // Panel order mirrors the target mockup: header, progress stepper, TRADE
-    // snapshot (fills the space the old numbered timeline wasted), then STATUS.
+    // snapshot (fills the freed space), then the STATUS banner at the bottom.
+    // On narrow panels the STATUS text wraps onto more lines, so give it extra
+    // height there so the "what's next" copy stays fully readable.
+    let narrow = !use_two_column_trade(area.width.saturating_sub(2));
+    let status_height = if narrow { 7 } else { 4 };
     let right_chunks = Layout::new(
         Direction::Vertical,
         [
             Constraint::Length(4),
             Constraint::Length(5),
             Constraint::Min(0),
-            Constraint::Length(3),
+            Constraint::Length(status_height),
         ],
     )
     .split(area);
@@ -214,29 +218,69 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
     );
 
     render_trade_snapshot_card(f, right_chunks[2], selected_msg);
+    render_status_card(f, right_chunks[3], selected_msg);
+}
 
-    let warning_from_status = message_timeline_warning_for_order_status(selected_msg.order_status);
-    let warning_opt = warning_from_status.or_else(|| {
-        message_timeline_warning(&selected_msg.message.get_inner_message_kind().action)
-    });
-    let warning = warning_opt.unwrap_or("Trade is on normal path").to_string();
-    let warning_style = if warning_opt.is_some() {
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Green)
-    };
-    let state = Paragraph::new(Line::from(Span::styled(warning, warning_style)))
-        .alignment(ratatui::layout::Alignment::Center)
-        .block(
-            Block::default()
-                .title(" State ")
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
-        );
-    f.render_widget(state, right_chunks[3]);
+/// STATUS banner: a one-line status (normal path / canceled / dispute) and, on
+/// the happy path, a `👉 Next:` callout describing the pending action. Replaces
+/// the old "State" box and the redundant numbered timeline. Text wraps, so it
+/// stays readable on narrow panels (which also get extra height from the caller).
+fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .title(Span::styled(
+            " STATUS ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let (emoji, text, color, is_normal) = status_banner(msg);
+    let mut lines = vec![Line::from(vec![
+        Span::styled(format!("{emoji} "), Style::default().fg(color)),
+        Span::styled(
+            text,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])];
+    if is_normal {
+        lines.push(Line::from(vec![
+            Span::styled(
+                "👉 Next: ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                waiting_phase_description(msg).to_string(),
+                Style::default().fg(Color::Gray),
+            ),
+        ]));
+    }
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+}
+
+/// Status banner content: `(emoji, text, color, is_normal)`. Prefers the
+/// persisted order status, then the last action, to classify canceled/dispute
+/// vs the happy path. `is_normal` gates the "what's next" callout.
+fn status_banner(msg: &OrderMessage) -> (&'static str, String, Color, bool) {
+    let action = msg.message.get_inner_message_kind().action.clone();
+    let warning = message_timeline_warning_for_order_status(msg.order_status)
+        .or_else(|| message_timeline_warning(&action));
+    match warning {
+        Some(text) if text.contains("dispute") => ("⚖️", text.to_string(), Color::Magenta, false),
+        Some(text) => ("❌", text.to_string(), Color::Red, false),
+        None => (
+            "✅",
+            "Trade is on the normal path".to_string(),
+            Color::Green,
+            true,
+        ),
+    }
 }
 
 /// Header card: order id + kind badge + maker/taker role chip, plus the absolute
@@ -730,7 +774,7 @@ mod sidebar_tests {
 #[cfg(test)]
 mod trade_snapshot_tests {
     use super::*;
-    use mostro_core::prelude::SmallOrder;
+    use mostro_core::prelude::{SmallOrder, Status};
 
     fn order(fiat_amount: i64, min: Option<i64>, max: Option<i64>) -> SmallOrder {
         SmallOrder {
@@ -807,6 +851,51 @@ mod trade_snapshot_tests {
         assert_eq!(role_chip(Some(true)), ("👤", "Maker"));
         assert_eq!(role_chip(Some(false)), ("🤝", "Taker"));
         assert_eq!(role_chip(None), ("❔", "—"));
+    }
+
+    fn message_with(action: mostro_core::prelude::Action, status: Option<Status>) -> OrderMessage {
+        use mostro_core::prelude::Message;
+        use nostr_sdk::Keys;
+        OrderMessage {
+            message: Message::new_order(None, None, None, action, None),
+            timestamp: 0,
+            sender: Keys::generate().public_key(),
+            order_id: None,
+            trade_index: 0,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind: None,
+            is_mine: None,
+            order_status: status,
+            read: true,
+            auto_popup_shown: true,
+        }
+    }
+
+    #[test]
+    fn status_banner_happy_path_is_normal_with_next_callout() {
+        use mostro_core::prelude::Action;
+        let (emoji, _text, color, is_normal) =
+            status_banner(&message_with(Action::PayInvoice, None));
+        assert_eq!(emoji, "✅");
+        assert_eq!(color, Color::Green);
+        assert!(is_normal);
+    }
+
+    #[test]
+    fn status_banner_flags_canceled_and_dispute() {
+        use mostro_core::prelude::Action;
+        let (emoji, _t, color, is_normal) =
+            status_banner(&message_with(Action::Canceled, Some(Status::Canceled)));
+        assert_eq!(emoji, "❌");
+        assert_eq!(color, Color::Red);
+        assert!(!is_normal);
+
+        let (emoji, _t, color, is_normal) =
+            status_banner(&message_with(Action::Dispute, Some(Status::Dispute)));
+        assert_eq!(emoji, "⚖️");
+        assert_eq!(color, Color::Magenta);
+        assert!(!is_normal);
     }
 
     #[test]

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -196,7 +196,7 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
         Direction::Vertical,
         [
             Constraint::Length(4),
-            Constraint::Length(7),
+            Constraint::Length(5),
             Constraint::Min(0),
             Constraint::Length(3),
         ],
@@ -433,49 +433,140 @@ fn group_thousands(raw: &str) -> String {
     format!("{sign}{out}")
 }
 
+/// Compact progress stepper: a single-line colored glyph track
+/// (`✔──✔──◉──○──○──○`) with the step labels underneath, plus a `LineGauge`
+/// showing `Step N of 6`. Render-only; `FlowStep`/label logic is unchanged.
 fn render_trade_stepper(
     f: &mut ratatui::Frame,
     area: Rect,
     current_step: FlowStep,
     steps: &[StepLabel; 6],
 ) {
-    let current_step = current_step.step_number();
-    let step_columns = Layout::new(
+    let current = current_step.step_number();
+
+    let block = Block::default()
+        .title(Span::styled(
+            " PROGRESS ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    // Glyph track + labels on the left; progress gauge on the right.
+    let halves = Layout::new(
         Direction::Horizontal,
-        [
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(16),
-            Constraint::Percentage(16),
-        ],
+        [Constraint::Min(0), Constraint::Length(20)],
     )
-    .split(area);
+    .split(inner);
+
+    let step_columns =
+        Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(halves[0]);
 
     for (idx, step_label) in steps.iter().enumerate() {
         let step_number = idx + 1;
-        let style = if step_number < current_step {
+        let (glyph, style) = step_glyph(step_number, current);
+        let width = step_columns[idx].width as usize;
+        let cell = Paragraph::new(vec![
+            glyph_cell_line(width, glyph, style, idx == 0, idx == steps.len() - 1),
+            Line::from(Span::styled(center_in(step_label.top, width), style)),
+            Line::from(Span::styled(center_in(step_label.bottom, width), style)),
+        ]);
+        f.render_widget(cell, step_columns[idx]);
+    }
+
+    let ratio = (current as f64 / steps.len() as f64).clamp(0.0, 1.0);
+    let gauge = LineGauge::default()
+        .filled_symbol("▰")
+        .unfilled_symbol("▱")
+        .filled_style(Style::default().fg(PRIMARY_COLOR))
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .ratio(ratio)
+        .label(Span::styled(
+            format!("Step {current} of {} ", steps.len()),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+    // Render on the top row of the gauge column, aligned with the glyph track.
+    let gauge_area = Rect {
+        height: 1,
+        ..halves[1]
+    };
+    f.render_widget(gauge, gauge_area);
+}
+
+/// Glyph + style for one step relative to the current step: done (`✔`, green),
+/// current (`◉`, primary), or upcoming (`○`, dim).
+fn step_glyph(step_number: usize, current: usize) -> (&'static str, Style) {
+    if step_number < current {
+        (
+            "✔",
             Style::default()
                 .fg(Color::Green)
-                .add_modifier(Modifier::BOLD)
-        } else if step_number == current_step {
+                .add_modifier(Modifier::BOLD),
+        )
+    } else if step_number == current {
+        (
+            "◉",
             Style::default()
                 .fg(PRIMARY_COLOR)
-                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-
-        let step = Paragraph::new(vec![
-            Line::from(Span::styled(format!("Step {step_number}"), style)),
-            Line::from(Span::styled(step_label.top.to_string(), style)),
-            Line::from(Span::styled(step_label.bottom.to_string(), style)),
-        ])
-        .alignment(ratatui::layout::Alignment::Center)
-        .block(Block::default().borders(Borders::ALL));
-        f.render_widget(step, step_columns[idx]);
+                .add_modifier(Modifier::BOLD),
+        )
+    } else {
+        ("○", Style::default().fg(Color::DarkGray))
     }
+}
+
+/// One cell of the glyph track: the step glyph centered in `width`, flanked by
+/// dim `─` connectors (blanked at the outer edges of the first/last steps) so
+/// adjacent cells join into a continuous line.
+fn glyph_cell_line(
+    width: usize,
+    glyph: &str,
+    glyph_style: Style,
+    is_first: bool,
+    is_last: bool,
+) -> Line<'static> {
+    if width == 0 {
+        return Line::default();
+    }
+    let mid = width / 2;
+    let left_n = mid;
+    let right_n = width - mid - 1;
+    let dash = Style::default().fg(Color::DarkGray);
+    let left = if is_first {
+        " ".repeat(left_n)
+    } else {
+        "─".repeat(left_n)
+    };
+    let right = if is_last {
+        " ".repeat(right_n)
+    } else {
+        "─".repeat(right_n)
+    };
+    Line::from(vec![
+        Span::styled(left, dash),
+        Span::styled(glyph.to_string(), glyph_style),
+        Span::styled(right, dash),
+    ])
+}
+
+/// Center `text` within `width`, truncating (by char) when it does not fit.
+fn center_in(text: &str, width: usize) -> String {
+    let truncated: String = text.chars().take(width).collect();
+    let len = truncated.chars().count();
+    if len >= width {
+        return truncated;
+    }
+    let total = width - len;
+    let left = total / 2;
+    let right = total - left;
+    format!("{}{}{}", " ".repeat(left), truncated, " ".repeat(right))
 }
 
 #[cfg(test)]
@@ -632,5 +723,41 @@ mod trade_snapshot_tests {
         assert_eq!(group_thousands("142857"), "142,857");
         assert_eq!(group_thousands("999"), "999");
         assert_eq!(group_thousands("market"), "market");
+    }
+}
+
+#[cfg(test)]
+mod stepper_tests {
+    use super::*;
+
+    #[test]
+    fn step_glyph_marks_done_current_and_upcoming() {
+        // current step = 3
+        assert_eq!(step_glyph(1, 3).0, "✔");
+        assert_eq!(step_glyph(2, 3).0, "✔");
+        assert_eq!(step_glyph(3, 3).0, "◉");
+        assert_eq!(step_glyph(4, 3).0, "○");
+    }
+
+    #[test]
+    fn center_in_centers_and_truncates() {
+        assert_eq!(center_in("Rate", 8), "  Rate  ");
+        assert_eq!(center_in("odd", 6), " odd  ");
+        // Longer than width: truncate by char, no panic.
+        assert_eq!(center_in("Counterparty", 5), "Count");
+    }
+
+    #[test]
+    fn glyph_cell_line_blanks_outer_edges_of_first_and_last() {
+        let (glyph, style) = step_glyph(1, 1);
+        let first = glyph_cell_line(5, glyph, style, true, false);
+        let first_text: String = first.spans.iter().map(|s| s.content.as_ref()).collect();
+        // First cell: no connector to the left of the glyph, dashes to the right.
+        assert_eq!(first_text, "  ◉──");
+
+        let last = glyph_cell_line(5, glyph, style, false, true);
+        let last_text: String = last.spans.iter().map(|s| s.content.as_ref()).collect();
+        // Last cell: dashes to the left, blank to the right.
+        assert_eq!(last_text, "──◉  ");
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,9 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, BorderType, Borders, LineGauge, List, ListItem, Padding, Paragraph, Wrap,
+};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -32,12 +34,7 @@ pub fn render_messages_tab(
     let inner = block.inner(area);
 
     if messages.is_empty() {
-        let paragraph = Paragraph::new(Span::raw(
-            "No messages yet. Messages related to your orders will appear here.",
-        ))
-        .block(Block::default())
-        .alignment(ratatui::layout::Alignment::Center);
-        f.render_widget(paragraph, inner);
+        render_empty_state(f, inner);
         return;
     }
 
@@ -189,6 +186,75 @@ fn build_sidebar_items(
         .collect()
 }
 
+/// Empty state: a centered mailbox glyph over a short "no trades yet" message
+/// pointing at the Orders tab. On narrow/short panels the art is dropped so the
+/// text stays readable (readability over decoration).
+fn render_empty_state(f: &mut ratatui::Frame, area: Rect) {
+    let art = helpers::MAILBOX_EMPTY_ART;
+    let art_w = art.iter().map(|l| l.chars().count()).max().unwrap_or(0) as u16;
+
+    // Text lines wrap (unlike the art), so the message stays readable when narrow.
+    let text_lines = vec![
+        Line::from(Span::styled(
+            "Your mailbox is empty",
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "No trades yet — messages from your orders will appear here.",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            "Go to the Orders tab to create or take an order",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        )),
+    ];
+
+    let show_art = area.width >= art_w && area.height >= art.len() as u16 + 4;
+    // Reserve a few rows for text (it may wrap to 2 lines on narrow panels).
+    let text_h = 4u16;
+    let block_h = if show_art {
+        art.len() as u16 + 1 + text_h
+    } else {
+        text_h
+    };
+    let mut y = area.y + area.height.saturating_sub(block_h) / 2;
+
+    if show_art {
+        let art_area = Rect {
+            x: area.x,
+            y,
+            width: area.width,
+            height: art.len() as u16,
+        };
+        helpers::render_centered_lines(f, art_area, art, style_mailbox_art);
+        y = y.saturating_add(art.len() as u16 + 1);
+    }
+
+    let text_area = Rect {
+        x: area.x,
+        y,
+        width: area.width,
+        height: area.height.saturating_sub(y.saturating_sub(area.y)),
+    };
+    f.render_widget(
+        Paragraph::new(text_lines)
+            .alignment(ratatui::layout::Alignment::Center)
+            .wrap(Wrap { trim: true }),
+        text_area,
+    );
+}
+
+fn style_mailbox_art(line: &str) -> Vec<Span<'static>> {
+    vec![Span::styled(
+        line.to_string(),
+        Style::default().fg(Color::DarkGray),
+    )]
+}
+
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
     // Panel order mirrors the target mockup: header, progress stepper, TRADE
     // snapshot (fills the freed space), then the STATUS banner at the bottom.
@@ -235,6 +301,7 @@ fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -289,6 +356,7 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);


### PR DESCRIPTION
# Messages tab UX restyle

Restyles the **Messages tab** in the visual language of the Create New Order form: denser information, emoji status vocabulary, a compact glyph stepper with a progress gauge, a trade snapshot card that fills the previously empty space, a clear "what's next" status banner, and a friendly empty state — all with responsive fallbacks so the tab stays readable on narrow terminals.

## Motivation

The old Messages tab wasted space and hid data:

- Left list rows were two thin lines in a plain block, with a bulky bordered "Controls" box eating vertical space.
- The right panel's "Timeline Details" box just repeated the six stepper labels as numbered text, leaving large blank areas below.
- Rich data already present on each message (fiat amount, sats, premium, payment method, maker/taker role, order status, trade index) was never shown.
- Flat styling that didn't match the restyled order form.

## What's changed

**Sidebar (My Trades list)**
- Title shows the trade count and an unread badge: `📨 My Trades (N) · ● K new`.
- Three-line rows: kind dot + KIND + short order id; action emoji + label; relative time + unread marker, with slim separators.
- The bordered "Controls" box is replaced by a single dim footer line; rounded borders throughout.

**Right panel**
- **Header card** — order id, kind badge (`🟢 BUY` / `🔴 SELL`), maker/taker role chip (`👤` / `🤝`), and absolute + relative last-update time.
- **PROGRESS** — a compact glyph stepper (`✔` done / `◉` current / `○` upcoming) with the step labels beneath, plus a `LineGauge` showing `Step N of 6`. Replaces six bordered boxes; render-only (step logic unchanged).
- **TRADE** — a two-column receipt built from the order payload (`SmallOrder`) plus the message sat amount: fiat amount or min–max range, sats, premium, payment method, trade index, role. Missing fields fall back to `—`.
- **STATUS** — merges the old "State" box and redundant timeline into one banner: `✅` normal / `❌` canceled / `⚖️` dispute, plus a `👉 Next: …` callout describing the pending action (maker/taker aware).

**Empty state**
- A centered mailbox glyph over "Your mailbox is empty", a short explainer, and a lime hint pointing at the Orders tab.

## Responsive design

Every part degrades gracefully when horizontal space is limited (readability over decoration):

- **PROGRESS** drops the six cramped labels for a full-width glyph track + full-width gauge + a single `▸ <current step>` line.
- **TRADE** collapses from two columns to a single stacked column.
- **STATUS** text wraps and the panel reserves extra height so the "what's next" copy stays visible.
- **Empty state** text wraps and stays centered; the art is dropped on panels too narrow/short to fit it.

Layout selection is driven by pure width helpers (`use_full_progress`, `use_two_column_trade`) with unit tests.

## Implementation notes

- New helpers: `message_action_emoji`, `order_status_badge`, `relative_time_compact`, `MAILBOX_EMPTY_ART`.
- The progress gauge uses ratatui's built-in `LineGauge` — **no new dependencies**.
- All flow/step/label logic (`FlowStep`, `listing_timeline_labels`, `waiting_phase_description`, `message_timeline_warning*`) is reused unchanged; the changes are render-only.