### PR TITLE
fix(ui): keep tab text white, color only the frame border green

### DIFF
--- a/src/ui/order_form.rs
+++ b/src/ui/order_form.rs
@@ -61,7 +61,8 @@ pub fn render_order_form(
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -116,7 +117,8 @@ fn render_details(
         .title(" Order details ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -471,7 +473,8 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
         .title(" Live preview ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(area);
     f.render_widget(&block, area);
 
@@ -494,7 +497,8 @@ fn render_preview(f: &mut ratatui::Frame, area: Rect, form: &FormState, accepted
         .title(" Order ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let card_inner = card.inner(split[0]);
     f.render_widget(card, split[0]);
     f.render_widget(
@@ -604,7 +608,8 @@ fn render_help(f: &mut ratatui::Frame, area: Rect, form: &FormState) {
                 .title(" Field help ")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         )
         .style(Style::default().fg(Color::Gray))
         .wrap(Wrap { trim: true });
@@ -686,7 +691,8 @@ fn render_currency_dropdown(
         .title(title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let inner = block.inner(popup);
     f.render_widget(block, popup);
 
@@ -1057,7 +1063,8 @@ pub fn render_form_initializing(f: &mut ratatui::Frame, area: Rect) {
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block, area);
 }
 

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -91,7 +91,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         .title(sidebar_title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     if filtered_disputes.is_empty() {
         let empty_msg = match app.dispute_filter {
@@ -477,7 +478,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                     ))
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             )
             .alignment(ratatui::layout::Alignment::Left);
         f.render_widget(header, main_chunks[0]);
@@ -622,7 +624,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                 .title(chat_title)
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR));
             let inner_area = chat_block.inner(chat_area);
             f.render_widget(chat_block, chat_area);
 
@@ -836,7 +839,8 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         let outer_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR));
         let inner_area = outer_block.inner(main_area);
         f.render_widget(outer_block, main_area);
 

--- a/src/ui/tabs/disputes_tab.rs
+++ b/src/ui/tabs/disputes_tab.rs
@@ -33,7 +33,8 @@ pub fn render_disputes_tab(
                     .title("Disputes Pending")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -67,7 +68,8 @@ pub fn render_disputes_tab(
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -118,7 +120,8 @@ pub fn render_disputes_tab(
                 .title("Disputes Pending")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         )
         .row_highlight_style(
             Style::default()

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -13,7 +13,8 @@ pub fn render_mostro_info_tab(f: &mut ratatui::Frame, area: Rect, app: &AppState
         .title("🧌 Mostro Instance Info")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -78,7 +78,8 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
             ))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
     );
     f.render_widget(header, chunks[0]);
 
@@ -87,7 +88,8 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         .title("Chat messages")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let chat_area = chunks[1];
     let inner_area = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -170,7 +170,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .title("Orders In Progress")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     if active_orders.is_empty() {
         f.render_widget(
             Paragraph::new("No active orders yet")
@@ -189,7 +190,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     .title("Order Chat")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             ),
             empty_main_chunks[0],
         );
@@ -410,7 +412,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                 ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         ),
         main_chunks[0],
     );
@@ -438,7 +441,8 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .title(chat_title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     let chat_inner = chat_block.inner(chat_area);
     f.render_widget(chat_block, chat_area);
 
@@ -497,7 +501,7 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     })
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR)),
             ),
         main_chunks[2],
     );

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -31,7 +31,8 @@ pub fn render_orders_tab(
                     .title("Orders")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                    .border_style(Style::default().fg(PRIMARY_COLOR))
+                    .style(Style::default().bg(BACKGROUND_COLOR)),
             );
             f.render_widget(paragraph, area);
             return;
@@ -48,7 +49,8 @@ pub fn render_orders_tab(
                 .title("Orders")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(paragraph, area);
     } else {
@@ -186,7 +188,8 @@ pub fn render_orders_tab(
                 .title("Orders")
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+                .border_style(Style::default().fg(PRIMARY_COLOR))
+                .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(table, area);
     }

--- a/src/ui/tabs/settings_tab.rs
+++ b/src/ui/tabs/settings_tab.rs
@@ -98,7 +98,8 @@ pub fn render_settings_tab(
         .title("⚙️  Settings")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
 
     let inner_area = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -16,7 +16,8 @@ pub fn render_coming_soon(f: &mut ratatui::Frame, area: Rect, title: &str) {
             .title(title)
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
     );
     f.render_widget(paragraph, area);
 }
@@ -83,7 +84,8 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
             .title("Exit")
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR)),
+            .border_style(Style::default().fg(PRIMARY_COLOR))
+            .style(Style::default().bg(BACKGROUND_COLOR)),
         area,
     );
 
@@ -91,7 +93,8 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
         .title("Exit")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR))
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR))
         .inner(area);
 
     let line_refs: Vec<&str> = logo_lines.to_vec();
@@ -200,7 +203,8 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
     let block = Block::default()
         .title("📨 Message")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block, popup);
 
     // Order ID
@@ -363,7 +367,8 @@ pub fn render_rating_order(f: &mut ratatui::Frame, state: &RatingOrderState) {
     let block = Block::default()
         .title("Rate counterparty")
         .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+        .border_style(Style::default().fg(PRIMARY_COLOR))
+        .style(Style::default().bg(BACKGROUND_COLOR));
     f.render_widget(block.clone(), popup);
     let inner = block.inner(popup);
     let chunks = Layout::new(


### PR DESCRIPTION
Using a block's base .style().fg(PRIMARY_COLOR) colored the border but also bled into any inner text without an explicit color (settings options, order detail labels, etc. rendered green). Move the green to .border_style() and keep the block base style background-only, so only the frame is green while text stays white/default (colored accents that set their own fg are unaffected).