### PR TITLE
Feat/messages tab ux restyle

### DIFF
--- a/src/ui/order_form.rs
+++ b/src/ui/order_form.rs
@@ -60,6 +60,7 @@ pub fn render_order_form(
         )))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -114,6 +115,7 @@ fn render_details(
     let block = Block::default()
         .title(" Order details ")
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -468,6 +470,7 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
     let block = Block::default()
         .title(" Live preview ")
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
@@ -600,6 +603,7 @@ fn render_help(f: &mut ratatui::Frame, area: Rect, form: &FormState) {
             Block::default()
                 .title(" Field help ")
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         )
         .style(Style::default().fg(Color::Gray))
@@ -1052,6 +1056,7 @@ pub fn render_form_initializing(f: &mut ratatui::Frame, area: Rect) {
         )))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     f.render_widget(block, area);
 }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -922,7 +922,7 @@ pub fn message_status_presentation(msg: &OrderMessage) -> MessageStatusPresentat
             Action::PayBondInvoice => ("🔒", "Bond payment required"),
             Action::AddBondInvoice => ("🔒", "Bond payout invoice required"),
             Action::Release | Action::FiatSentOk => ("🔓", "Release required"),
-            Action::FiatSent => ("💸", "Confirm fiat sent"),
+            Action::FiatSent | Action::HoldInvoicePaymentAccepted => ("💸", "Confirm fiat sent"),
             Action::Rate => ("⭐", "Rating required"),
             _ => ("👉", "Action required"),
         };
@@ -982,6 +982,13 @@ fn actionable_next_step(msg: &OrderMessage, action: &Action) -> Option<&'static 
             ) =>
         {
             Some("Confirm that you sent the fiat payment.")
+        }
+        // Mostro reports the seller's hold invoice is paid: the Enter router
+        // (`enter_handlers.rs`) opens the fiat-confirmation popup that sends
+        // `FiatSent`, so this is actionable for the buyer — not a waiting phase.
+        // Kept unconditional to match that router's actionability classification.
+        Action::HoldInvoicePaymentAccepted => {
+            Some("Confirm you sent the fiat payment to continue.")
         }
         Action::Rate => Some("Rate your counterparty."),
         _ => None,
@@ -1463,6 +1470,26 @@ mod message_emoji_and_badge_tests {
         let p = message_status_presentation(&m);
         assert_eq!(p.title, "Invoice required");
         assert_eq!(p.next, Some("Add your Lightning invoice to continue."));
+    }
+
+    #[test]
+    fn status_presentation_hold_invoice_accepted_is_actionable() {
+        // Mostro reports the hold invoice paid; the Enter router opens the
+        // fiat-confirmation popup, so STATUS must prompt the buyer to act rather
+        // than fall through to the "no action required" waiting default.
+        let m = sample_msg(
+            Action::HoldInvoicePaymentAccepted,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::SettledHoldInvoice),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.emoji, "💸");
+        assert_eq!(p.title, "Confirm fiat sent");
+        assert_eq!(
+            p.next,
+            Some("Confirm you sent the fiat payment to continue.")
+        );
     }
 
     #[test]

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -477,6 +477,11 @@ pub fn waiting_phase_description(msg: &OrderMessage) -> &'static str {
         (_, true, Action::PayBondInvoice) => {
             "Pay the anti-abuse bond to publish your order to the book."
         }
+        // Your order was taken: the next actionable prompt (invoice/payment) arrives
+        // as a follow-up DM, so this phase is informational, not something to act on.
+        (_, _, Action::BuyerTookOrder) => {
+            "Your order was taken. Waiting for the trade to proceed."
+        }
         _ => "Waiting for the counterparty. No action is required from you right now.",
     }
 }
@@ -923,6 +928,7 @@ pub fn message_status_presentation(msg: &OrderMessage) -> MessageStatusPresentat
             Action::AddBondInvoice => ("🔒", "Bond payout invoice required"),
             Action::Release | Action::FiatSentOk => ("🔓", "Release required"),
             Action::FiatSent | Action::HoldInvoicePaymentAccepted => ("💸", "Confirm fiat sent"),
+            Action::CooperativeCancelInitiatedByPeer => ("⚠️", "Cancel requested"),
             Action::Rate => ("⭐", "Rating required"),
             _ => ("👉", "Action required"),
         };
@@ -989,6 +995,11 @@ fn actionable_next_step(msg: &OrderMessage, action: &Action) -> Option<&'static 
         // Kept unconditional to match that router's actionability classification.
         Action::HoldInvoicePaymentAccepted => {
             Some("Confirm you sent the fiat payment to continue.")
+        }
+        // Peer asked to cooperatively cancel: the Enter router opens a decision
+        // popup, so surface it as a decision rather than a silent waiting state.
+        Action::CooperativeCancelInitiatedByPeer => {
+            Some("Your counterparty asked to cooperatively cancel — press Enter to review.")
         }
         Action::Rate => Some("Rate your counterparty."),
         _ => None,
