### PR TITLE
feat(ui): Messages tab UX restyle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## UI / TUI guidelines
+
+- **Always design TUI panels to degrade gracefully on narrow terminals.** When
+  horizontal space is limited, prefer a simpler, still-readable layout over
+  decoration (readability over beauty on small screens). Concretely: drop or
+  wrap secondary decoration, collapse multi-column layouts into a single column,
+  and keep the essential information visible rather than clipping it off-screen.
+  The Messages tab (`src/ui/tabs/message_flow_tab.rs`) is the reference example —
+  it switches between full and compact layouts via width helpers
+  (`use_full_progress`, `use_two_column_trade`) and reserves extra height for
+  wrapped text on narrow panels.
+
+## Build / test
+
+Standard Cargo workflow (toolchain pinned in `rust-toolchain.toml`):
+
+- Build: `cargo build`
+- Lint: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`
+- Test: `cargo test --all-features`
+
+TUI render logic can be verified deterministically in unit tests with
+`ratatui::backend::TestBackend` (render a widget to a fixed-size buffer and
+assert on the output) — no live relay/Lightning needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,17 @@
 
 ## UI / TUI guidelines
 
-- **Always design TUI panels to degrade gracefully on narrow terminals.** When
-  horizontal space is limited, prefer a simpler, still-readable layout over
-  decoration (readability over beauty on small screens). Concretely: drop or
-  wrap secondary decoration, collapse multi-column layouts into a single column,
-  and keep the essential information visible rather than clipping it off-screen.
-  The Messages tab (`src/ui/tabs/message_flow_tab.rs`) is the reference example —
-  it switches between full and compact layouts via width helpers
-  (`use_full_progress`, `use_two_column_trade`) and reserves extra height for
-  wrapped text on narrow panels.
+- **Always design TUI panels to degrade gracefully on narrow *and short*
+  terminals.** When horizontal or vertical space is limited, prefer a simpler,
+  still-readable layout over decoration (readability over beauty on small
+  screens). Concretely: drop or wrap secondary decoration, collapse multi-column
+  layouts into a single column, shrink fixed header/progress/status blocks so
+  content cards keep a usable minimum height, and keep the essential information
+  visible rather than clipping it off-screen. The Messages tab
+  (`src/ui/tabs/message_flow_tab.rs`) is the reference example — it switches
+  between full and compact layouts via width helpers (`use_full_progress`,
+  `use_two_column_trade`) and height helpers (`right_panel_heights`), and
+  reserves extra height for wrapped text on narrow panels.
 
 ## Build / test
 

--- a/src/ui/helpers/ascii_art.rs
+++ b/src/ui/helpers/ascii_art.rs
@@ -2,6 +2,19 @@ use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+/// Empty-mailbox art for the Messages tab empty state. All lines share the same
+/// visual width so [`render_centered_lines`] keeps the shape aligned when it
+/// centers each row independently.
+pub const MAILBOX_EMPTY_ART: &[&str] = &[
+    "   ╭──────────────╮   ",
+    "   │  ╲        ╱  │   ",
+    "   │   (empty)    │   ",
+    "   │              │   ",
+    "   ╰──────┬┬──────╯   ",
+    "          ││          ",
+    "          ││          ",
+];
+
 /// Renders each line centered horizontally within `area`, one row per line.
 pub fn render_centered_lines<F>(f: &mut ratatui::Frame, area: Rect, lines: &[&str], style_line: F)
 where
@@ -39,5 +52,24 @@ where
         };
 
         f.render_widget(Paragraph::new(Line::from(style_line(line))), centered_rect);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mailbox_art_lines_share_width() {
+        // Equal widths keep the shape aligned when each row is centered independently.
+        let widths: Vec<usize> = MAILBOX_EMPTY_ART
+            .iter()
+            .map(|l| l.chars().count())
+            .collect();
+        assert!(!widths.is_empty());
+        assert!(
+            widths.iter().all(|&w| w == widths[0]),
+            "mailbox art rows must share a width, got {widths:?}"
+        );
     }
 }

--- a/src/ui/helpers/formatting.rs
+++ b/src/ui/helpers/formatting.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use mostro_core::prelude::UserInfo;
 
 use crate::models::AdminDispute;
@@ -32,5 +33,100 @@ pub fn format_order_id(order_id: Option<uuid::Uuid>) -> String {
         )
     } else {
         "Order: Unknown".to_string()
+    }
+}
+
+/// Truncated order id for compact displays (sidebar rows, header cards); no `"Order: "` prefix.
+/// Returns `"unknown"` when absent. Pairs with [`format_order_id`] (which keeps the prefix and
+/// is used in full-sentence contexts like popups).
+#[must_use]
+pub fn short_order_id(order_id: Option<uuid::Uuid>) -> String {
+    order_id
+        .map(|id| id.to_string().chars().take(8).collect::<String>())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Compact relative-time label for list rows (e.g. `"3m ago"`, `"2d ago"`), as opposed to the
+/// more verbose `format_instance_info_age` (e.g. `"2 hours ago"`) used for instance info banners.
+#[must_use]
+pub fn relative_time_compact(timestamp: i64) -> String {
+    relative_time_compact_from(timestamp, Utc::now().timestamp())
+}
+
+/// Testable core of [`relative_time_compact`] with an explicit `now` reference point.
+fn relative_time_compact_from(timestamp: i64, now: i64) -> String {
+    let delta = now.saturating_sub(timestamp).max(0);
+    const MINUTE: i64 = 60;
+    const HOUR: i64 = 60 * MINUTE;
+    const DAY: i64 = 24 * HOUR;
+    const MONTH: i64 = 30 * DAY;
+
+    if delta < MINUTE {
+        "just now".to_string()
+    } else if delta < HOUR {
+        format!("{}m ago", delta / MINUTE)
+    } else if delta < DAY {
+        format!("{}h ago", delta / HOUR)
+    } else if delta < MONTH {
+        format!("{}d ago", delta / DAY)
+    } else {
+        format!("{}mo ago", delta / MONTH)
+    }
+}
+
+#[cfg(test)]
+mod short_order_id_tests {
+    use super::*;
+
+    #[test]
+    fn truncates_to_eight_chars_without_prefix() {
+        let id = uuid::Uuid::parse_str("6c162b3f-0000-0000-0000-000000000000").unwrap();
+        assert_eq!(short_order_id(Some(id)), "6c162b3f");
+    }
+
+    #[test]
+    fn none_renders_unknown() {
+        assert_eq!(short_order_id(None), "unknown");
+    }
+}
+
+#[cfg(test)]
+mod relative_time_tests {
+    use super::*;
+
+    #[test]
+    fn under_a_minute_is_just_now() {
+        assert_eq!(relative_time_compact_from(1_000, 1_030), "just now");
+    }
+
+    #[test]
+    fn minutes_ago() {
+        assert_eq!(relative_time_compact_from(1_000, 1_000 + 90), "1m ago");
+    }
+
+    #[test]
+    fn hours_ago() {
+        assert_eq!(relative_time_compact_from(1_000, 1_000 + 3_661), "1h ago");
+    }
+
+    #[test]
+    fn days_ago() {
+        assert_eq!(
+            relative_time_compact_from(1_000, 1_000 + 2 * 86_400 + 10),
+            "2d ago"
+        );
+    }
+
+    #[test]
+    fn months_ago() {
+        assert_eq!(
+            relative_time_compact_from(1_000, 1_000 + 65 * 86_400),
+            "2mo ago"
+        );
+    }
+
+    #[test]
+    fn future_timestamp_clamps_to_just_now() {
+        assert_eq!(relative_time_compact_from(2_000, 1_000), "just now");
     }
 }

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -27,7 +27,10 @@ pub use chat_visibility::{
     count_order_attachments, count_visible_attachments, get_order_attachment_messages,
     get_selected_chat_message, get_visible_attachment_messages, message_visible_for_party,
 };
-pub use formatting::{format_order_id, format_user_rating, is_dispute_finalized};
+pub use formatting::{
+    format_order_id, format_user_rating, is_dispute_finalized, relative_time_compact,
+    short_order_id,
+};
 pub use layout::{
     create_centered_popup, render_help_text, render_yes_no_buttons, render_yes_no_cancel_buttons,
 };

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -8,7 +8,7 @@ mod layout;
 mod order_chat_projection;
 mod startup;
 
-pub use ascii_art::render_centered_lines;
+pub use ascii_art::{render_centered_lines, MAILBOX_EMPTY_ART};
 
 pub(crate) use attachments::try_parse_attachment_message;
 pub use attachments::{

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -290,7 +290,7 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         request_id,
         Some(trade_index),
         action,
-        Some(Payload::Order(payload_order)),
+        Some(Payload::Order(payload_order.clone())),
     );
 
     let history_message = OrderMessage {
@@ -307,6 +307,7 @@ fn db_order_to_history_message(order: &Order, sender: PublicKey) -> Option<Order
         order_kind: kind,
         is_mine: Some(order.is_mine),
         order_status: status,
+        order_snapshot: Some(payload_order),
         read: true,
         auto_popup_shown: !matches!(
             status,

--- a/src/ui/order_form.rs
+++ b/src/ui/order_form.rs
@@ -60,6 +60,7 @@ pub fn render_order_form(
         )))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -114,6 +115,7 @@ fn render_details(
     let block = Block::default()
         .title(" Order details ")
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -468,6 +470,7 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
     let block = Block::default()
         .title(" Live preview ")
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -600,6 +603,7 @@ fn render_help(f: &mut ratatui::Frame, area: Rect, form: &FormState) {
             Block::default()
                 .title(" Field help ")
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         )
         .style(Style::default().fg(Color::Gray))
@@ -1052,6 +1056,7 @@ pub fn render_form_initializing(f: &mut ratatui::Frame, area: Rect) {
         )))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     f.render_widget(block, area);
 }

--- a/src/ui/order_form.rs
+++ b/src/ui/order_form.rs
@@ -61,7 +61,8 @@ pub fn render_order_form(
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -116,7 +117,8 @@ fn render_details(
         .title(" Order details ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -471,7 +473,8 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
         .title(" Live preview ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -494,7 +497,8 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
         .title(" Order ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let card_inner = card.inner(split[0]);
     f.render_widget(card, split[0]);
     f.render_widget(
@@ -604,7 +608,8 @@ fn render_help(f: &mut ratatui::Frame, area: Rect, form: &FormState) {
                 .title(" Field help ")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         )
         .style(Style::default().fg(Color::Gray))
         .wrap(Wrap { trim: true });
@@ -686,7 +691,8 @@ fn render_currency_dropdown(
         .title(title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(popup);
     f.render_widget(block, popup);
 
@@ -1057,7 +1063,8 @@ pub fn render_form_initializing(f: &mut ratatui::Frame, area: Rect) {
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block, area);
 }
 

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -922,7 +922,7 @@ pub fn message_status_presentation(msg: &OrderMessage) -> MessageStatusPresentat
             Action::PayBondInvoice => ("🔒", "Bond payment required"),
             Action::AddBondInvoice => ("🔒", "Bond payout invoice required"),
             Action::Release | Action::FiatSentOk => ("🔓", "Release required"),
-            Action::FiatSent => ("💸", "Confirm fiat sent"),
+            Action::FiatSent | Action::HoldInvoicePaymentAccepted => ("💸", "Confirm fiat sent"),
             Action::Rate => ("⭐", "Rating required"),
             _ => ("👉", "Action required"),
         };
@@ -982,6 +982,13 @@ fn actionable_next_step(msg: &OrderMessage, action: &Action) -> Option<&'static 
             ) =>
         {
             Some("Confirm that you sent the fiat payment.")
+        }
+        // Mostro reports the seller's hold invoice is paid: the Enter router
+        // (`enter_handlers.rs`) opens the fiat-confirmation popup that sends
+        // `FiatSent`, so this is actionable for the buyer — not a waiting phase.
+        // Kept unconditional to match that router's actionability classification.
+        Action::HoldInvoicePaymentAccepted => {
+            Some("Confirm you sent the fiat payment to continue.")
         }
         Action::Rate => Some("Rate your counterparty."),
         _ => None,
@@ -1463,6 +1470,26 @@ mod message_emoji_and_badge_tests {
         let p = message_status_presentation(&m);
         assert_eq!(p.title, "Invoice required");
         assert_eq!(p.next, Some("Add your Lightning invoice to continue."));
+    }
+
+    #[test]
+    fn status_presentation_hold_invoice_accepted_is_actionable() {
+        // Mostro reports the hold invoice paid; the Enter router opens the
+        // fiat-confirmation popup, so STATUS must prompt the buyer to act rather
+        // than fall through to the "no action required" waiting default.
+        let m = sample_msg(
+            Action::HoldInvoicePaymentAccepted,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::SettledHoldInvoice),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.emoji, "💸");
+        assert_eq!(p.title, "Confirm fiat sent");
+        assert_eq!(
+            p.next,
+            Some("Confirm you sent the fiat payment to continue.")
+        );
     }
 
     #[test]

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -98,7 +98,7 @@ pub(crate) fn try_placeholder_order_message_from_success(
         None,
         Some(trade_index),
         action,
-        Some(Payload::Order(small)),
+        Some(Payload::Order(small.clone())),
     );
     Some(OrderMessage {
         message,
@@ -111,6 +111,7 @@ pub(crate) fn try_placeholder_order_message_from_success(
         order_kind: os.kind,
         is_mine: Some(header.is_mine),
         order_status: os.status,
+        order_snapshot: Some(small),
         read: true,
         auto_popup_shown: true,
     })
@@ -337,6 +338,10 @@ pub struct OrderMessage {
     pub is_mine: Option<bool>,
     /// Last known Mostro order status for this trade (payload or DB).
     pub order_status: Option<mostro_core::order::Status>,
+    /// Stable trade receipt fields for the Messages TRADE card. Carried across
+    /// DMs that omit `Payload::Order` (e.g. `PaymentRequest`, payload-less
+    /// `FiatSent` / `Release`) so Fiat/Premium/Method do not blank mid-trade.
+    pub order_snapshot: Option<SmallOrder>,
     pub read: bool, // Whether the message has been read
     /// Whether we've already shown the automatic popup for this message
     pub auto_popup_shown: bool,
@@ -762,21 +767,39 @@ pub fn message_action_emoji(action: &Action) -> &'static str {
     }
 }
 
+/// Status-aware emoji for Messages sidebar rows. Prefers [`OrderMessage::order_status`]
+/// so terminal/waiting rows do not keep a stale action glyph (e.g. `🆕` after Success).
+pub fn message_action_emoji_for_message(msg: &OrderMessage) -> &'static str {
+    match msg.order_status {
+        Some(Status::Success) => "✅",
+        Some(Status::SettledByAdmin) | Some(Status::CompletedByAdmin) => "✅",
+        Some(Status::Canceled)
+        | Some(Status::CanceledByAdmin)
+        | Some(Status::CooperativelyCanceled) => "❌",
+        Some(Status::Expired) => "⌛",
+        Some(Status::Dispute) => "⚖️",
+        Some(Status::FiatSent) => "💸",
+        Some(Status::Pending)
+        | Some(Status::WaitingPayment)
+        | Some(Status::WaitingBuyerInvoice)
+        | Some(Status::WaitingTakerBond)
+        | Some(Status::WaitingMakerBond) => "⏳",
+        Some(Status::InProgress) | Some(Status::Active) | Some(Status::SettledHoldInvoice) => "💬",
+        None => message_action_emoji(&msg.message.get_inner_message_kind().action),
+    }
+}
+
 /// Emoji + color badge summarizing the overall order status (header card, sidebar accents).
 /// `None` (status not yet hydrated) renders the same as an active/in-progress trade.
-///
-/// Not yet called from any render path: wired into the Messages-tab header card in the
-/// Messages Tab UX Restyle plan's Step 3 (right-panel header + trade snapshot card).
-#[allow(dead_code)]
 pub fn order_status_badge(status: Option<Status>) -> (&'static str, Color) {
     match status {
         Some(Status::Success) => ("✅", Color::Green),
-        Some(Status::SettledByAdmin) | Some(Status::CompletedByAdmin) => ("⚖️", Color::Yellow),
+        Some(Status::SettledByAdmin) | Some(Status::CompletedByAdmin) => ("✅", Color::Green),
         Some(Status::Canceled)
         | Some(Status::CanceledByAdmin)
         | Some(Status::CooperativelyCanceled) => ("❌", Color::Red),
         Some(Status::Expired) => ("⌛", Color::DarkGray),
-        Some(Status::Dispute) => ("⚖️", Color::Yellow),
+        Some(Status::Dispute) => ("⚖️", Color::Magenta),
         Some(Status::FiatSent) => ("💸", PRIMARY_COLOR),
         Some(Status::Pending)
         | Some(Status::WaitingPayment)
@@ -787,6 +810,181 @@ pub fn order_status_badge(status: Option<Status>) -> (&'static str, Color) {
         | Some(Status::Active)
         | Some(Status::SettledHoldInvoice)
         | None => ("💬", PRIMARY_COLOR),
+    }
+}
+
+/// Own a [`SmallOrder`] from any payload shape that embeds one (standalone order,
+/// payment-request with order, or bond-payout request).
+pub fn small_order_from_payload(payload: &Option<Payload>) -> Option<SmallOrder> {
+    match payload.as_ref()? {
+        Payload::Order(o) => Some(o.clone()),
+        Payload::PaymentRequest(Some(o), _, _) => Some(o.clone()),
+        Payload::BondPayoutRequest(req) => Some(req.order.clone()),
+        _ => None,
+    }
+}
+
+/// Score how useful a snapshot is for the TRADE receipt (higher = richer).
+fn snapshot_richness(o: &SmallOrder) -> i32 {
+    let mut score = 0;
+    if !o.payment_method.trim().is_empty() {
+        score += 4;
+    }
+    if o.fiat_amount > 0 || o.min_amount.is_some() || o.max_amount.is_some() {
+        score += 2;
+    }
+    if !o.fiat_code.trim().is_empty() {
+        score += 1;
+    }
+    if o.amount > 0 {
+        score += 1;
+    }
+    score
+}
+
+/// Pick the richest snapshot among payload / prior row / DB-derived candidates.
+pub fn merge_order_snapshots(
+    incoming: Option<SmallOrder>,
+    prior: Option<SmallOrder>,
+    from_db: Option<SmallOrder>,
+) -> Option<SmallOrder> {
+    [incoming, prior, from_db]
+        .into_iter()
+        .flatten()
+        .max_by_key(snapshot_richness)
+}
+
+/// STATUS / Next presentation for the Messages detail panel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageStatusPresentation {
+    pub emoji: &'static str,
+    pub title: &'static str,
+    pub color: Color,
+    /// `None` for terminal / warning states (no "what's next" callout).
+    pub next: Option<&'static str>,
+}
+
+/// Single status/role/action-aware mapping for the STATUS banner.
+///
+/// Prefer persisted [`OrderMessage::order_status`], then fall back to the last
+/// DM action. Actionable invoice phases get explicit "do X" copy; waiting phases
+/// reuse [`waiting_phase_description`]; terminal/warning states omit Next.
+pub fn message_status_presentation(msg: &OrderMessage) -> MessageStatusPresentation {
+    let action = msg.message.get_inner_message_kind().action.clone();
+    if let Some(text) = message_timeline_warning_for_order_status(msg.order_status)
+        .or_else(|| message_timeline_warning(&action))
+    {
+        let (emoji, color) = if text.contains("dispute") {
+            ("⚖️", Color::Magenta)
+        } else {
+            ("❌", Color::Red)
+        };
+        return MessageStatusPresentation {
+            emoji,
+            title: text,
+            color,
+            next: None,
+        };
+    }
+
+    match msg.order_status {
+        Some(Status::Success) => {
+            if matches!(action, Action::Rate) {
+                return MessageStatusPresentation {
+                    emoji: "⭐",
+                    title: "Trade completed",
+                    color: Color::Green,
+                    next: Some("Rate your counterparty."),
+                };
+            }
+            return MessageStatusPresentation {
+                emoji: "✅",
+                title: "Trade completed",
+                color: Color::Green,
+                next: None,
+            };
+        }
+        Some(Status::SettledByAdmin) | Some(Status::CompletedByAdmin) => {
+            return MessageStatusPresentation {
+                emoji: "✅",
+                title: "Trade settled by admin",
+                color: Color::Green,
+                next: None,
+            };
+        }
+        _ => {}
+    }
+
+    if let Some(next) = actionable_next_step(msg, &action) {
+        let (emoji, title) = match action {
+            Action::AddInvoice => ("🧾", "Invoice required"),
+            Action::PayInvoice => ("⚡", "Payment required"),
+            Action::PayBondInvoice => ("🔒", "Bond payment required"),
+            Action::AddBondInvoice => ("🔒", "Bond payout invoice required"),
+            Action::Release | Action::FiatSentOk => ("🔓", "Release required"),
+            Action::FiatSent => ("💸", "Confirm fiat sent"),
+            Action::Rate => ("⭐", "Rating required"),
+            _ => ("👉", "Action required"),
+        };
+        return MessageStatusPresentation {
+            emoji,
+            title,
+            color: PRIMARY_COLOR,
+            next: Some(next),
+        };
+    }
+
+    MessageStatusPresentation {
+        emoji: "✅",
+        title: "Trade is on the normal path",
+        color: Color::Green,
+        next: Some(waiting_phase_description(msg)),
+    }
+}
+
+/// Explicit next-step copy when the local user must act; `None` when waiting or N/A.
+fn actionable_next_step(msg: &OrderMessage, action: &Action) -> Option<&'static str> {
+    match action {
+        Action::AddInvoice
+        | Action::PayInvoice
+        | Action::PayBondInvoice
+        | Action::AddBondInvoice
+            if local_user_must_act_on_invoice_popup(msg, action) =>
+        {
+            Some(match action {
+                Action::AddInvoice => "Add your Lightning invoice to continue.",
+                Action::PayInvoice => "Pay the hold invoice to continue.",
+                Action::PayBondInvoice
+                    if msg.order_status == Some(Status::WaitingMakerBond)
+                        || (msg.order_status.is_none() && msg.is_mine == Some(true)) =>
+                {
+                    "Pay the anti-abuse bond to publish your order to the book."
+                }
+                Action::PayBondInvoice => "Pay the anti-abuse bond to continue.",
+                Action::AddBondInvoice => "Add a bond payout invoice to claim your share.",
+                _ => "Complete the required payment step.",
+            })
+        }
+        Action::FiatSentOk | Action::Release
+            if matches!(
+                (msg.order_kind, msg.is_mine),
+                (Some(mostro_core::order::Kind::Buy), Some(false))
+                    | (Some(mostro_core::order::Kind::Sell), Some(true))
+            ) =>
+        {
+            Some("Release sats to complete the trade.")
+        }
+        Action::FiatSent
+            if matches!(
+                (msg.order_kind, msg.is_mine),
+                (Some(mostro_core::order::Kind::Buy), Some(true))
+                    | (Some(mostro_core::order::Kind::Sell), Some(false))
+            ) =>
+        {
+            Some("Confirm that you sent the fiat payment.")
+        }
+        Action::Rate => Some("Rate your counterparty."),
+        _ => None,
     }
 }
 
@@ -1195,10 +1393,18 @@ mod message_emoji_and_badge_tests {
     }
 
     #[test]
-    fn dispute_status_badges_as_yellow_scales() {
+    fn dispute_status_badges_as_magenta_scales() {
         assert_eq!(
             order_status_badge(Some(Status::Dispute)),
-            ("⚖️", Color::Yellow)
+            ("⚖️", Color::Magenta)
+        );
+    }
+
+    #[test]
+    fn admin_settled_badge_is_green_check_not_dispute_scales() {
+        assert_eq!(
+            order_status_badge(Some(Status::SettledByAdmin)),
+            ("✅", Color::Green)
         );
     }
 
@@ -1209,6 +1415,106 @@ mod message_emoji_and_badge_tests {
             order_status_badge(Some(Status::InProgress)),
             ("💬", PRIMARY_COLOR)
         );
+    }
+
+    fn sample_msg(
+        action: Action,
+        order_kind: Option<mostro_core::order::Kind>,
+        is_mine: Option<bool>,
+        order_status: Option<Status>,
+    ) -> OrderMessage {
+        let keys = nostr_sdk::Keys::generate();
+        OrderMessage {
+            message: Message::new_order(None, None, None, action, None),
+            timestamp: 0,
+            sender: keys.public_key(),
+            order_id: None,
+            trade_index: 0,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind,
+            is_mine,
+            order_status,
+            order_snapshot: None,
+            read: true,
+            auto_popup_shown: true,
+        }
+    }
+
+    #[test]
+    fn sidebar_emoji_prefers_success_status_over_stale_new_order_action() {
+        let m = sample_msg(
+            Action::NewOrder,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::Success),
+        );
+        assert_eq!(message_action_emoji_for_message(&m), "✅");
+    }
+
+    #[test]
+    fn status_presentation_buy_maker_add_invoice_is_actionable() {
+        let m = sample_msg(
+            Action::AddInvoice,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::WaitingBuyerInvoice),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.title, "Invoice required");
+        assert_eq!(p.next, Some("Add your Lightning invoice to continue."));
+    }
+
+    #[test]
+    fn status_presentation_success_has_no_waiting_callout() {
+        let m = sample_msg(
+            Action::Released,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::Success),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.title, "Trade completed");
+        assert!(p.next.is_none());
+    }
+
+    #[test]
+    fn payment_request_payload_yields_order_snapshot() {
+        let order = SmallOrder {
+            fiat_amount: 100,
+            fiat_code: "USD".to_string(),
+            payment_method: "SEPA".to_string(),
+            amount: 50_000,
+            premium: 1,
+            ..Default::default()
+        };
+        let payload = Some(Payload::PaymentRequest(
+            Some(order.clone()),
+            "lnbc1…".to_string(),
+            None,
+        ));
+        let snap = small_order_from_payload(&payload).expect("order");
+        assert_eq!(snap.fiat_amount, 100);
+        assert_eq!(snap.payment_method, "SEPA");
+    }
+
+    #[test]
+    fn merge_order_snapshots_keeps_richer_prior_over_sparse_incoming() {
+        let rich = SmallOrder {
+            fiat_amount: 100,
+            fiat_code: "EUR".to_string(),
+            payment_method: "Revolut".to_string(),
+            amount: 10_000,
+            premium: 0,
+            ..Default::default()
+        };
+        let sparse = SmallOrder {
+            amount: 10_000,
+            ..Default::default()
+        };
+        let merged = merge_order_snapshots(Some(sparse), Some(rich.clone()), None).unwrap();
+        assert_eq!(merged.payment_method, "Revolut");
+        assert_eq!(merged.fiat_code, "EUR");
     }
 }
 
@@ -1311,6 +1617,7 @@ mod timeline_step_tests {
             order_kind,
             is_mine,
             order_status,
+            order_snapshot: None,
             read: false,
             auto_popup_shown: false,
         }
@@ -1504,6 +1811,7 @@ mod invoice_popup_role_tests {
             order_kind,
             is_mine,
             order_status,
+            order_snapshot: None,
             read: false,
             auto_popup_shown: false,
         }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -9,6 +9,7 @@ use crate::ui::constants::{
     SELL_ORDER_FLOW_STEPS_MAKER, SELL_ORDER_FLOW_STEPS_TAKER,
     VIEW_MESSAGE_BUYER_TOOK_ORDER_PREVIEW, VIEW_MESSAGE_HOLD_INVOICE_PREVIEW,
 };
+use crate::ui::PRIMARY_COLOR;
 
 pub use crate::ui::constants::StepLabel;
 
@@ -735,6 +736,60 @@ pub fn message_action_compact_label_for_message(msg: &OrderMessage) -> &'static 
     }
 }
 
+/// Emoji glyph for an [`Action`], used to give Messages-tab rows an at-a-glance icon.
+/// Mirrors the action set covered by [`message_action_compact_label`] plus a generic fallback.
+pub fn message_action_emoji(action: &Action) -> &'static str {
+    match action {
+        Action::AddInvoice => "🧾",
+        Action::AddBondInvoice => "🔒",
+        Action::PayInvoice => "⚡",
+        Action::PayBondInvoice => "🔒",
+        Action::WaitingBuyerInvoice => "⏳",
+        Action::WaitingSellerToPay => "⏳",
+        Action::HoldInvoicePaymentAccepted => "🔐",
+        Action::BuyerTookOrder => "🤝",
+        Action::FiatSent => "💸",
+        Action::FiatSentOk => "✅",
+        Action::Release | Action::Released => "🔓",
+        Action::Dispute | Action::DisputeInitiatedByYou => "⚖️",
+        Action::Canceled => "❌",
+        Action::AdminCanceled => "🛑",
+        Action::Rate => "⭐",
+        Action::RateReceived => "🌟",
+        Action::CooperativeCancelInitiatedByPeer | Action::CooperativeCancelInitiatedByYou => "✋",
+        Action::NewOrder => "🆕",
+        _ => "✉️",
+    }
+}
+
+/// Emoji + color badge summarizing the overall order status (header card, sidebar accents).
+/// `None` (status not yet hydrated) renders the same as an active/in-progress trade.
+///
+/// Not yet called from any render path: wired into the Messages-tab header card in the
+/// Messages Tab UX Restyle plan's Step 3 (right-panel header + trade snapshot card).
+#[allow(dead_code)]
+pub fn order_status_badge(status: Option<Status>) -> (&'static str, Color) {
+    match status {
+        Some(Status::Success) => ("✅", Color::Green),
+        Some(Status::SettledByAdmin) | Some(Status::CompletedByAdmin) => ("⚖️", Color::Yellow),
+        Some(Status::Canceled)
+        | Some(Status::CanceledByAdmin)
+        | Some(Status::CooperativelyCanceled) => ("❌", Color::Red),
+        Some(Status::Expired) => ("⌛", Color::DarkGray),
+        Some(Status::Dispute) => ("⚖️", Color::Yellow),
+        Some(Status::FiatSent) => ("💸", PRIMARY_COLOR),
+        Some(Status::Pending)
+        | Some(Status::WaitingPayment)
+        | Some(Status::WaitingBuyerInvoice)
+        | Some(Status::WaitingTakerBond)
+        | Some(Status::WaitingMakerBond) => ("⏳", Color::Yellow),
+        Some(Status::InProgress)
+        | Some(Status::Active)
+        | Some(Status::SettledHoldInvoice)
+        | None => ("💬", PRIMARY_COLOR),
+    }
+}
+
 /// Book order kind for sidebar: prefer persisted [`OrderMessage::order_kind`], then payload,
 /// then take-action hints when the listing side is implied (`take-sell` → sell listing, etc.).
 pub fn message_order_kind_label(msg: &OrderMessage) -> &'static str {
@@ -1079,6 +1134,81 @@ pub fn apply_kind_color(kind: &mostro_core::order::Kind) -> Style {
     match kind {
         mostro_core::order::Kind::Buy => Style::default().fg(Color::Green),
         mostro_core::order::Kind::Sell => Style::default().fg(Color::Red),
+    }
+}
+
+#[cfg(test)]
+mod message_emoji_and_badge_tests {
+    use super::*;
+
+    #[test]
+    fn add_invoice_and_pay_invoice_have_distinct_emoji() {
+        assert_eq!(message_action_emoji(&Action::AddInvoice), "🧾");
+        assert_eq!(message_action_emoji(&Action::PayInvoice), "⚡");
+    }
+
+    #[test]
+    fn dispute_actions_share_the_scales_emoji() {
+        assert_eq!(message_action_emoji(&Action::Dispute), "⚖️");
+        assert_eq!(message_action_emoji(&Action::DisputeInitiatedByYou), "⚖️");
+    }
+
+    #[test]
+    fn unmapped_action_falls_back_to_envelope() {
+        assert_eq!(message_action_emoji(&Action::Orders), "✉️");
+    }
+
+    #[test]
+    fn success_status_badge_is_green_check() {
+        assert_eq!(
+            order_status_badge(Some(Status::Success)),
+            ("✅", Color::Green)
+        );
+    }
+
+    #[test]
+    fn cancel_variants_badge_as_red_cross() {
+        assert_eq!(
+            order_status_badge(Some(Status::Canceled)),
+            ("❌", Color::Red)
+        );
+        assert_eq!(
+            order_status_badge(Some(Status::CanceledByAdmin)),
+            ("❌", Color::Red)
+        );
+        assert_eq!(
+            order_status_badge(Some(Status::CooperativelyCanceled)),
+            ("❌", Color::Red)
+        );
+    }
+
+    #[test]
+    fn waiting_phases_badge_as_yellow_hourglass() {
+        assert_eq!(
+            order_status_badge(Some(Status::WaitingBuyerInvoice)),
+            ("⏳", Color::Yellow)
+        );
+        assert_eq!(
+            order_status_badge(Some(Status::WaitingMakerBond)),
+            ("⏳", Color::Yellow)
+        );
+    }
+
+    #[test]
+    fn dispute_status_badges_as_yellow_scales() {
+        assert_eq!(
+            order_status_badge(Some(Status::Dispute)),
+            ("⚖️", Color::Yellow)
+        );
+    }
+
+    #[test]
+    fn none_status_defaults_to_active_chat_badge() {
+        assert_eq!(order_status_badge(None), ("💬", PRIMARY_COLOR));
+        assert_eq!(
+            order_status_badge(Some(Status::InProgress)),
+            ("💬", PRIMARY_COLOR)
+        );
     }
 }
 

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -477,6 +477,11 @@ pub fn waiting_phase_description(msg: &OrderMessage) -> &'static str {
         (_, true, Action::PayBondInvoice) => {
             "Pay the anti-abuse bond to publish your order to the book."
         }
+        // Your order was taken: the next actionable prompt (invoice/payment) arrives
+        // as a follow-up DM, so this phase is informational, not something to act on.
+        (_, _, Action::BuyerTookOrder) => {
+            "Your order was taken. Waiting for the trade to proceed."
+        }
         _ => "Waiting for the counterparty. No action is required from you right now.",
     }
 }
@@ -923,6 +928,7 @@ pub fn message_status_presentation(msg: &OrderMessage) -> MessageStatusPresentat
             Action::AddBondInvoice => ("🔒", "Bond payout invoice required"),
             Action::Release | Action::FiatSentOk => ("🔓", "Release required"),
             Action::FiatSent | Action::HoldInvoicePaymentAccepted => ("💸", "Confirm fiat sent"),
+            Action::CooperativeCancelInitiatedByPeer => ("⚠️", "Cancel requested"),
             Action::Rate => ("⭐", "Rating required"),
             _ => ("👉", "Action required"),
         };
@@ -989,6 +995,11 @@ fn actionable_next_step(msg: &OrderMessage, action: &Action) -> Option<&'static 
         // Kept unconditional to match that router's actionability classification.
         Action::HoldInvoicePaymentAccepted => {
             Some("Confirm you sent the fiat payment to continue.")
+        }
+        // Peer asked to cooperatively cancel: the Enter router opens a decision
+        // popup, so surface it as a decision rather than a silent waiting state.
+        Action::CooperativeCancelInitiatedByPeer => {
+            Some("Your counterparty asked to cooperatively cancel — press Enter to review.")
         }
         Action::Rate => Some("Rate your counterparty."),
         _ => None,
@@ -1489,6 +1500,43 @@ mod message_emoji_and_badge_tests {
         assert_eq!(
             p.next,
             Some("Confirm you sent the fiat payment to continue.")
+        );
+    }
+
+    #[test]
+    fn status_presentation_cooperative_cancel_peer_is_actionable() {
+        // Peer-initiated cooperative cancel: Enter opens a decision popup, so STATUS
+        // must surface it rather than showing the generic waiting default.
+        let m = sample_msg(
+            Action::CooperativeCancelInitiatedByPeer,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::Active),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.emoji, "⚠️");
+        assert_eq!(p.title, "Cancel requested");
+        assert_eq!(
+            p.next,
+            Some("Your counterparty asked to cooperatively cancel — press Enter to review.")
+        );
+    }
+
+    #[test]
+    fn status_presentation_buyer_took_order_is_informational_waiting() {
+        // "Order taken" is a waiting phase (the actionable prompt arrives later), so
+        // it should read as normal-path waiting with specific copy, not "must act".
+        let m = sample_msg(
+            Action::BuyerTookOrder,
+            Some(mostro_core::order::Kind::Sell),
+            Some(true),
+            Some(Status::Active),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.title, "Trade is on the normal path");
+        assert_eq!(
+            p.next,
+            Some("Your order was taken. Waiting for the trade to proceed.")
         );
     }
 

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -91,7 +91,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         .title(sidebar_title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     if filtered_disputes.is_empty() {
         let empty_msg = match app.dispute_filter {
@@ -477,7 +478,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                     ))
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             )
             .alignment(ratatui::layout::Alignment::Left);
         f.render_widget(header, main_chunks[0]);
@@ -622,7 +624,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                 .title(chat_title)
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR));
             let inner_area = chat_block.inner(chat_area);
             f.render_widget(chat_block, chat_area);
 
@@ -836,7 +839,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         let outer_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR));
         let inner_area = outer_block.inner(main_area);
         f.render_widget(outer_block, main_area);
 

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -6,7 +6,7 @@ use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::constants::*;
@@ -90,7 +90,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
     let disputes_block = Block::default()
         .title(sidebar_title)
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     if filtered_disputes.is_empty() {
         let empty_msg = match app.dispute_filter {
@@ -475,7 +476,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                             .add_modifier(Modifier::BOLD),
                     ))
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             )
             .alignment(ratatui::layout::Alignment::Left);
         f.render_widget(header, main_chunks[0]);
@@ -526,13 +528,23 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
 
             f.render_widget(
                 Paragraph::new(buyer_text)
-                    .block(Block::default().borders(Borders::ALL).style(buyer_style))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_type(BorderType::Rounded)
+                            .style(buyer_style),
+                    )
                     .alignment(ratatui::layout::Alignment::Center),
                 party_chunks[0],
             );
             f.render_widget(
                 Paragraph::new(seller_text)
-                    .block(Block::default().borders(Borders::ALL).style(seller_style))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_type(BorderType::Rounded)
+                            .style(seller_style),
+                    )
                     .alignment(ratatui::layout::Alignment::Center),
                 party_chunks[1],
             );
@@ -609,7 +621,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
             let chat_block = Block::default()
                 .title(chat_title)
                 .borders(Borders::ALL)
-                .style(Style::default());
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
             let inner_area = chat_block.inner(chat_area);
             f.render_widget(chat_block, chat_area);
 
@@ -662,6 +675,7 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                     Block::default()
                         .title(input_title)
                         .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
                         .border_style(input_border_style)
                         .style(input_style),
                 )
@@ -821,7 +835,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         // Render the outer block first, then content inside it
         let outer_block = Block::default()
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR));
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
         let inner_area = outer_block.inner(main_area);
         f.render_widget(outer_block, main_area);
 

--- a/src/ui/tabs/disputes_tab.rs
+++ b/src/ui/tabs/disputes_tab.rs
@@ -33,7 +33,8 @@ pub fn render_disputes_tab(
                     .title("Disputes Pending")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -67,7 +68,8 @@ pub fn render_disputes_tab(
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -118,7 +120,8 @@ pub fn render_disputes_tab(
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         )
         .row_highlight_style(
             Style::default()

--- a/src/ui/tabs/disputes_tab.rs
+++ b/src/ui/tabs/disputes_tab.rs
@@ -6,7 +6,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::Constraint;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
 use crate::ui::{BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -32,7 +32,8 @@ pub fn render_disputes_tab(
                 Block::default()
                     .title("Disputes Pending")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -65,7 +66,8 @@ pub fn render_disputes_tab(
             Block::default()
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -115,7 +117,8 @@ pub fn render_disputes_tab(
             Block::default()
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         )
         .row_highlight_style(
             Style::default()

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -6,6 +6,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 
+use mostro_core::prelude::{Payload, SmallOrder};
+
 use crate::ui::helpers;
 use crate::ui::orders::{
     listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
@@ -188,38 +190,20 @@ fn build_sidebar_items(
 }
 
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
+    // Panel order mirrors the target mockup: header, progress stepper, TRADE
+    // snapshot (fills the space the old numbered timeline wasted), then STATUS.
     let right_chunks = Layout::new(
         Direction::Vertical,
         [
-            Constraint::Length(3),
+            Constraint::Length(4),
             Constraint::Length(7),
-            Constraint::Length(3),
             Constraint::Min(0),
+            Constraint::Length(3),
         ],
     )
     .split(area);
 
-    let order_id = selected_msg
-        .order_id
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| "Unknown order id".to_string());
-    let timestamp = DateTime::<Utc>::from_timestamp(selected_msg.timestamp, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
-        .unwrap_or_else(|| "Unknown time".to_string());
-
-    let header = Paragraph::new(vec![
-        Line::from(Span::styled(
-            format!("Order {order_id}"),
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(format!("Last message at {timestamp}"))),
-    ])
-    .block(
-        Block::default()
-            .title("Selected Trade")
-            .borders(Borders::ALL),
-    );
-    f.render_widget(header, right_chunks[0]);
+    render_header_card(f, right_chunks[0], selected_msg);
 
     let step_labels = listing_timeline_labels(selected_msg);
     render_trade_stepper(
@@ -228,6 +212,8 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
         message_trade_timeline_step(selected_msg),
         &step_labels,
     );
+
+    render_trade_snapshot_card(f, right_chunks[2], selected_msg);
 
     let warning_from_status = message_timeline_warning_for_order_status(selected_msg.order_status);
     let warning_opt = warning_from_status.or_else(|| {
@@ -243,35 +229,208 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
     };
     let state = Paragraph::new(Line::from(Span::styled(warning, warning_style)))
         .alignment(ratatui::layout::Alignment::Center)
-        .block(Block::default().title("State").borders(Borders::ALL));
-    f.render_widget(state, right_chunks[2]);
+        .block(
+            Block::default()
+                .title(" State ")
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+        );
+    f.render_widget(state, right_chunks[3]);
+}
 
-    let action_text = message_action_compact_label_for_message(selected_msg);
-    let details = Paragraph::new(vec![
-        Line::from(Span::styled(
-            "Current action",
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(action_text)),
-        Line::from(Span::raw("")),
-        Line::from(Span::styled(
-            "Trade timeline",
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(Span::raw(format!("1) {}", step_labels[0].as_single_line()))),
-        Line::from(Span::raw(format!("2) {}", step_labels[1].as_single_line()))),
-        Line::from(Span::raw(format!("3) {}", step_labels[2].as_single_line()))),
-        Line::from(Span::raw(format!("4) {}", step_labels[3].as_single_line()))),
-        Line::from(Span::raw(format!("5) {}", step_labels[4].as_single_line()))),
-        Line::from(Span::raw(format!("6) {}", step_labels[5].as_single_line()))),
-    ])
-    .block(
-        Block::default()
-            .title("Timeline Details")
-            .borders(Borders::ALL),
+/// Header card: order id + kind badge + maker/taker role chip, plus the absolute
+/// and relative last-update time.
+fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let kind_label = message_order_kind_label(msg);
+    let (dot, kind_color) = kind_dot(kind_label);
+    let (role_emoji, role_label) = role_chip(msg.is_mine);
+
+    let line1 = Line::from(vec![
+        Span::styled("🧾 Order ", Style::default().fg(Color::Gray)),
+        Span::styled(
+            helpers::short_order_id(msg.order_id),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!("{dot} {kind_label}"),
+            Style::default().fg(kind_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!("{role_emoji} {role_label}"),
+            Style::default().fg(Color::Cyan),
+        ),
+    ]);
+
+    let absolute = DateTime::<Utc>::from_timestamp(msg.timestamp, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let relative = helpers::relative_time_compact(msg.timestamp);
+    let line2 = Line::from(Span::styled(
+        format!("Last update: {absolute} ({relative})"),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    f.render_widget(Paragraph::new(vec![line1, line2]), inner);
+}
+
+/// TRADE snapshot card: two-column receipt of the order payload (fiat, sats,
+/// premium, method, trade index, role). Values gracefully fall back to `—`.
+fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .title(Span::styled(
+            " TRADE ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let inner_kind = msg.message.get_inner_message_kind();
+    let order = match &inner_kind.payload {
+        Some(Payload::Order(order)) => Some(order),
+        _ => None,
+    };
+
+    let (premium, premium_color) = premium_display(order);
+    let (role_emoji, role_label) = role_chip(msg.is_mine);
+    let white = Style::default().fg(Color::White);
+
+    let left = vec![
+        snapshot_field("💰", "Fiat", fiat_display(order), white),
+        snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white),
+        snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white),
+    ];
+    let right = vec![
+        snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color)),
+        snapshot_field("🧾", "Method", method_display(order), white),
+        snapshot_field(
+            role_emoji,
+            "Role",
+            role_label.to_string(),
+            Style::default().fg(Color::Cyan),
+        ),
+    ];
+
+    let cols = Layout::new(
+        Direction::Horizontal,
+        [Constraint::Percentage(50), Constraint::Percentage(50)],
     )
-    .wrap(ratatui::widgets::Wrap { trim: true });
-    f.render_widget(details, right_chunks[3]);
+    .split(inner);
+    f.render_widget(Paragraph::new(left), cols[0]);
+    f.render_widget(Paragraph::new(right), cols[1]);
+}
+
+/// One `emoji label value` row inside the TRADE snapshot card. The leading emoji
+/// stays at the start of the row (kept out of the aligned label/value columns) so
+/// double-width glyphs never break alignment.
+fn snapshot_field(emoji: &str, label: &str, value: String, value_style: Style) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!(" {emoji} "), Style::default().fg(Color::Gray)),
+        Span::styled(format!("{label:<10}"), Style::default().fg(Color::DarkGray)),
+        Span::styled(value, value_style),
+    ])
+}
+
+/// Maker/taker chip from [`OrderMessage::is_mine`] (`is_mine` == "I am the maker").
+fn role_chip(is_mine: Option<bool>) -> (&'static str, &'static str) {
+    match is_mine {
+        Some(true) => ("👤", "Maker"),
+        Some(false) => ("🤝", "Taker"),
+        None => ("❔", "—"),
+    }
+}
+
+/// Fiat amount (or min–max range) with currency code; `—` when no order payload.
+fn fiat_display(order: Option<&SmallOrder>) -> String {
+    let Some(order) = order else {
+        return "—".to_string();
+    };
+    let code = order.fiat_code.trim().to_ascii_uppercase();
+    let value = match (order.min_amount, order.max_amount) {
+        (Some(min), Some(max)) if min > 0 && max > 0 => format!("{min}–{max}"),
+        _ if order.fiat_amount > 0 => order.fiat_amount.to_string(),
+        _ => String::new(),
+    };
+    match (value.is_empty(), code.is_empty()) {
+        (true, true) => "—".to_string(),
+        (true, false) => code,
+        (false, true) => value,
+        (false, false) => format!("{value} {code}"),
+    }
+}
+
+/// Sats for the trade: prefer the message `sat_amount`, then the order amount,
+/// showing `market` for a 0-amount (market-price) order and `—` when unknown.
+fn sats_display(order: Option<&SmallOrder>, sat_amount: Option<i64>) -> String {
+    if let Some(sats) = sat_amount {
+        if sats > 0 {
+            return group_thousands(&sats.to_string());
+        }
+    }
+    match order {
+        Some(order) if order.amount > 0 => group_thousands(&order.amount.to_string()),
+        Some(_) => "market".to_string(),
+        None => "—".to_string(),
+    }
+}
+
+/// Premium string + color: `+p%` green, `p%` red, `0%` gray, `—` when absent.
+fn premium_display(order: Option<&SmallOrder>) -> (String, Color) {
+    match order {
+        None => ("—".to_string(), Color::DarkGray),
+        Some(order) => match order.premium {
+            0 => ("0%".to_string(), Color::Gray),
+            p if p > 0 => (format!("+{p}%"), Color::Green),
+            p => (format!("{p}%"), Color::Red),
+        },
+    }
+}
+
+/// Payment method, or `—` when absent/empty.
+fn method_display(order: Option<&SmallOrder>) -> String {
+    match order {
+        Some(order) if !order.payment_method.trim().is_empty() => {
+            order.payment_method.trim().to_string()
+        }
+        _ => "—".to_string(),
+    }
+}
+
+/// Group an integer string into thousands (e.g. `142857` → `142,857`).
+fn group_thousands(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let (sign, digits) = match trimmed.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", trimmed),
+    };
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return raw.to_string();
+    }
+    let mut out = String::new();
+    let n = digits.len();
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (n - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    format!("{sign}{out}")
 }
 
 fn render_trade_stepper(
@@ -383,5 +542,95 @@ mod sidebar_tests {
         assert_eq!(items[0].height(), 4);
         // Last row: no trailing separator = 3 lines.
         assert_eq!(items[1].height(), 3);
+    }
+}
+
+#[cfg(test)]
+mod trade_snapshot_tests {
+    use super::*;
+    use mostro_core::prelude::SmallOrder;
+
+    fn order(fiat_amount: i64, min: Option<i64>, max: Option<i64>) -> SmallOrder {
+        SmallOrder {
+            fiat_code: "USD".to_string(),
+            fiat_amount,
+            min_amount: min,
+            max_amount: max,
+            amount: 0,
+            premium: 0,
+            payment_method: String::new(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fiat_display_none_is_placeholder() {
+        assert_eq!(fiat_display(None), "—");
+    }
+
+    #[test]
+    fn fiat_display_single_amount_with_code() {
+        assert_eq!(fiat_display(Some(&order(100, None, None))), "100 USD");
+    }
+
+    #[test]
+    fn fiat_display_prefers_min_max_range() {
+        assert_eq!(
+            fiat_display(Some(&order(0, Some(50), Some(200)))),
+            "50–200 USD"
+        );
+    }
+
+    #[test]
+    fn sats_display_prefers_message_sat_amount_grouped() {
+        let mut o = order(100, None, None);
+        o.amount = 5;
+        assert_eq!(sats_display(Some(&o), Some(142_857)), "142,857");
+    }
+
+    #[test]
+    fn sats_display_falls_back_to_order_amount_then_market() {
+        let mut o = order(100, None, None);
+        o.amount = 1_000;
+        assert_eq!(sats_display(Some(&o), None), "1,000");
+        o.amount = 0;
+        assert_eq!(sats_display(Some(&o), None), "market");
+        assert_eq!(sats_display(None, None), "—");
+    }
+
+    #[test]
+    fn premium_display_signs_and_colors() {
+        let mut o = order(100, None, None);
+        o.premium = 2;
+        assert_eq!(premium_display(Some(&o)), ("+2%".to_string(), Color::Green));
+        o.premium = -3;
+        assert_eq!(premium_display(Some(&o)), ("-3%".to_string(), Color::Red));
+        o.premium = 0;
+        assert_eq!(premium_display(Some(&o)), ("0%".to_string(), Color::Gray));
+        assert_eq!(premium_display(None), ("—".to_string(), Color::DarkGray));
+    }
+
+    #[test]
+    fn method_display_trims_and_falls_back() {
+        let mut o = order(100, None, None);
+        o.payment_method = "  SEPA  ".to_string();
+        assert_eq!(method_display(Some(&o)), "SEPA");
+        o.payment_method = "   ".to_string();
+        assert_eq!(method_display(Some(&o)), "—");
+        assert_eq!(method_display(None), "—");
+    }
+
+    #[test]
+    fn role_chip_maps_maker_taker_unknown() {
+        assert_eq!(role_chip(Some(true)), ("👤", "Maker"));
+        assert_eq!(role_chip(Some(false)), ("🤝", "Taker"));
+        assert_eq!(role_chip(None), ("❔", "—"));
+    }
+
+    #[test]
+    fn group_thousands_formats_and_passes_through_non_digits() {
+        assert_eq!(group_thousands("142857"), "142,857");
+        assert_eq!(group_thousands("999"), "999");
+        assert_eq!(group_thousands("market"), "market");
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,11 +4,12 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 
+use crate::ui::helpers;
 use crate::ui::orders::{
-    listing_timeline_labels, message_action_compact_label_for_message, message_order_kind_label,
-    message_timeline_warning, message_timeline_warning_for_order_status,
+    listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
+    message_order_kind_label, message_timeline_warning, message_timeline_warning_for_order_status,
     message_trade_timeline_step, FlowStep, StepLabel,
 };
 use crate::ui::{OrderMessage, BACKGROUND_COLOR, PRIMARY_COLOR};
@@ -20,9 +21,10 @@ pub fn render_messages_tab(
     selected_idx: usize,
 ) {
     let block = Block::default()
-        .title("Messages")
+        .title(sidebar_title(messages))
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     f.render_widget(block.clone(), area);
     let inner = block.inner(area);
@@ -48,21 +50,79 @@ pub fn render_messages_tab(
 
     let left_chunks = Layout::new(
         Direction::Vertical,
-        [Constraint::Min(0), Constraint::Length(2)],
+        [Constraint::Min(0), Constraint::Length(1)],
     )
     .split(columns[0]);
 
-    let items: Vec<ListItem> = messages
+    let separator_width = left_chunks[0].width as usize;
+    let items = build_sidebar_items(messages, selected_idx, separator_width);
+
+    let list = List::new(items)
+        .highlight_style(Style::default().bg(PRIMARY_COLOR).fg(Color::Black))
+        .highlight_symbol("▶ ")
+        .highlight_spacing(ratatui::widgets::HighlightSpacing::Always);
+
+    f.render_stateful_widget(
+        list,
+        left_chunks[0],
+        &mut ratatui::widgets::ListState::default().with_selected(Some(selected_idx)),
+    );
+
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("↑↓", Style::default().fg(PRIMARY_COLOR)),
+        Span::styled(" move · ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(PRIMARY_COLOR)),
+        Span::styled(" open · ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Ctrl+H", Style::default().fg(PRIMARY_COLOR)),
+        Span::styled(" help", Style::default().fg(Color::DarkGray)),
+    ]))
+    .alignment(ratatui::layout::Alignment::Center);
+    f.render_widget(footer, left_chunks[1]);
+
+    render_message_timeline_panel(f, columns[1], selected_msg);
+}
+
+/// Sidebar title with total trade count and, when present, an unread badge.
+fn sidebar_title(messages: &[OrderMessage]) -> Line<'static> {
+    let unread = messages.iter().filter(|m| !m.read).count();
+    let mut spans = vec![Span::styled(
+        format!(" 📨 My Trades ({}) ", messages.len()),
+        Style::default()
+            .fg(PRIMARY_COLOR)
+            .add_modifier(Modifier::BOLD),
+    )];
+    if unread > 0 {
+        spans.push(Span::styled("· ", Style::default().fg(Color::DarkGray)));
+        spans.push(Span::styled(
+            format!("● {unread} new "),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    Line::from(spans)
+}
+
+/// Emoji + color for the order-kind dot shown on each sidebar row.
+fn kind_dot(kind_label: &str) -> (&'static str, Color) {
+    match kind_label {
+        "BUY" => ("🟢", Color::Green),
+        "SELL" => ("🔴", Color::Red),
+        _ => ("⚪", Color::DarkGray),
+    }
+}
+
+/// Builds the three-line-plus-separator sidebar rows: kind/id, action, relative time/unread.
+fn build_sidebar_items(
+    messages: &[OrderMessage],
+    selected_idx: usize,
+    separator_width: usize,
+) -> Vec<ListItem<'static>> {
+    let last_idx = messages.len().saturating_sub(1);
+    messages
         .iter()
         .enumerate()
         .map(|(idx, msg)| {
-            let kind = message_order_kind_label(msg);
-            let action_label = message_action_compact_label_for_message(msg);
-
-            let timestamp = DateTime::<Utc>::from_timestamp(msg.timestamp, 0)
-                .map(|dt| dt.format("%H:%M:%S").to_string())
-                .unwrap_or_else(|| "Unknown time".to_string());
-
             let is_selected = idx == selected_idx;
             let base_style = if is_selected {
                 Style::default()
@@ -74,58 +134,57 @@ pub fn render_messages_tab(
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(Color::Gray)
             };
 
+            let kind_label = message_order_kind_label(msg);
+            let (dot, kind_color) = kind_dot(kind_label);
             let kind_style = if is_selected {
                 base_style
-            } else if kind == "BUY" {
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD)
-            } else if kind == "SELL" {
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
             } else {
-                base_style
+                Style::default().fg(kind_color).add_modifier(Modifier::BOLD)
             };
 
+            let short_id = helpers::short_order_id(msg.order_id);
             let line1 = Line::from(vec![
-                Span::styled(format!("{kind:4} "), kind_style),
+                Span::styled(format!("{dot} "), kind_style),
+                Span::styled(format!("{kind_label:<4} "), kind_style),
+                Span::styled(short_id, base_style),
+            ]);
+
+            let action = msg.message.get_inner_message_kind().action.clone();
+            let emoji = message_action_emoji(&action);
+            let action_label = message_action_compact_label_for_message(msg);
+            let line2 = Line::from(vec![
+                Span::styled(format!("  {emoji} "), base_style),
                 Span::styled(action_label.to_string(), base_style),
             ]);
-            let line2 = Line::from(vec![Span::styled(format!("  {timestamp}"), base_style)]);
-            ListItem::new(vec![line1, line2])
+
+            let time = helpers::relative_time_compact(msg.timestamp);
+            let mut line3_spans = vec![
+                Span::styled("  🕐 ", base_style),
+                Span::styled(time, base_style),
+            ];
+            if !msg.read {
+                line3_spans.push(Span::styled(
+                    " · unread ",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                line3_spans.push(Span::styled("●", Style::default().fg(Color::Yellow)));
+            }
+            let line3 = Line::from(line3_spans);
+
+            let mut lines = vec![line1, line2, line3];
+            if idx != last_idx {
+                lines.push(Line::from(Span::styled(
+                    "─".repeat(separator_width.max(1)),
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+
+            ListItem::new(lines)
         })
-        .collect();
-
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .title("Orders")
-                .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
-        )
-        .highlight_style(Style::default().bg(PRIMARY_COLOR).fg(Color::Black))
-        .highlight_symbol(">>")
-        .highlight_spacing(ratatui::widgets::HighlightSpacing::Always);
-
-    f.render_stateful_widget(
-        list,
-        left_chunks[0],
-        &mut ratatui::widgets::ListState::default().with_selected(Some(selected_idx)),
-    );
-
-    let help = Paragraph::new(Line::from(vec![
-        Span::styled("Up/Down", Style::default().fg(PRIMARY_COLOR)),
-        Span::raw(" move   "),
-        Span::styled("Enter", Style::default().fg(PRIMARY_COLOR)),
-        Span::raw(" open action"),
-    ]))
-    .alignment(ratatui::layout::Alignment::Center)
-    .block(Block::default().borders(Borders::ALL).title("Controls"));
-    f.render_widget(help, left_chunks[1]);
-
-    render_message_timeline_panel(f, columns[1], selected_msg);
+        .collect()
 }
 
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
@@ -257,5 +316,72 @@ fn render_trade_stepper(
         .alignment(ratatui::layout::Alignment::Center)
         .block(Block::default().borders(Borders::ALL));
         f.render_widget(step, step_columns[idx]);
+    }
+}
+
+#[cfg(test)]
+mod sidebar_tests {
+    use super::*;
+    use mostro_core::prelude::{Action, Message};
+    use nostr_sdk::Keys;
+
+    fn sample_message(read: bool) -> OrderMessage {
+        let keys = Keys::generate();
+        OrderMessage {
+            message: Message::new_order(None, None, None, Action::PayInvoice, None),
+            timestamp: 0,
+            sender: keys.public_key(),
+            order_id: None,
+            trade_index: 0,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind: None,
+            is_mine: None,
+            order_status: None,
+            read,
+            auto_popup_shown: false,
+        }
+    }
+
+    fn spans_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn kind_dot_maps_buy_sell_and_unknown_to_distinct_glyphs() {
+        assert_eq!(kind_dot("BUY"), ("🟢", Color::Green));
+        assert_eq!(kind_dot("SELL"), ("🔴", Color::Red));
+        assert_eq!(kind_dot("N/A"), ("⚪", Color::DarkGray));
+    }
+
+    #[test]
+    fn sidebar_title_omits_unread_badge_when_all_read() {
+        let messages = vec![sample_message(true), sample_message(true)];
+        let text = spans_text(&sidebar_title(&messages));
+        assert!(text.contains("My Trades (2)"));
+        assert!(!text.contains("new"));
+    }
+
+    #[test]
+    fn sidebar_title_shows_unread_count_badge() {
+        let messages = vec![
+            sample_message(false),
+            sample_message(true),
+            sample_message(false),
+        ];
+        let text = spans_text(&sidebar_title(&messages));
+        assert!(text.contains("My Trades (3)"));
+        assert!(text.contains("● 2 new"));
+    }
+
+    #[test]
+    fn build_sidebar_items_adds_separator_between_rows_but_not_after_last() {
+        let messages = vec![sample_message(false), sample_message(true)];
+        let items = build_sidebar_items(&messages, 0, 20);
+        assert_eq!(items.len(), 2);
+        // Non-last row: kind/id + action + time + separator = 4 lines.
+        assert_eq!(items[0].height(), 4);
+        // Last row: no trailing separator = 3 lines.
+        assert_eq!(items[1].height(), 3);
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -285,8 +285,10 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     f.render_widget(Paragraph::new(vec![line1, line2]), inner);
 }
 
-/// TRADE snapshot card: two-column receipt of the order payload (fiat, sats,
-/// premium, method, trade index, role). Values gracefully fall back to `—`.
+/// TRADE snapshot card: a receipt of the order payload (fiat, sats, premium,
+/// method, trade index, role). Values gracefully fall back to `—`. Renders two
+/// columns when there is room, and stacks into a single column on narrow panels
+/// so nothing is squeezed off-screen.
 fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let block = Block::default()
         .title(Span::styled(
@@ -311,29 +313,33 @@ fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMes
     let (role_emoji, role_label) = role_chip(msg.is_mine);
     let white = Style::default().fg(Color::White);
 
-    let left = vec![
-        snapshot_field("💰", "Fiat", fiat_display(order), white),
-        snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white),
-        snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white),
-    ];
-    let right = vec![
-        snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color)),
-        snapshot_field("🧾", "Method", method_display(order), white),
-        snapshot_field(
-            role_emoji,
-            "Role",
-            role_label.to_string(),
-            Style::default().fg(Color::Cyan),
-        ),
-    ];
+    let fiat = snapshot_field("💰", "Fiat", fiat_display(order), white);
+    let sats = snapshot_field("⚡", "Sats", sats_display(order, msg.sat_amount), white);
+    let trade_idx = snapshot_field("🔑", "Trade idx", msg.trade_index.to_string(), white);
+    let premium = snapshot_field("📈", "Premium", premium, Style::default().fg(premium_color));
+    let method = snapshot_field("🧾", "Method", method_display(order), white);
+    let role = snapshot_field(
+        role_emoji,
+        "Role",
+        role_label.to_string(),
+        Style::default().fg(Color::Cyan),
+    );
 
-    let cols = Layout::new(
-        Direction::Horizontal,
-        [Constraint::Percentage(50), Constraint::Percentage(50)],
-    )
-    .split(inner);
-    f.render_widget(Paragraph::new(left), cols[0]);
-    f.render_widget(Paragraph::new(right), cols[1]);
+    if use_two_column_trade(inner.width) {
+        let cols = Layout::new(
+            Direction::Horizontal,
+            [Constraint::Percentage(50), Constraint::Percentage(50)],
+        )
+        .split(inner);
+        f.render_widget(Paragraph::new(vec![fiat, sats, trade_idx]), cols[0]);
+        f.render_widget(Paragraph::new(vec![premium, method, role]), cols[1]);
+    } else {
+        // Narrow panel: stack every field in one readable column.
+        f.render_widget(
+            Paragraph::new(vec![fiat, sats, premium, method, trade_idx, role]),
+            inner,
+        );
+    }
 }
 
 /// One `emoji label value` row inside the TRADE snapshot card. The leading emoji
@@ -457,47 +463,132 @@ fn render_trade_stepper(
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
-    // Glyph track + labels on the left; progress gauge on the right.
-    let halves = Layout::new(
-        Direction::Horizontal,
-        [Constraint::Min(0), Constraint::Length(20)],
-    )
-    .split(inner);
-
-    let step_columns =
-        Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(halves[0]);
-
-    for (idx, step_label) in steps.iter().enumerate() {
-        let step_number = idx + 1;
-        let (glyph, style) = step_glyph(step_number, current);
-        let width = step_columns[idx].width as usize;
-        let cell = Paragraph::new(vec![
-            glyph_cell_line(width, glyph, style, idx == 0, idx == steps.len() - 1),
-            Line::from(Span::styled(center_in(step_label.top, width), style)),
-            Line::from(Span::styled(center_in(step_label.bottom, width), style)),
-        ]);
-        f.render_widget(cell, step_columns[idx]);
+    if use_full_progress(inner.width) {
+        render_progress_full(f, inner, current, steps);
+    } else {
+        render_progress_compact(f, inner, current, steps);
     }
+}
 
-    let ratio = (current as f64 / steps.len() as f64).clamp(0.0, 1.0);
-    let gauge = LineGauge::default()
+/// Progress gauge widget (`Step N of 6` + `▰▱` bar) shared by both layouts.
+fn progress_gauge(current: usize, total: usize) -> LineGauge<'static> {
+    let ratio = (current as f64 / total as f64).clamp(0.0, 1.0);
+    LineGauge::default()
         .filled_symbol("▰")
         .unfilled_symbol("▱")
         .filled_style(Style::default().fg(PRIMARY_COLOR))
         .unfilled_style(Style::default().fg(Color::DarkGray))
         .ratio(ratio)
         .label(Span::styled(
-            format!("Step {current} of {} ", steps.len()),
+            format!("Step {current} of {total} "),
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
-        ));
-    // Render on the top row of the gauge column, aligned with the glyph track.
+        ))
+}
+
+/// Render the glyph track across `area` as six columns, optionally with the
+/// top/bottom `StepLabel` words centered beneath each glyph.
+fn render_glyph_columns(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+    with_labels: bool,
+) {
+    let step_columns = Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(area);
+    for (idx, step_label) in steps.iter().enumerate() {
+        let (glyph, style) = step_glyph(idx + 1, current);
+        let width = step_columns[idx].width as usize;
+        let mut lines = vec![glyph_cell_line(
+            width,
+            glyph,
+            style,
+            idx == 0,
+            idx == steps.len() - 1,
+        )];
+        if with_labels {
+            lines.push(Line::from(Span::styled(
+                center_in(step_label.top, width),
+                style,
+            )));
+            lines.push(Line::from(Span::styled(
+                center_in(step_label.bottom, width),
+                style,
+            )));
+        }
+        f.render_widget(Paragraph::new(lines), step_columns[idx]);
+    }
+}
+
+/// Wide layout: glyph track + per-step labels on the left, gauge on the right.
+fn render_progress_full(
+    f: &mut ratatui::Frame,
+    inner: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+) {
+    let halves = Layout::new(
+        Direction::Horizontal,
+        [Constraint::Min(0), Constraint::Length(20)],
+    )
+    .split(inner);
+    render_glyph_columns(f, halves[0], current, steps, true);
+    // Gauge on the top row of its column, aligned with the glyph track.
     let gauge_area = Rect {
         height: 1,
         ..halves[1]
     };
-    f.render_widget(gauge, gauge_area);
+    f.render_widget(progress_gauge(current, steps.len()), gauge_area);
+}
+
+/// Narrow layout: drop the six per-step labels (unreadable when cramped) in
+/// favor of a full-width glyph track, a full-width gauge, and a single clear
+/// "current step" line — readability over beauty on small screens.
+fn render_progress_compact(
+    f: &mut ratatui::Frame,
+    inner: Rect,
+    current: usize,
+    steps: &[StepLabel; 6],
+) {
+    let rows = Layout::new(
+        Direction::Vertical,
+        [
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ],
+    )
+    .split(inner);
+
+    render_glyph_columns(f, rows[0], current, steps, false);
+    f.render_widget(progress_gauge(current, steps.len()), rows[1]);
+
+    let current_label = steps
+        .get(current.saturating_sub(1))
+        .map(|s| s.as_single_line())
+        .unwrap_or_default();
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!("▸ {current_label}"),
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .alignment(ratatui::layout::Alignment::Center),
+        rows[2],
+    );
+}
+
+/// Whether the TRADE card has room for its two-column receipt layout.
+fn use_two_column_trade(inner_width: u16) -> bool {
+    inner_width >= 48
+}
+
+/// Whether the PROGRESS block has room for the full glyph-track + per-step
+/// labels + side gauge layout (else fall back to the compact stacked layout).
+fn use_full_progress(inner_width: u16) -> bool {
+    inner_width >= 68
 }
 
 /// Glyph + style for one step relative to the current step: done (`✔`, green),
@@ -745,6 +836,20 @@ mod stepper_tests {
         assert_eq!(center_in("odd", 6), " odd  ");
         // Longer than width: truncate by char, no panic.
         assert_eq!(center_in("Counterparty", 5), "Count");
+    }
+
+    #[test]
+    fn responsive_thresholds_switch_layouts_by_width() {
+        // TRADE: two columns only when wide enough, else single stacked column.
+        assert!(use_two_column_trade(60));
+        assert!(use_two_column_trade(48));
+        assert!(!use_two_column_trade(47));
+        assert!(!use_two_column_trade(20));
+        // PROGRESS: full labels+gauge only when wide, else compact stacked.
+        assert!(use_full_progress(80));
+        assert!(use_full_progress(68));
+        assert!(!use_full_progress(67));
+        assert!(!use_full_progress(30));
     }
 
     #[test]

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph, Wrap};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -12,7 +12,7 @@ use crate::ui::helpers;
 use crate::ui::orders::{
     listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
     message_order_kind_label, message_timeline_warning, message_timeline_warning_for_order_status,
-    message_trade_timeline_step, FlowStep, StepLabel,
+    message_trade_timeline_step, waiting_phase_description, FlowStep, StepLabel,
 };
 use crate::ui::{OrderMessage, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -191,14 +191,18 @@ fn build_sidebar_items(
 
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
     // Panel order mirrors the target mockup: header, progress stepper, TRADE
-    // snapshot (fills the space the old numbered timeline wasted), then STATUS.
+    // snapshot (fills the freed space), then the STATUS banner at the bottom.
+    // On narrow panels the STATUS text wraps onto more lines, so give it extra
+    // height there so the "what's next" copy stays fully readable.
+    let narrow = !use_two_column_trade(area.width.saturating_sub(2));
+    let status_height = if narrow { 7 } else { 4 };
     let right_chunks = Layout::new(
         Direction::Vertical,
         [
             Constraint::Length(4),
             Constraint::Length(5),
             Constraint::Min(0),
-            Constraint::Length(3),
+            Constraint::Length(status_height),
         ],
     )
     .split(area);
@@ -214,29 +218,69 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
     );
 
     render_trade_snapshot_card(f, right_chunks[2], selected_msg);
+    render_status_card(f, right_chunks[3], selected_msg);
+}
 
-    let warning_from_status = message_timeline_warning_for_order_status(selected_msg.order_status);
-    let warning_opt = warning_from_status.or_else(|| {
-        message_timeline_warning(&selected_msg.message.get_inner_message_kind().action)
-    });
-    let warning = warning_opt.unwrap_or("Trade is on normal path").to_string();
-    let warning_style = if warning_opt.is_some() {
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Green)
-    };
-    let state = Paragraph::new(Line::from(Span::styled(warning, warning_style)))
-        .alignment(ratatui::layout::Alignment::Center)
-        .block(
-            Block::default()
-                .title(" State ")
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
-        );
-    f.render_widget(state, right_chunks[3]);
+/// STATUS banner: a one-line status (normal path / canceled / dispute) and, on
+/// the happy path, a `👉 Next:` callout describing the pending action. Replaces
+/// the old "State" box and the redundant numbered timeline. Text wraps, so it
+/// stays readable on narrow panels (which also get extra height from the caller).
+fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
+    let block = Block::default()
+        .title(Span::styled(
+            " STATUS ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    let (emoji, text, color, is_normal) = status_banner(msg);
+    let mut lines = vec![Line::from(vec![
+        Span::styled(format!("{emoji} "), Style::default().fg(color)),
+        Span::styled(
+            text,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])];
+    if is_normal {
+        lines.push(Line::from(vec![
+            Span::styled(
+                "👉 Next: ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                waiting_phase_description(msg).to_string(),
+                Style::default().fg(Color::Gray),
+            ),
+        ]));
+    }
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+}
+
+/// Status banner content: `(emoji, text, color, is_normal)`. Prefers the
+/// persisted order status, then the last action, to classify canceled/dispute
+/// vs the happy path. `is_normal` gates the "what's next" callout.
+fn status_banner(msg: &OrderMessage) -> (&'static str, String, Color, bool) {
+    let action = msg.message.get_inner_message_kind().action.clone();
+    let warning = message_timeline_warning_for_order_status(msg.order_status)
+        .or_else(|| message_timeline_warning(&action));
+    match warning {
+        Some(text) if text.contains("dispute") => ("⚖️", text.to_string(), Color::Magenta, false),
+        Some(text) => ("❌", text.to_string(), Color::Red, false),
+        None => (
+            "✅",
+            "Trade is on the normal path".to_string(),
+            Color::Green,
+            true,
+        ),
+    }
 }
 
 /// Header card: order id + kind badge + maker/taker role chip, plus the absolute
@@ -730,7 +774,7 @@ mod sidebar_tests {
 #[cfg(test)]
 mod trade_snapshot_tests {
     use super::*;
-    use mostro_core::prelude::SmallOrder;
+    use mostro_core::prelude::{SmallOrder, Status};
 
     fn order(fiat_amount: i64, min: Option<i64>, max: Option<i64>) -> SmallOrder {
         SmallOrder {
@@ -807,6 +851,51 @@ mod trade_snapshot_tests {
         assert_eq!(role_chip(Some(true)), ("👤", "Maker"));
         assert_eq!(role_chip(Some(false)), ("🤝", "Taker"));
         assert_eq!(role_chip(None), ("❔", "—"));
+    }
+
+    fn message_with(action: mostro_core::prelude::Action, status: Option<Status>) -> OrderMessage {
+        use mostro_core::prelude::Message;
+        use nostr_sdk::Keys;
+        OrderMessage {
+            message: Message::new_order(None, None, None, action, None),
+            timestamp: 0,
+            sender: Keys::generate().public_key(),
+            order_id: None,
+            trade_index: 0,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind: None,
+            is_mine: None,
+            order_status: status,
+            read: true,
+            auto_popup_shown: true,
+        }
+    }
+
+    #[test]
+    fn status_banner_happy_path_is_normal_with_next_callout() {
+        use mostro_core::prelude::Action;
+        let (emoji, _text, color, is_normal) =
+            status_banner(&message_with(Action::PayInvoice, None));
+        assert_eq!(emoji, "✅");
+        assert_eq!(color, Color::Green);
+        assert!(is_normal);
+    }
+
+    #[test]
+    fn status_banner_flags_canceled_and_dispute() {
+        use mostro_core::prelude::Action;
+        let (emoji, _t, color, is_normal) =
+            status_banner(&message_with(Action::Canceled, Some(Status::Canceled)));
+        assert_eq!(emoji, "❌");
+        assert_eq!(color, Color::Red);
+        assert!(!is_normal);
+
+        let (emoji, _t, color, is_normal) =
+            status_banner(&message_with(Action::Dispute, Some(Status::Dispute)));
+        assert_eq!(emoji, "⚖️");
+        assert_eq!(color, Color::Magenta);
+        assert!(!is_normal);
     }
 
     #[test]

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -196,7 +196,7 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
         Direction::Vertical,
         [
             Constraint::Length(4),
-            Constraint::Length(7),
+            Constraint::Length(5),
             Constraint::Min(0),
             Constraint::Length(3),
         ],
@@ -433,49 +433,140 @@ fn group_thousands(raw: &str) -> String {
     format!("{sign}{out}")
 }
 
+/// Compact progress stepper: a single-line colored glyph track
+/// (`✔──✔──◉──○──○──○`) with the step labels underneath, plus a `LineGauge`
+/// showing `Step N of 6`. Render-only; `FlowStep`/label logic is unchanged.
 fn render_trade_stepper(
     f: &mut ratatui::Frame,
     area: Rect,
     current_step: FlowStep,
     steps: &[StepLabel; 6],
 ) {
-    let current_step = current_step.step_number();
-    let step_columns = Layout::new(
+    let current = current_step.step_number();
+
+    let block = Block::default()
+        .title(Span::styled(
+            " PROGRESS ",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let inner = block.inner(area);
+    f.render_widget(&block, area);
+
+    // Glyph track + labels on the left; progress gauge on the right.
+    let halves = Layout::new(
         Direction::Horizontal,
-        [
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(17),
-            Constraint::Percentage(16),
-            Constraint::Percentage(16),
-        ],
+        [Constraint::Min(0), Constraint::Length(20)],
     )
-    .split(area);
+    .split(inner);
+
+    let step_columns =
+        Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 6); 6]).split(halves[0]);
 
     for (idx, step_label) in steps.iter().enumerate() {
         let step_number = idx + 1;
-        let style = if step_number < current_step {
+        let (glyph, style) = step_glyph(step_number, current);
+        let width = step_columns[idx].width as usize;
+        let cell = Paragraph::new(vec![
+            glyph_cell_line(width, glyph, style, idx == 0, idx == steps.len() - 1),
+            Line::from(Span::styled(center_in(step_label.top, width), style)),
+            Line::from(Span::styled(center_in(step_label.bottom, width), style)),
+        ]);
+        f.render_widget(cell, step_columns[idx]);
+    }
+
+    let ratio = (current as f64 / steps.len() as f64).clamp(0.0, 1.0);
+    let gauge = LineGauge::default()
+        .filled_symbol("▰")
+        .unfilled_symbol("▱")
+        .filled_style(Style::default().fg(PRIMARY_COLOR))
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .ratio(ratio)
+        .label(Span::styled(
+            format!("Step {current} of {} ", steps.len()),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+    // Render on the top row of the gauge column, aligned with the glyph track.
+    let gauge_area = Rect {
+        height: 1,
+        ..halves[1]
+    };
+    f.render_widget(gauge, gauge_area);
+}
+
+/// Glyph + style for one step relative to the current step: done (`✔`, green),
+/// current (`◉`, primary), or upcoming (`○`, dim).
+fn step_glyph(step_number: usize, current: usize) -> (&'static str, Style) {
+    if step_number < current {
+        (
+            "✔",
             Style::default()
                 .fg(Color::Green)
-                .add_modifier(Modifier::BOLD)
-        } else if step_number == current_step {
+                .add_modifier(Modifier::BOLD),
+        )
+    } else if step_number == current {
+        (
+            "◉",
             Style::default()
                 .fg(PRIMARY_COLOR)
-                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-
-        let step = Paragraph::new(vec![
-            Line::from(Span::styled(format!("Step {step_number}"), style)),
-            Line::from(Span::styled(step_label.top.to_string(), style)),
-            Line::from(Span::styled(step_label.bottom.to_string(), style)),
-        ])
-        .alignment(ratatui::layout::Alignment::Center)
-        .block(Block::default().borders(Borders::ALL));
-        f.render_widget(step, step_columns[idx]);
+                .add_modifier(Modifier::BOLD),
+        )
+    } else {
+        ("○", Style::default().fg(Color::DarkGray))
     }
+}
+
+/// One cell of the glyph track: the step glyph centered in `width`, flanked by
+/// dim `─` connectors (blanked at the outer edges of the first/last steps) so
+/// adjacent cells join into a continuous line.
+fn glyph_cell_line(
+    width: usize,
+    glyph: &str,
+    glyph_style: Style,
+    is_first: bool,
+    is_last: bool,
+) -> Line<'static> {
+    if width == 0 {
+        return Line::default();
+    }
+    let mid = width / 2;
+    let left_n = mid;
+    let right_n = width - mid - 1;
+    let dash = Style::default().fg(Color::DarkGray);
+    let left = if is_first {
+        " ".repeat(left_n)
+    } else {
+        "─".repeat(left_n)
+    };
+    let right = if is_last {
+        " ".repeat(right_n)
+    } else {
+        "─".repeat(right_n)
+    };
+    Line::from(vec![
+        Span::styled(left, dash),
+        Span::styled(glyph.to_string(), glyph_style),
+        Span::styled(right, dash),
+    ])
+}
+
+/// Center `text` within `width`, truncating (by char) when it does not fit.
+fn center_in(text: &str, width: usize) -> String {
+    let truncated: String = text.chars().take(width).collect();
+    let len = truncated.chars().count();
+    if len >= width {
+        return truncated;
+    }
+    let total = width - len;
+    let left = total / 2;
+    let right = total - left;
+    format!("{}{}{}", " ".repeat(left), truncated, " ".repeat(right))
 }
 
 #[cfg(test)]
@@ -632,5 +723,41 @@ mod trade_snapshot_tests {
         assert_eq!(group_thousands("142857"), "142,857");
         assert_eq!(group_thousands("999"), "999");
         assert_eq!(group_thousands("market"), "market");
+    }
+}
+
+#[cfg(test)]
+mod stepper_tests {
+    use super::*;
+
+    #[test]
+    fn step_glyph_marks_done_current_and_upcoming() {
+        // current step = 3
+        assert_eq!(step_glyph(1, 3).0, "✔");
+        assert_eq!(step_glyph(2, 3).0, "✔");
+        assert_eq!(step_glyph(3, 3).0, "◉");
+        assert_eq!(step_glyph(4, 3).0, "○");
+    }
+
+    #[test]
+    fn center_in_centers_and_truncates() {
+        assert_eq!(center_in("Rate", 8), "  Rate  ");
+        assert_eq!(center_in("odd", 6), " odd  ");
+        // Longer than width: truncate by char, no panic.
+        assert_eq!(center_in("Counterparty", 5), "Count");
+    }
+
+    #[test]
+    fn glyph_cell_line_blanks_outer_edges_of_first_and_last() {
+        let (glyph, style) = step_glyph(1, 1);
+        let first = glyph_cell_line(5, glyph, style, true, false);
+        let first_text: String = first.spans.iter().map(|s| s.content.as_ref()).collect();
+        // First cell: no connector to the left of the glyph, dashes to the right.
+        assert_eq!(first_text, "  ◉──");
+
+        let last = glyph_cell_line(5, glyph, style, false, true);
+        let last_text: String = last.spans.iter().map(|s| s.content.as_ref()).collect();
+        // Last cell: dashes to the left, blank to the right.
+        assert_eq!(last_text, "──◉  ");
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -4,7 +4,9 @@ use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, LineGauge, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, BorderType, Borders, LineGauge, List, ListItem, Padding, Paragraph, Wrap,
+};
 
 use mostro_core::prelude::{Payload, SmallOrder};
 
@@ -32,12 +34,7 @@ pub fn render_messages_tab(
     let inner = block.inner(area);
 
     if messages.is_empty() {
-        let paragraph = Paragraph::new(Span::raw(
-            "No messages yet. Messages related to your orders will appear here.",
-        ))
-        .block(Block::default())
-        .alignment(ratatui::layout::Alignment::Center);
-        f.render_widget(paragraph, inner);
+        render_empty_state(f, inner);
         return;
     }
 
@@ -189,6 +186,75 @@ fn build_sidebar_items(
         .collect()
 }
 
+/// Empty state: a centered mailbox glyph over a short "no trades yet" message
+/// pointing at the Orders tab. On narrow/short panels the art is dropped so the
+/// text stays readable (readability over decoration).
+fn render_empty_state(f: &mut ratatui::Frame, area: Rect) {
+    let art = helpers::MAILBOX_EMPTY_ART;
+    let art_w = art.iter().map(|l| l.chars().count()).max().unwrap_or(0) as u16;
+
+    // Text lines wrap (unlike the art), so the message stays readable when narrow.
+    let text_lines = vec![
+        Line::from(Span::styled(
+            "Your mailbox is empty",
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "No trades yet — messages from your orders will appear here.",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            "Go to the Orders tab to create or take an order",
+            Style::default()
+                .fg(PRIMARY_COLOR)
+                .add_modifier(Modifier::BOLD),
+        )),
+    ];
+
+    let show_art = area.width >= art_w && area.height >= art.len() as u16 + 4;
+    // Reserve a few rows for text (it may wrap to 2 lines on narrow panels).
+    let text_h = 4u16;
+    let block_h = if show_art {
+        art.len() as u16 + 1 + text_h
+    } else {
+        text_h
+    };
+    let mut y = area.y + area.height.saturating_sub(block_h) / 2;
+
+    if show_art {
+        let art_area = Rect {
+            x: area.x,
+            y,
+            width: area.width,
+            height: art.len() as u16,
+        };
+        helpers::render_centered_lines(f, art_area, art, style_mailbox_art);
+        y = y.saturating_add(art.len() as u16 + 1);
+    }
+
+    let text_area = Rect {
+        x: area.x,
+        y,
+        width: area.width,
+        height: area.height.saturating_sub(y.saturating_sub(area.y)),
+    };
+    f.render_widget(
+        Paragraph::new(text_lines)
+            .alignment(ratatui::layout::Alignment::Center)
+            .wrap(Wrap { trim: true }),
+        text_area,
+    );
+}
+
+fn style_mailbox_art(line: &str) -> Vec<Span<'static>> {
+    vec![Span::styled(
+        line.to_string(),
+        Style::default().fg(Color::DarkGray),
+    )]
+}
+
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
     // Panel order mirrors the target mockup: header, progress stepper, TRADE
     // snapshot (fills the freed space), then the STATUS banner at the bottom.
@@ -235,6 +301,7 @@ fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -289,6 +356,7 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -12,9 +12,9 @@ use mostro_core::prelude::{Payload, SmallOrder};
 
 use crate::ui::helpers;
 use crate::ui::orders::{
-    listing_timeline_labels, message_action_compact_label_for_message, message_action_emoji,
-    message_order_kind_label, message_timeline_warning, message_timeline_warning_for_order_status,
-    message_trade_timeline_step, waiting_phase_description, FlowStep, StepLabel,
+    listing_timeline_labels, message_action_compact_label_for_message,
+    message_action_emoji_for_message, message_order_kind_label, message_status_presentation,
+    message_trade_timeline_step, order_status_badge, FlowStep, StepLabel,
 };
 use crate::ui::{OrderMessage, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -151,8 +151,7 @@ fn build_sidebar_items(
                 Span::styled(short_id, base_style),
             ]);
 
-            let action = msg.message.get_inner_message_kind().action.clone();
-            let emoji = message_action_emoji(&action);
+            let emoji = message_action_emoji_for_message(msg);
             let action_label = message_action_compact_label_for_message(msg);
             let line2 = Line::from(vec![
                 Span::styled(format!("  {emoji} "), base_style),
@@ -258,17 +257,17 @@ fn style_mailbox_art(line: &str) -> Vec<Span<'static>> {
 fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_msg: &OrderMessage) {
     // Panel order mirrors the target mockup: header, progress stepper, TRADE
     // snapshot (fills the freed space), then the STATUS banner at the bottom.
-    // On narrow panels the STATUS text wraps onto more lines, so give it extra
-    // height there so the "what's next" copy stays fully readable.
+    // Heights shrink on short terminals so TRADE keeps a usable receipt (Hermeme:
+    // at 80x24 the old fixed Length(4/5/4) left TRADE with one content row).
     let narrow = !use_two_column_trade(area.width.saturating_sub(2));
-    let status_height = if narrow { 7 } else { 4 };
+    let (header_h, progress_h, status_h) = right_panel_heights(area.height, narrow);
     let right_chunks = Layout::new(
         Direction::Vertical,
         [
-            Constraint::Length(4),
-            Constraint::Length(5),
+            Constraint::Length(header_h),
+            Constraint::Length(progress_h),
             Constraint::Min(0),
-            Constraint::Length(status_height),
+            Constraint::Length(status_h),
         ],
     )
     .split(area);
@@ -287,10 +286,40 @@ fn render_message_timeline_panel(f: &mut ratatui::Frame, area: Rect, selected_ms
     render_status_card(f, right_chunks[3], selected_msg);
 }
 
-/// STATUS banner: a one-line status (normal path / canceled / dispute) and, on
-/// the happy path, a `👉 Next:` callout describing the pending action. Replaces
-/// the old "State" box and the redundant numbered timeline. Text wraps, so it
-/// stays readable on narrow panels (which also get extra height from the caller).
+/// Allocate header / progress / status heights so TRADE retains a usable minimum
+/// on short panels. `area_height` is the right-column height (inside the outer
+/// Messages border). TRADE wants ≥5 rows (2 borders + 3 content) when wide, ≥8
+/// when stacked.
+fn right_panel_heights(area_height: u16, narrow: bool) -> (u16, u16, u16) {
+    let trade_min = if narrow { 8 } else { 5 };
+    let mut header = 4u16;
+    let mut progress = 5u16;
+    let mut status = if narrow { 7 } else { 4 };
+
+    let shrink_to_fit = |header: &mut u16, progress: &mut u16, status: &mut u16| {
+        while *header + *progress + *status + trade_min > area_height {
+            if *status > 3 {
+                *status -= 1;
+                continue;
+            }
+            if *progress > 3 {
+                *progress -= 1;
+                continue;
+            }
+            if *header > 3 {
+                *header -= 1;
+                continue;
+            }
+            break;
+        }
+    };
+    shrink_to_fit(&mut header, &mut progress, &mut status);
+    (header, progress, status)
+}
+
+/// STATUS banner: a one-line status (normal path / canceled / dispute) and, when
+/// appropriate, a `👉 Next:` callout. Replaces the old "State" box and the
+/// redundant numbered timeline. Text wraps, so it stays readable on narrow panels.
 fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let block = Block::default()
         .title(Span::styled(
@@ -306,15 +335,20 @@ fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
-    let (emoji, text, color, is_normal) = status_banner(msg);
+    let presentation = message_status_presentation(msg);
     let mut lines = vec![Line::from(vec![
-        Span::styled(format!("{emoji} "), Style::default().fg(color)),
         Span::styled(
-            text,
-            Style::default().fg(color).add_modifier(Modifier::BOLD),
+            format!("{} ", presentation.emoji),
+            Style::default().fg(presentation.color),
+        ),
+        Span::styled(
+            presentation.title.to_string(),
+            Style::default()
+                .fg(presentation.color)
+                .add_modifier(Modifier::BOLD),
         ),
     ])];
-    if is_normal {
+    if let Some(next) = presentation.next {
         lines.push(Line::from(vec![
             Span::styled(
                 "👉 Next: ",
@@ -322,32 +356,10 @@ fn render_status_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                waiting_phase_description(msg).to_string(),
-                Style::default().fg(Color::Gray),
-            ),
+            Span::styled(next.to_string(), Style::default().fg(Color::Gray)),
         ]));
     }
     f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
-}
-
-/// Status banner content: `(emoji, text, color, is_normal)`. Prefers the
-/// persisted order status, then the last action, to classify canceled/dispute
-/// vs the happy path. `is_normal` gates the "what's next" callout.
-fn status_banner(msg: &OrderMessage) -> (&'static str, String, Color, bool) {
-    let action = msg.message.get_inner_message_kind().action.clone();
-    let warning = message_timeline_warning_for_order_status(msg.order_status)
-        .or_else(|| message_timeline_warning(&action));
-    match warning {
-        Some(text) if text.contains("dispute") => ("⚖️", text.to_string(), Color::Magenta, false),
-        Some(text) => ("❌", text.to_string(), Color::Red, false),
-        None => (
-            "✅",
-            "Trade is on the normal path".to_string(),
-            Color::Green,
-            true,
-        ),
-    }
 }
 
 /// Header card: order id + kind badge + maker/taker role chip, plus the absolute
@@ -364,6 +376,7 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
     let kind_label = message_order_kind_label(msg);
     let (dot, kind_color) = kind_dot(kind_label);
     let (role_emoji, role_label) = role_chip(msg.is_mine);
+    let (status_emoji, status_color) = order_status_badge(msg.order_status);
 
     let line1 = Line::from(vec![
         Span::styled("🧾 Order ", Style::default().fg(Color::Gray)),
@@ -383,6 +396,8 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
             format!("{role_emoji} {role_label}"),
             Style::default().fg(Color::Cyan),
         ),
+        Span::raw("   "),
+        Span::styled(status_emoji.to_string(), Style::default().fg(status_color)),
     ]);
 
     let absolute = DateTime::<Utc>::from_timestamp(msg.timestamp, 0)
@@ -415,11 +430,7 @@ fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMes
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
-    let inner_kind = msg.message.get_inner_message_kind();
-    let order = match &inner_kind.payload {
-        Some(Payload::Order(order)) => Some(order),
-        _ => None,
-    };
+    let order = trade_order_snapshot(msg);
 
     let (premium, premium_color) = premium_display(order);
     let (role_emoji, role_label) = role_chip(msg.is_mine);
@@ -451,6 +462,20 @@ fn render_trade_snapshot_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMes
             Paragraph::new(vec![fiat, sats, premium, method, trade_idx, role]),
             inner,
         );
+    }
+}
+
+/// Prefer the stable [`OrderMessage::order_snapshot`], then any order embedded in
+/// the current DM payload (including `PaymentRequest`).
+fn trade_order_snapshot(msg: &OrderMessage) -> Option<&SmallOrder> {
+    if let Some(snap) = msg.order_snapshot.as_ref() {
+        return Some(snap);
+    }
+    match &msg.message.get_inner_message_kind().payload {
+        Some(Payload::Order(order)) => Some(order),
+        Some(Payload::PaymentRequest(Some(order), _, _)) => Some(order),
+        Some(Payload::BondPayoutRequest(req)) => Some(&req.order),
+        _ => None,
     }
 }
 
@@ -575,7 +600,7 @@ fn render_trade_stepper(
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
-    if use_full_progress(inner.width) {
+    if use_full_progress(inner.width) && inner.height >= 3 {
         render_progress_full(f, inner, current, steps);
     } else {
         render_progress_compact(f, inner, current, steps);
@@ -791,6 +816,7 @@ mod sidebar_tests {
             order_kind: None,
             is_mine: None,
             order_status: None,
+            order_snapshot: None,
             read,
             auto_popup_shown: false,
         }
@@ -935,35 +961,78 @@ mod trade_snapshot_tests {
             order_kind: None,
             is_mine: None,
             order_status: status,
+            order_snapshot: None,
             read: true,
             auto_popup_shown: true,
         }
     }
 
     #[test]
-    fn status_banner_happy_path_is_normal_with_next_callout() {
-        use mostro_core::prelude::Action;
-        let (emoji, _text, color, is_normal) =
-            status_banner(&message_with(Action::PayInvoice, None));
-        assert_eq!(emoji, "✅");
-        assert_eq!(color, Color::Green);
-        assert!(is_normal);
+    fn trade_order_snapshot_prefers_stable_field_over_empty_payload() {
+        use mostro_core::prelude::{Action, Message, Payload};
+        use nostr_sdk::Keys;
+        let snap = order(100, None, None);
+        let msg = OrderMessage {
+            message: Message::new_order(None, None, None, Action::FiatSent, None),
+            timestamp: 0,
+            sender: Keys::generate().public_key(),
+            order_id: None,
+            trade_index: 4,
+            sat_amount: None,
+            buyer_invoice: None,
+            order_kind: Some(mostro_core::order::Kind::Buy),
+            is_mine: Some(true),
+            order_status: Some(Status::FiatSent),
+            order_snapshot: Some(snap.clone()),
+            read: true,
+            auto_popup_shown: true,
+        };
+        assert_eq!(trade_order_snapshot(&msg).map(|o| o.fiat_amount), Some(100));
+
+        let with_payment = OrderMessage {
+            message: Message::new_order(
+                None,
+                None,
+                None,
+                Action::PayInvoice,
+                Some(Payload::PaymentRequest(
+                    Some(order(250, None, None)),
+                    "lnbc1".into(),
+                    None,
+                )),
+            ),
+            order_snapshot: None,
+            ..msg
+        };
+        assert_eq!(
+            trade_order_snapshot(&with_payment).map(|o| o.fiat_amount),
+            Some(250)
+        );
     }
 
     #[test]
-    fn status_banner_flags_canceled_and_dispute() {
+    fn status_presentation_waiting_pay_invoice_unknown_role_still_has_next() {
         use mostro_core::prelude::Action;
-        let (emoji, _t, color, is_normal) =
-            status_banner(&message_with(Action::Canceled, Some(Status::Canceled)));
-        assert_eq!(emoji, "❌");
-        assert_eq!(color, Color::Red);
-        assert!(!is_normal);
+        // Unknown role defaults to taker for buy PayInvoice → actionable.
+        let mut m = message_with(Action::PayInvoice, Some(Status::WaitingPayment));
+        m.order_kind = Some(mostro_core::order::Kind::Buy);
+        let p = message_status_presentation(&m);
+        assert_eq!(p.next, Some("Pay the hold invoice to continue."));
+    }
 
-        let (emoji, _t, color, is_normal) =
-            status_banner(&message_with(Action::Dispute, Some(Status::Dispute)));
-        assert_eq!(emoji, "⚖️");
-        assert_eq!(color, Color::Magenta);
-        assert!(!is_normal);
+    #[test]
+    fn status_presentation_flags_canceled_and_dispute_without_next() {
+        use mostro_core::prelude::Action;
+        let p =
+            message_status_presentation(&message_with(Action::Canceled, Some(Status::Canceled)));
+        assert_eq!(p.emoji, "❌");
+        assert_eq!(p.color, Color::Red);
+        assert!(p.next.is_none());
+
+        let p = message_status_presentation(&message_with(Action::Dispute, Some(Status::Dispute)));
+        assert_eq!(p.emoji, "⚖️");
+        assert_eq!(p.color, Color::Magenta);
+        assert!(p.next.is_none());
     }
 
     #[test]
@@ -971,6 +1040,97 @@ mod trade_snapshot_tests {
         assert_eq!(group_thousands("142857"), "142,857");
         assert_eq!(group_thousands("999"), "999");
         assert_eq!(group_thousands("market"), "market");
+    }
+}
+
+#[cfg(test)]
+mod layout_and_render_tests {
+    use super::*;
+    use mostro_core::prelude::{Action, Message, SmallOrder, Status};
+    use nostr_sdk::Keys;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn rich_message() -> OrderMessage {
+        let snap = SmallOrder {
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            amount: 142_857,
+            premium: 2,
+            payment_method: "SEPA".to_string(),
+            ..Default::default()
+        };
+        OrderMessage {
+            message: Message::new_order(None, None, None, Action::PayInvoice, None),
+            timestamp: 1_720_000_000,
+            sender: Keys::generate().public_key(),
+            order_id: Some(uuid::Uuid::parse_str("6c162b3f-0000-0000-0000-000000000000").unwrap()),
+            trade_index: 4,
+            sat_amount: Some(142_857),
+            buyer_invoice: None,
+            order_kind: Some(mostro_core::order::Kind::Buy),
+            is_mine: Some(true),
+            order_status: Some(Status::WaitingPayment),
+            order_snapshot: Some(snap),
+            read: false,
+            auto_popup_shown: true,
+        }
+    }
+
+    #[test]
+    fn right_panel_heights_preserve_trade_on_80x24_content() {
+        // App: 24 rows − tabs(3) − status(3) = 18 content; outer Messages borders → 16.
+        let (h, p, s) = right_panel_heights(16, false);
+        assert!(h + p + s + 5 <= 16, "header={h} progress={p} status={s}");
+        let trade = 16u16.saturating_sub(h + p + s);
+        assert!(trade >= 5, "TRADE height {trade} too small");
+    }
+
+    #[test]
+    fn right_panel_heights_preserve_trade_on_short_narrow() {
+        let (h, p, s) = right_panel_heights(16, true);
+        let trade = 16u16.saturating_sub(h + p + s);
+        assert!(trade >= 5, "TRADE height {trade} on narrow short panel");
+    }
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        let mut flat = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                flat.push_str(buf[(x, y)].symbol());
+            }
+            flat.push('\n');
+        }
+        flat.contains(needle)
+    }
+
+    #[test]
+    fn render_messages_tab_shows_trade_fields_on_80x18() {
+        // 80x18 ≈ Messages content area on an 80x24 terminal (tabs+status reserved).
+        let backend = TestBackend::new(80, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec![rich_message()];
+        terminal
+            .draw(|f| render_messages_tab(f, f.area(), &messages, 0))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        assert!(buffer_contains(buf, "TRADE"), "missing TRADE title");
+        assert!(buffer_contains(buf, "Fiat"), "missing Fiat label");
+        assert!(buffer_contains(buf, "SEPA"), "missing payment method");
+        assert!(buffer_contains(buf, "STATUS"), "missing STATUS title");
+    }
+
+    #[test]
+    fn render_messages_tab_shows_trade_on_60x18_narrow() {
+        let backend = TestBackend::new(60, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let messages = vec![rich_message()];
+        terminal
+            .draw(|f| render_messages_tab(f, f.area(), &messages, 0))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        assert!(buffer_contains(buf, "TRADE"));
+        assert!(buffer_contains(buf, "100 USD") || buffer_contains(buf, "Fiat"));
     }
 }
 

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 
 use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 use crate::util::{
@@ -12,7 +12,8 @@ pub fn render_mostro_info_tab(f: &mut ratatui::Frame, area: Rect, app: &AppState
     let block = Block::default()
         .title("🧌 Mostro Instance Info")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -13,7 +13,8 @@ pub fn render_mostro_info_tab(f: &mut ratatui::Frame, area: Rect, app: &AppState
         .title("🧌 Mostro Instance Info")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::helpers::build_observer_scrollview_content;
@@ -77,14 +77,17 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
                     .add_modifier(Modifier::BOLD),
             ))
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
     );
     f.render_widget(header, chunks[0]);
 
     // Chat view (reuses the same formatting as dispute chat) with scrollview.
     let chat_block = Block::default()
         .title("Chat messages")
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let chat_area = chunks[1];
     let inner_area = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
@@ -160,6 +163,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         Block::default()
             .title(key_title)
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(key_border),
     );
     f.render_widget(key_input, input_chunks[0]);

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -78,7 +78,8 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
             ))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
     );
     f.render_widget(header, chunks[0]);
 
@@ -87,7 +88,8 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         .title("Chat messages")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let chat_area = chunks[1];
     let inner_area = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -170,7 +170,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .title("Orders In Progress")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     if active_orders.is_empty() {
         f.render_widget(
             Paragraph::new("No active orders yet")
@@ -189,7 +190,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     .title("Order Chat")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             ),
             empty_main_chunks[0],
         );
@@ -410,7 +412,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                 ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         ),
         main_chunks[0],
     );
@@ -438,7 +441,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .title(chat_title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let chat_inner = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
 
@@ -497,7 +501,7 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     })
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR)),
             ),
         main_chunks[2],
     );

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -4,7 +4,7 @@ use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 use uuid::Uuid;
 
@@ -169,7 +169,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     let sidebar_block = Block::default()
         .title("Orders In Progress")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     if active_orders.is_empty() {
         f.render_widget(
             Paragraph::new("No active orders yet")
@@ -187,7 +188,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                 Block::default()
                     .title("Order Chat")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             ),
             empty_main_chunks[0],
         );
@@ -407,7 +409,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                         .add_modifier(Modifier::BOLD),
                 ))
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         ),
         main_chunks[0],
     );
@@ -434,7 +437,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     let chat_block = Block::default()
         .title(chat_title)
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let chat_inner = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
 
@@ -491,7 +495,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     } else {
                         "Message (disabled: Shift+I)"
                     })
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().fg(PRIMARY_COLOR)),
             ),
         main_chunks[2],
     );

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -31,7 +31,8 @@ pub fn render_orders_tab(
                     .title("Orders")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -48,7 +49,8 @@ pub fn render_orders_tab(
                 .title("Orders")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -186,7 +188,8 @@ pub fn render_orders_tab(
                 .title("Orders")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(table, area);
     }

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -5,7 +5,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
 use crate::ui::{apply_kind_color, AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -30,7 +30,8 @@ pub fn render_orders_tab(
                 Block::default()
                     .title("Orders")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -46,7 +47,8 @@ pub fn render_orders_tab(
             Block::default()
                 .title("Orders")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -183,7 +185,8 @@ pub fn render_orders_tab(
             Block::default()
                 .title("Orders")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(table, area);
     }

--- a/src/ui/tabs/settings_tab.rs
+++ b/src/ui/tabs/settings_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 
 use crate::ui::{UserRole, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -97,7 +97,8 @@ pub fn render_settings_tab(
     let block = Block::default()
         .title("⚙️  Settings")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     let inner_area = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/settings_tab.rs
+++ b/src/ui/tabs/settings_tab.rs
@@ -98,7 +98,8 @@ pub fn render_settings_tab(
         .title("⚙️  Settings")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     let inner_area = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/tab_bar.rs
+++ b/src/ui/tabs/tab_bar.rs
@@ -1,5 +1,5 @@
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Tabs};
 
@@ -12,9 +12,11 @@ pub fn render_tabs(f: &mut ratatui::Frame, area: Rect, active_tab: Tab, role: Us
     let tabs = Tabs::new(tab_titles)
         .select(active_tab.as_index())
         .block(
+            // Keep the top tab selector a plain white, square frame so it stays
+            // visually distinct from the green rounded content frames below.
             Block::default()
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(Color::White)),
         )
         .highlight_style(
             Style::default()

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -16,7 +16,8 @@ pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
             .title(title)
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
     );
     f.render_widget(paragraph, area);
 }
@@ -83,7 +84,8 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
             .title("Exit")
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
         area,
     );
 
@@ -91,7 +93,8 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
         .title("Exit")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR))
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR))
         .inner(area);
 
     let line_refs: Vec<&str> = logo_lines.to_vec();
@@ -200,7 +203,8 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     let block = Block::default()
         .title("📨 Message")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block, popup);
 
     // Order ID
@@ -363,7 +367,8 @@ pub fn render_rating_order(f: &mut ratatui::Frame, state: &RatingOrderState) {
     let block = Block::default()
         .title("Rate counterparty")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block.clone(), popup);
     let inner = block.inner(popup);
     let chunks = Layout::new(

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -2,7 +2,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 
 use crate::ui::{
     helpers::{self, render_centered_lines},
@@ -15,7 +15,8 @@ pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
         Block::default()
             .title(title)
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
     );
     f.render_widget(paragraph, area);
 }
@@ -81,14 +82,16 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
         Block::default()
             .title("Exit")
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         area,
     );
 
     let inner_area = Block::default()
         .title("Exit")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR))
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR))
         .inner(area);
 
     let line_refs: Vec<&str> = logo_lines.to_vec();

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use crate::models::{Order, User};
 use crate::ui::order_message_to_notification;
+use crate::ui::orders::{merge_order_snapshots, small_order_from_payload};
 use crate::ui::{MessageNotification, OrderMessage};
 use crate::util::chat_listener::{maybe_track_order_chat, untrack_order_chat};
 use crate::util::db_utils::{delete_order_by_id, save_order, update_order_status};
@@ -489,6 +490,29 @@ fn small_order_ref_from_payload(payload: &Option<Payload>) -> Option<&SmallOrder
     }
 }
 
+/// Build a TRADE-card snapshot from a persisted SQLite order row.
+fn small_order_from_db_order(row: &Order) -> SmallOrder {
+    SmallOrder {
+        id: row.id.as_ref().and_then(|s| uuid::Uuid::parse_str(s).ok()),
+        kind: row
+            .kind
+            .as_ref()
+            .and_then(|s| mostro_core::order::Kind::from_str(s).ok()),
+        status: row.status.as_ref().and_then(|s| Status::from_str(s).ok()),
+        amount: row.amount,
+        fiat_code: row.fiat_code.clone(),
+        min_amount: row.min_amount,
+        max_amount: row.max_amount,
+        fiat_amount: row.fiat_amount,
+        payment_method: row.payment_method.clone(),
+        premium: row.premium,
+        buyer_invoice: row.buyer_invoice.clone(),
+        created_at: row.created_at,
+        expires_at: row.expires_at,
+        ..Default::default()
+    }
+}
+
 fn resolved_status_candidate(action: &Action, payload: &Option<Payload>) -> Option<Status> {
     if let Some(order_payload) = small_order_ref_from_payload(payload) {
         return map_action_to_status(action, order_payload);
@@ -914,6 +938,7 @@ async fn handle_trade_dm_for_order(
                     m.order_kind,
                     m.is_mine,
                     m.order_status,
+                    m.order_snapshot.clone(),
                 )
             })
     };
@@ -926,7 +951,7 @@ async fn handle_trade_dm_for_order(
     // strictly newer timestamp (dedup stale/duplicate events).
     let is_new_message = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, _)) => {
+        Some((existing_timestamp, existing_action, _, _, _, _, _, _, _)) => {
             if action != *existing_action {
                 true
             } else {
@@ -937,23 +962,26 @@ async fn handle_trade_dm_for_order(
 
     let prior_sat_amount = existing_message_data
         .as_ref()
-        .and_then(|(_, _, amt, _, _, _, _, _)| *amt);
+        .and_then(|(_, _, amt, _, _, _, _, _, _)| *amt);
     let prior_invoice = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, inv, _, _, _, _)| inv.clone());
+        .and_then(|(_, _, _, inv, _, _, _, _, _)| inv.clone());
     let prior_auto_popup_shown = existing_message_data
         .as_ref()
-        .map(|(_, existing_action, _, _, shown, _, _, _)| *shown && *existing_action == action)
+        .map(|(_, existing_action, _, _, shown, _, _, _, _)| *shown && *existing_action == action)
         .unwrap_or(false);
     let prior_order_kind = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, _, _, k, _, _)| *k);
+        .and_then(|(_, _, _, _, _, k, _, _, _)| *k);
     let prior_is_mine = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, _, _, _, im, _)| *im);
+        .and_then(|(_, _, _, _, _, _, im, _, _)| *im);
     let prior_order_status = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, _, _, _, _, st)| *st);
+        .and_then(|(_, _, _, _, _, _, _, st, _)| *st);
+    let prior_order_snapshot = existing_message_data
+        .as_ref()
+        .and_then(|(_, _, _, _, _, _, _, _, snap)| snap.clone());
 
     let kind_from_payload = small_order_ref_from_payload(&inner_kind.payload).and_then(|o| o.kind);
     let kind_from_take_action = match &action {
@@ -1032,6 +1060,13 @@ async fn handle_trade_dm_for_order(
     let effective_sat_amount = sat_amount.or(prior_sat_amount);
     let effective_invoice = invoice.clone().or(prior_invoice);
 
+    let snapshot_from_db = db_order.as_ref().map(small_order_from_db_order);
+    let effective_order_snapshot = merge_order_snapshots(
+        small_order_from_payload(&inner_kind.payload),
+        prior_order_snapshot,
+        snapshot_from_db,
+    );
+
     if notify && is_new_message && is_actionable_notification {
         match pending_notifications.lock() {
             Ok(mut pending_notifications) => {
@@ -1058,6 +1093,7 @@ async fn handle_trade_dm_for_order(
         order_kind: effective_order_kind,
         is_mine: effective_is_mine,
         order_status: effective_order_status,
+        order_snapshot: effective_order_snapshot,
         // Preserve popup-shown state for same-action updates (e.g. duplicate AddInvoice
         // carrying peer reputation payload but no amount), preventing noisy re-popups.
         auto_popup_shown: prior_auto_popup_shown,
@@ -1076,7 +1112,7 @@ async fn handle_trade_dm_for_order(
     // currently selected action row after startup/reconnect hydration.
     let should_replace_row = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status)) => {
+        Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status, _)) => {
             if new_order_would_regress_messages_row(&action, existing_action) {
                 false
             } else if timestamp > *existing_timestamp {

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -801,6 +801,20 @@ fn effective_is_mine_for_trade_dm_message(
     prior_message_is_mine
 }
 
+/// Snapshot of the newest existing Messages row for an order, captured under a
+/// short `messages` lock so later dedup/merge logic can compare without holding it.
+struct PriorMessageSnapshot {
+    timestamp: i64,
+    action: Action,
+    sat_amount: Option<i64>,
+    buyer_invoice: Option<String>,
+    auto_popup_shown: bool,
+    order_kind: Option<mostro_core::order::Kind>,
+    is_mine: Option<bool>,
+    order_status: Option<Status>,
+    order_snapshot: Option<SmallOrder>,
+}
+
 /// Handle a single decoded trade DM for a given order/trade index.
 #[allow(clippy::too_many_arguments)]
 async fn handle_trade_dm_for_order(
@@ -928,18 +942,16 @@ async fn handle_trade_dm_for_order(
             .iter()
             .filter(|m| m.order_id == Some(order_id))
             .max_by_key(|m| m.timestamp)
-            .map(|m| {
-                (
-                    m.timestamp,
-                    m.message.get_inner_message_kind().action.clone(),
-                    m.sat_amount,
-                    m.buyer_invoice.clone(),
-                    m.auto_popup_shown,
-                    m.order_kind,
-                    m.is_mine,
-                    m.order_status,
-                    m.order_snapshot.clone(),
-                )
+            .map(|m| PriorMessageSnapshot {
+                timestamp: m.timestamp,
+                action: m.message.get_inner_message_kind().action.clone(),
+                sat_amount: m.sat_amount,
+                buyer_invoice: m.buyer_invoice.clone(),
+                auto_popup_shown: m.auto_popup_shown,
+                order_kind: m.order_kind,
+                is_mine: m.is_mine,
+                order_status: m.order_status,
+                order_snapshot: m.order_snapshot.clone(),
             })
     };
 
@@ -951,37 +963,29 @@ async fn handle_trade_dm_for_order(
     // strictly newer timestamp (dedup stale/duplicate events).
     let is_new_message = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, _, _)) => {
-            if action != *existing_action {
+        Some(prior) => {
+            if action != prior.action {
                 true
             } else {
-                timestamp > *existing_timestamp
+                timestamp > prior.timestamp
             }
         }
     };
 
-    let prior_sat_amount = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, amt, _, _, _, _, _, _)| *amt);
+    let prior_sat_amount = existing_message_data.as_ref().and_then(|p| p.sat_amount);
     let prior_invoice = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, inv, _, _, _, _, _)| inv.clone());
+        .and_then(|p| p.buyer_invoice.clone());
     let prior_auto_popup_shown = existing_message_data
         .as_ref()
-        .map(|(_, existing_action, _, _, shown, _, _, _, _)| *shown && *existing_action == action)
+        .map(|p| p.auto_popup_shown && p.action == action)
         .unwrap_or(false);
-    let prior_order_kind = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, k, _, _, _)| *k);
-    let prior_is_mine = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, _, im, _, _)| *im);
-    let prior_order_status = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, _, _, st, _)| *st);
+    let prior_order_kind = existing_message_data.as_ref().and_then(|p| p.order_kind);
+    let prior_is_mine = existing_message_data.as_ref().and_then(|p| p.is_mine);
+    let prior_order_status = existing_message_data.as_ref().and_then(|p| p.order_status);
     let prior_order_snapshot = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, _, _, _, _, _, snap)| snap.clone());
+        .and_then(|p| p.order_snapshot.clone());
 
     let kind_from_payload = small_order_ref_from_payload(&inner_kind.payload).and_then(|o| o.kind);
     let kind_from_take_action = match &action {
@@ -1112,19 +1116,22 @@ async fn handle_trade_dm_for_order(
     // currently selected action row after startup/reconnect hydration.
     let should_replace_row = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status, _)) => {
+        Some(prior) => {
+            let existing_timestamp = prior.timestamp;
+            let existing_action = &prior.action;
+            let existing_order_status = prior.order_status;
             if new_order_would_regress_messages_row(&action, existing_action) {
                 false
-            } else if timestamp > *existing_timestamp {
+            } else if timestamp > existing_timestamp {
                 true
-            } else if timestamp == *existing_timestamp {
+            } else if timestamp == existing_timestamp {
                 action != *existing_action
             } else {
                 // Older-than-current replay: only replace if the payload status **strictly** advances
                 // the status already shown on the row (not merely equal; `should_accept_candidate`
                 // allows equality vs baseline for DB updates).
                 status_candidate.is_some_and(|c| {
-                    should_strictly_advance_status(*existing_order_status, c, effective_order_kind)
+                    should_strictly_advance_status(existing_order_status, c, effective_order_kind)
                 })
             }
         }

--- a/src/util/order_utils/execute_add_invoice.rs
+++ b/src/util/order_utils/execute_add_invoice.rs
@@ -127,6 +127,26 @@ fn build_order_message_from_reply(
         order_kind: order_kind_from_db(db_order),
         is_mine: Some(db_order.is_mine),
         order_status: status,
+        order_snapshot: crate::ui::orders::merge_order_snapshots(
+            crate::ui::orders::small_order_from_payload(&inner.payload),
+            None,
+            Some(SmallOrder {
+                id: Some(order_id),
+                kind: order_kind_from_db(db_order),
+                status: status_from_db(db_order),
+                amount: db_order.amount,
+                fiat_code: db_order.fiat_code.clone(),
+                min_amount: db_order.min_amount,
+                max_amount: db_order.max_amount,
+                fiat_amount: db_order.fiat_amount,
+                payment_method: db_order.payment_method.clone(),
+                premium: db_order.premium,
+                buyer_invoice: db_order.buyer_invoice.clone(),
+                created_at: db_order.created_at,
+                expires_at: db_order.expires_at,
+                ..Default::default()
+            }),
+        ),
         read: false,
         auto_popup_shown: false,
     }


### PR DESCRIPTION
# Messages tab UX restyle

Restyles the **Messages tab** in the visual language of the Create New Order form: denser information, emoji status vocabulary, a compact glyph stepper with a progress gauge, a trade snapshot card that fills the previously empty space, a clear "what's next" status banner, and a friendly empty state — all with responsive fallbacks so the tab stays readable on narrow terminals.

## Motivation

The old Messages tab wasted space and hid data:

- Left list rows were two thin lines in a plain block, with a bulky bordered "Controls" box eating vertical space.
- The right panel's "Timeline Details" box just repeated the six stepper labels as numbered text, leaving large blank areas below.
- Rich data already present on each message (fiat amount, sats, premium, payment method, maker/taker role, order status, trade index) was never shown.
- Flat styling that didn't match the restyled order form.

## What's changed

**Sidebar (My Trades list)**
- Title shows the trade count and an unread badge: `📨 My Trades (N) · ● K new`.
- Three-line rows: kind dot + KIND + short order id; action emoji + label; relative time + unread marker, with slim separators.
- The bordered "Controls" box is replaced by a single dim footer line; rounded borders throughout.

**Right panel**
- **Header card** — order id, kind badge (`🟢 BUY` / `🔴 SELL`), maker/taker role chip (`👤` / `🤝`), and absolute + relative last-update time.
- **PROGRESS** — a compact glyph stepper (`✔` done / `◉` current / `○` upcoming) with the step labels beneath, plus a `LineGauge` showing `Step N of 6`. Replaces six bordered boxes; render-only (step logic unchanged).
- **TRADE** — a two-column receipt built from the order payload (`SmallOrder`) plus the message sat amount: fiat amount or min–max range, sats, premium, payment method, trade index, role. Missing fields fall back to `—`.
- **STATUS** — merges the old "State" box and redundant timeline into one banner: `✅` normal / `❌` canceled / `⚖️` dispute, plus a `👉 Next: …` callout describing the pending action (maker/taker aware).

**Empty state**
- A centered mailbox glyph over "Your mailbox is empty", a short explainer, and a lime hint pointing at the Orders tab.

## Responsive design

Every part degrades gracefully when horizontal space is limited (readability over decoration):

- **PROGRESS** drops the six cramped labels for a full-width glyph track + full-width gauge + a single `▸ <current step>` line.
- **TRADE** collapses from two columns to a single stacked column.
- **STATUS** text wraps and the panel reserves extra height so the "what's next" copy stays visible.
- **Empty state** text wraps and stays centered; the art is dropped on panels too narrow/short to fit it.

Layout selection is driven by pure width helpers (`use_full_progress`, `use_two_column_trade`) with unit tests.

## Implementation notes

- New helpers: `message_action_emoji`, `order_status_badge`, `relative_time_compact`, `MAILBOX_EMPTY_ART`.
- The progress gauge uses ratatui's built-in `LineGauge` — **no new dependencies**.
- All flow/step/label logic (`FlowStep`, `listing_timeline_labels`, `waiting_phase_description`, `message_timeline_warning*`) is reused unchanged; the changes are render-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesign of the Messages tab: clearer, color-coded sidebar with unread badges, action icons, relative timestamps, status badges, and mailbox-style empty state.
  * Trade detail cards (status/banner, header, snapshot) with a responsive progress stepper.
* **Improvements**
  * More consistent trade/message receipt display via persisted order snapshots, including stable DM replay/upserts.
  * Compact formatting enhancements (short order IDs, short relative times) and improved narrow/short terminal layout behavior.
  * Consistent rounded/primary-colored UI styling across tabs.
* **Documentation**
  * Added contributor guidance (UI/TUI layout and build/test workflow).
* **Tests**
  * Expanded unit tests for formatting, badges/status presentation, layout sizing, and snapshot selection/merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->