### PR TITLE
feat(settings): normalize hex keys to bech32 in admin key setup

### DIFF
--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -12,7 +12,7 @@ use crate::ui::key_handler::confirmation::{
     create_key_input_state, handle_confirmation_enter, handle_input_to_confirmation,
 };
 use crate::ui::key_handler::settings::try_save_admin_key_to_settings;
-use crate::ui::key_handler::validation::{validate_npub, validate_nsec};
+use crate::ui::key_handler::validation::{normalize_to_nsec, validate_npub};
 use crate::ui::orders::OperationResult;
 use crate::ui::UserRole;
 use crate::util::order_utils::execute_take_dispute;
@@ -237,12 +237,11 @@ pub(crate) fn handle_enter_admin_mode(
             }
         }
         UiMode::AdminMode(AdminMode::SetupAdminKey(key_state)) => {
-            match validate_nsec(&key_state.key_input) {
-                Ok(_) => {
-                    app.mode =
-                        handle_input_to_confirmation(&key_state.key_input, default_mode, |input| {
-                            UiMode::AdminMode(AdminMode::ConfirmAdminKey(input, true))
-                        });
+            match normalize_to_nsec(&key_state.key_input) {
+                Ok(normalized) => {
+                    app.mode = handle_input_to_confirmation(&normalized, default_mode, |input| {
+                        UiMode::AdminMode(AdminMode::ConfirmAdminKey(input, true))
+                    });
                 }
                 Err(e) => {
                     // Show error popup

--- a/src/ui/key_handler/validation.rs
+++ b/src/ui/key_handler/validation.rs
@@ -26,6 +26,7 @@ pub fn validate_npub(npub_or_hex: &str) -> Result<(), String> {
 /// Validate if a string is a valid nsec (Nostr secret key) or hex secret key.
 /// Accepts both bech32 (nsec1...) and 64-character hex formats.
 /// Returns Ok(()) if valid, Err with error message if invalid.
+#[allow(unused)]
 pub fn validate_nsec(nsec_or_hex: &str) -> Result<(), String> {
     let key = nsec_or_hex.trim();
     if key.is_empty() {
@@ -62,6 +63,21 @@ pub fn hex_seckey_to_nsec(hex: &str) -> Option<String> {
     SecretKey::from_str(hex)
         .ok()
         .and_then(|sk| sk.to_bech32().ok())
+}
+
+/// Normalize a secret key to bech32 nsec format.
+/// Accepts nsec1... (bech32) or 64-char hex. Always returns nsec1... on success.
+pub fn normalize_to_nsec(input: &str) -> Result<String, String> {
+    let key = input.trim();
+    if key.is_empty() {
+        return Err("Secret key cannot be empty".to_string());
+    }
+    if SecretKey::from_bech32(key).is_ok() {
+        return Ok(key.to_string());
+    }
+    hex_seckey_to_nsec(key).ok_or_else(|| {
+        "Invalid secret key: expected nsec1... (bech32) or 64-char hex string".to_string()
+    })
 }
 
 /// Validate if a string is a valid hex-encoded Mostro pubkey
@@ -178,5 +194,37 @@ mod tests {
     #[test]
     fn hex_seckey_to_nsec_returns_none_for_invalid() {
         assert!(hex_seckey_to_nsec("invalid").is_none());
+    }
+
+    #[test]
+    fn normalize_to_nsec_accepts_bech32_and_returns_it() {
+        let hex = "627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84af";
+        let nsec = SecretKey::from_str(hex)
+            .expect("hex must parse as secret key")
+            .to_bech32()
+            .expect("secret key must convert to bech32");
+        let result = normalize_to_nsec(&nsec).expect("bech32 input must succeed");
+        assert_eq!(result, nsec);
+    }
+
+    #[test]
+    fn normalize_to_nsec_converts_hex_to_bech32() {
+        let hex = "627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84af";
+        let result = normalize_to_nsec(hex).expect("hex input must succeed");
+        assert!(result.starts_with("nsec1"));
+    }
+
+    #[test]
+    fn normalize_to_nsec_rejects_invalid() {
+        assert!(normalize_to_nsec("not-a-key").is_err());
+        assert!(normalize_to_nsec("").is_err());
+    }
+
+    #[test]
+    fn normalize_to_nsec_roundtrip_matches_hex() {
+        let hex = "627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84af";
+        let nsec = normalize_to_nsec(hex).expect("must convert");
+        let sk = SecretKey::from_bech32(&nsec).expect("must decode");
+        assert_eq!(sk.to_secret_hex(), hex);
     }
 }


### PR DESCRIPTION
## Summary

Closes #57

- Add `normalize_to_nsec()` to `validation.rs` — validates and converts a raw 64-char hex private key to `nsec1...` bech32 format in a single pass, reusing the existing `hex_seckey_to_nsec` helper
- Wire `normalize_to_nsec` into the `SetupAdminKey` flow so both the confirmation popup and `settings.toml` always receive canonical `nsec1...` format regardless of whether the user typed hex or bech32
- Add 4 unit tests: bech32 passthrough, hex → bech32 conversion, invalid input rejection, and round-trip correctness

## What was already implemented
The validation functions (`validate_npub`, `validate_nsec`), UI placeholders (`nsec... / hex...`), and wire-format normalization for Add Solver (`normalize_solver_pubkey`) were already in place. This PR completes the missing normalization step for the admin key input path.

## Test plan

- [x] Enter a 64-char hex private key in Settings → Change Admin Key
- [x] Confirm the popup shows `nsec1...` (not raw hex)
- [x] Confirm `~/.mostrix/settings.toml` saves `admin_privkey` as `nsec1...`
- [x] Enter an `nsec1...` key — verify it is accepted and saved unchanged
- [x] Enter an invalid string — verify the error message appears
- [s] Run `cargo test normalize_to_nsec` — all 4 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Admin setup now accepts secret keys in either hexadecimal or `nsec1...` format.
  - Inputs are automatically trimmed and converted to a standardized format when needed.

- **Bug Fixes**
  - Improved validation rejects empty or malformed keys with clearer error feedback.
  - Existing valid `nsec1...` keys continue to work unchanged.

- **Tests**
  - Added coverage for key conversion, validation, and format consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->