@@ -1489,6 +1500,43 @@ mod message_emoji_and_badge_tests {
         assert_eq!(
             p.next,
             Some("Confirm you sent the fiat payment to continue.")
+        );
+    }
+
+    #[test]
+    fn status_presentation_cooperative_cancel_peer_is_actionable() {
+        // Peer-initiated cooperative cancel: Enter opens a decision popup, so STATUS
+        // must surface it rather than showing the generic waiting default.
+        let m = sample_msg(
+            Action::CooperativeCancelInitiatedByPeer,
+            Some(mostro_core::order::Kind::Buy),
+            Some(true),
+            Some(Status::Active),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.emoji, "⚠️");
+        assert_eq!(p.title, "Cancel requested");
+        assert_eq!(
+            p.next,
+            Some("Your counterparty asked to cooperatively cancel — press Enter to review.")
+        );
+    }
+
+    #[test]
+    fn status_presentation_buyer_took_order_is_informational_waiting() {
+        // "Order taken" is a waiting phase (the actionable prompt arrives later), so
+        // it should read as normal-path waiting with specific copy, not "must act".
+        let m = sample_msg(
+            Action::BuyerTookOrder,
+            Some(mostro_core::order::Kind::Sell),
+            Some(true),
+            Some(Status::Active),
+        );
+        let p = message_status_presentation(&m);
+        assert_eq!(p.title, "Trade is on the normal path");
+        assert_eq!(
+            p.next,
+            Some("Your order was taken. Waiting for the trade to proceed.")
         );
     }
 

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -6,7 +6,7 @@ use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::constants::*;
@@ -90,7 +90,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
     let disputes_block = Block::default()
         .title(sidebar_title)
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     if filtered_disputes.is_empty() {
         let empty_msg = match app.dispute_filter {
@@ -475,7 +476,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                             .add_modifier(Modifier::BOLD),
                     ))
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             )
             .alignment(ratatui::layout::Alignment::Left);
         f.render_widget(header, main_chunks[0]);
@@ -526,13 +528,23 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
 
             f.render_widget(
                 Paragraph::new(buyer_text)
-                    .block(Block::default().borders(Borders::ALL).style(buyer_style))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_type(BorderType::Rounded)
+                            .style(buyer_style),
+                    )
                     .alignment(ratatui::layout::Alignment::Center),
                 party_chunks[0],
             );
             f.render_widget(
                 Paragraph::new(seller_text)
-                    .block(Block::default().borders(Borders::ALL).style(seller_style))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_type(BorderType::Rounded)
+                            .style(seller_style),
+                    )
                     .alignment(ratatui::layout::Alignment::Center),
                 party_chunks[1],
             );
@@ -609,7 +621,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
             let chat_block = Block::default()
                 .title(chat_title)
                 .borders(Borders::ALL)
-                .style(Style::default());
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
             let inner_area = chat_block.inner(chat_area);
             f.render_widget(chat_block, chat_area);
 
@@ -662,6 +675,7 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                     Block::default()
                         .title(input_title)
                         .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
                         .border_style(input_border_style)
                         .style(input_style),
                 )
@@ -821,7 +835,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         // Render the outer block first, then content inside it
         let outer_block = Block::default()
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR));
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
         let inner_area = outer_block.inner(main_area);
         f.render_widget(outer_block, main_area);
 

--- a/src/ui/tabs/disputes_tab.rs
+++ b/src/ui/tabs/disputes_tab.rs
@@ -6,7 +6,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::Constraint;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
 use crate::ui::{BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -32,7 +32,8 @@ pub fn render_disputes_tab(
                 Block::default()
                     .title("Disputes Pending")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -65,7 +66,8 @@ pub fn render_disputes_tab(
             Block::default()
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -115,7 +117,8 @@ pub fn render_disputes_tab(
             Block::default()
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         )
         .row_highlight_style(
             Style::default()

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 
 use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 use crate::util::{
@@ -12,7 +12,8 @@ pub fn render_mostro_info_tab(f: &mut ratatui::Frame, area: Rect, app: &AppState
     let block = Block::default()
         .title("🧌 Mostro Instance Info")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::helpers::build_observer_scrollview_content;
@@ -77,14 +77,17 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
                     .add_modifier(Modifier::BOLD),
             ))
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
     );
     f.render_widget(header, chunks[0]);
 
     // Chat view (reuses the same formatting as dispute chat) with scrollview.
     let chat_block = Block::default()
         .title("Chat messages")
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let chat_area = chunks[1];
     let inner_area = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
@@ -160,6 +163,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         Block::default()
             .title(key_title)
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(key_border),
     );
     f.render_widget(key_input, input_chunks[0]);

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -4,7 +4,7 @@ use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 use uuid::Uuid;
 
@@ -169,7 +169,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     let sidebar_block = Block::default()
         .title("Orders In Progress")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     if active_orders.is_empty() {
         f.render_widget(
             Paragraph::new("No active orders yet")
@@ -187,7 +188,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                 Block::default()
                     .title("Order Chat")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             ),
             empty_main_chunks[0],
         );
@@ -407,7 +409,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                         .add_modifier(Modifier::BOLD),
                 ))
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         ),
         main_chunks[0],
     );
@@ -434,7 +437,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     let chat_block = Block::default()
         .title(chat_title)
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
     let chat_inner = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
 
@@ -491,7 +495,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     } else {
                         "Message (disabled: Shift+I)"
                     })
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().fg(PRIMARY_COLOR)),
             ),
         main_chunks[2],
     );

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -5,7 +5,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
 use crate::ui::{apply_kind_color, AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -30,7 +30,8 @@ pub fn render_orders_tab(
                 Block::default()
                     .title("Orders")
                     .borders(Borders::ALL)
-                    .style(Style::default().bg(BACKGROUND_COLOR)),
+                    .border_type(BorderType::Rounded)
+                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -46,7 +47,8 @@ pub fn render_orders_tab(
             Block::default()
                 .title("Orders")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -183,7 +185,8 @@ pub fn render_orders_tab(
             Block::default()
                 .title("Orders")
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .border_type(BorderType::Rounded)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         );
         f.render_widget(table, area);
     }

--- a/src/ui/tabs/settings_tab.rs
+++ b/src/ui/tabs/settings_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 
 use crate::ui::{UserRole, BACKGROUND_COLOR, PRIMARY_COLOR};
 
@@ -97,7 +97,8 @@ pub fn render_settings_tab(
     let block = Block::default()
         .title("⚙️  Settings")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR));
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
 
     let inner_area = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/tab_bar.rs
+++ b/src/ui/tabs/tab_bar.rs
@@ -1,5 +1,5 @@
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Tabs};
 
@@ -12,9 +12,11 @@ pub fn render_tabs(f: &mut ratatui::Frame, area: Rect, active_tab: Tab, role: Us
     let tabs = Tabs::new(tab_titles)
         .select(active_tab.as_index())
         .block(
+            // Keep the top tab selector a plain white, square frame so it stays
+            // visually distinct from the green rounded content frames below.
             Block::default()
                 .borders(Borders::ALL)
-                .style(Style::default().bg(BACKGROUND_COLOR)),
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(Color::White)),
         )
         .highlight_style(
             Style::default()

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -2,7 +2,7 @@ use mostro_core::prelude::*;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 
 use crate::ui::{
     helpers::{self, render_centered_lines},
@@ -15,7 +15,8 @@ pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
         Block::default()
             .title(title)
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
     );
     f.render_widget(paragraph, area);
 }
@@ -81,14 +82,16 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
         Block::default()
             .title("Exit")
             .borders(Borders::ALL)
-            .style(Style::default().bg(BACKGROUND_COLOR)),
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
         area,
     );
 
     let inner_area = Block::default()
         .title("Exit")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR))
+        .border_type(BorderType::Rounded)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR))
         .inner(area);
 
     let line_refs: Vec<&str> = logo_lines.to_vec();

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -801,6 +801,20 @@ fn effective_is_mine_for_trade_dm_message(
     prior_message_is_mine
 }
 
+/// Snapshot of the newest existing Messages row for an order, captured under a
+/// short `messages` lock so later dedup/merge logic can compare without holding it.
+struct PriorMessageSnapshot {
+    timestamp: i64,
+    action: Action,
+    sat_amount: Option<i64>,
+    buyer_invoice: Option<String>,
+    auto_popup_shown: bool,
+    order_kind: Option<mostro_core::order::Kind>,
+    is_mine: Option<bool>,
+    order_status: Option<Status>,
+    order_snapshot: Option<SmallOrder>,
+}
+
 /// Handle a single decoded trade DM for a given order/trade index.
 #[allow(clippy::too_many_arguments)]
 async fn handle_trade_dm_for_order(
@@ -928,18 +942,16 @@ async fn handle_trade_dm_for_order(
             .iter()
             .filter(|m| m.order_id == Some(order_id))
             .max_by_key(|m| m.timestamp)
-            .map(|m| {
-                (
-                    m.timestamp,
-                    m.message.get_inner_message_kind().action.clone(),
-                    m.sat_amount,
-                    m.buyer_invoice.clone(),
-                    m.auto_popup_shown,
-                    m.order_kind,
-                    m.is_mine,
-                    m.order_status,
-                    m.order_snapshot.clone(),
-                )
+            .map(|m| PriorMessageSnapshot {
+                timestamp: m.timestamp,
+                action: m.message.get_inner_message_kind().action.clone(),
+                sat_amount: m.sat_amount,
+                buyer_invoice: m.buyer_invoice.clone(),
+                auto_popup_shown: m.auto_popup_shown,
+                order_kind: m.order_kind,
+                is_mine: m.is_mine,
+                order_status: m.order_status,
+                order_snapshot: m.order_snapshot.clone(),
             })
     };
 
@@ -951,37 +963,29 @@ async fn handle_trade_dm_for_order(
     // strictly newer timestamp (dedup stale/duplicate events).
     let is_new_message = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, _, _)) => {
-            if action != *existing_action {
+        Some(prior) => {
+            if action != prior.action {
                 true
             } else {
-                timestamp > *existing_timestamp
+                timestamp > prior.timestamp
             }
         }
     };
 
-    let prior_sat_amount = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, amt, _, _, _, _, _, _)| *amt);
+    let prior_sat_amount = existing_message_data.as_ref().and_then(|p| p.sat_amount);
     let prior_invoice = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, inv, _, _, _, _, _)| inv.clone());
+        .and_then(|p| p.buyer_invoice.clone());
     let prior_auto_popup_shown = existing_message_data
         .as_ref()
-        .map(|(_, existing_action, _, _, shown, _, _, _, _)| *shown && *existing_action == action)
+        .map(|p| p.auto_popup_shown && p.action == action)
         .unwrap_or(false);
-    let prior_order_kind = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, k, _, _, _)| *k);
-    let prior_is_mine = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, _, im, _, _)| *im);
-    let prior_order_status = existing_message_data
-        .as_ref()
-        .and_then(|(_, _, _, _, _, _, _, st, _)| *st);
+    let prior_order_kind = existing_message_data.as_ref().and_then(|p| p.order_kind);
+    let prior_is_mine = existing_message_data.as_ref().and_then(|p| p.is_mine);
+    let prior_order_status = existing_message_data.as_ref().and_then(|p| p.order_status);
     let prior_order_snapshot = existing_message_data
         .as_ref()
-        .and_then(|(_, _, _, _, _, _, _, _, snap)| snap.clone());
+        .and_then(|p| p.order_snapshot.clone());
 
     let kind_from_payload = small_order_ref_from_payload(&inner_kind.payload).and_then(|o| o.kind);
     let kind_from_take_action = match &action {
@@ -1112,19 +1116,22 @@ async fn handle_trade_dm_for_order(
     // currently selected action row after startup/reconnect hydration.
     let should_replace_row = match &existing_message_data {
         None => true,
-        Some((existing_timestamp, existing_action, _, _, _, _, _, existing_order_status, _)) => {
+        Some(prior) => {
+            let existing_timestamp = prior.timestamp;
+            let existing_action = &prior.action;
+            let existing_order_status = prior.order_status;
             if new_order_would_regress_messages_row(&action, existing_action) {
                 false
-            } else if timestamp > *existing_timestamp {
+            } else if timestamp > existing_timestamp {
                 true
-            } else if timestamp == *existing_timestamp {
+            } else if timestamp == existing_timestamp {
                 action != *existing_action
             } else {
                 // Older-than-current replay: only replace if the payload status **strictly** advances
                 // the status already shown on the row (not merely equal; `should_accept_candidate`
                 // allows equality vs baseline for DB updates).
                 status_candidate.is_some_and(|c| {
-                    should_strictly_advance_status(*existing_order_status, c, effective_order_kind)
+                    should_strictly_advance_status(existing_order_status, c, effective_order_kind)
                 })
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to the merged blocker fix (PR #3), addressing the two optional items from review of the Messages tab restyle. Targets `feat/messages-tab-ux-restyle`.

### 1. STATUS/Next parity with the Enter router
Bring the remaining Enter-actionable actions into the STATUS banner:
- **`CooperativeCancelInitiatedByPeer`** — the Enter router opens a decision popup, so it's now surfaced as actionable: `⚠️ "Cancel requested"` → "Your counterparty asked to cooperatively cancel — press Enter to review." (previously fell through to the generic waiting default).
- **`BuyerTookOrder`** — deliberately kept as a *waiting* phase (the actionable prompt arrives in a later DM; labeling it "must act" would be a false instruction), but given specific copy via `waiting_phase_description`: "Your order was taken. Waiting for the trade to proceed."
- Regression tests for both.

### 2. Refactor: named struct instead of a 9-field tuple
`handle_trade_dm_for_order` captured the newest existing Messages row as a 9-element tuple accessed positionally (`|(_, _, _, _, _, _, _, _, snap)|`), which is error-prone as fields are added. Introduced `PriorMessageSnapshot` with named fields so the dedup/merge logic reads by name. No behavior change.


