### PR TITLE
feat(chat): adapt to mostro-core kind-14 envelope (step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,15 +2138,16 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d763fddd85d86033f78dacadb8b75041100af7dae4d50e5bea9dc91fc1a1d24c"
+version = "0.14.1"
+source = "git+https://github.com/MostroP2P/mostro-core?rev=f2f4480ccf1374076985547b6f82c630d359bd9f#f2f4480ccf1374076985547b6f82c630d359bd9f"
 dependencies = [
  "bitcoin",
  "chrono",
+ "hkdf",
  "nostr-sdk",
  "serde",
  "serde_json",
+ "sha2",
  "uuid",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = "0.13.0"
+mostro-core = { git = "https://github.com/MostroP2P/mostro-core", rev = "f2f4480ccf1374076985547b6f82c630d359bd9f" }
 nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.5", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/src/ui/tabs/mostro_info_tab.rs
+++ b/src/ui/tabs/mostro_info_tab.rs
@@ -192,6 +192,7 @@ fn build_info_lines(info: &MostroInstanceInfo) -> Vec<Line<'static>> {
 }
 
 fn transport_display_label(transport: Transport) -> &'static str {
+    #[allow(deprecated)]
     match transport {
         Transport::GiftWrap => "GiftWrap (NIP-59)",
         Transport::Nip44Direct => "NIP-44 direct",

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -1,12 +1,12 @@
 //! Shared-key chat subscription router (P2P order chat + admin dispute chat).
 //!
-//! Replaces the previous 2-second timed `fetch_events` polling with a single
-//! long-lived subscription, mirroring Mostro Mobile's `SubscriptionManager`: one
-//! relay subscription whose filter batches **all** active shared-key pubkeys
-//! (`kind: 1059`, `#p: [shared pubkeys]`). Incoming gift wraps are routed to the
-//! owning chat by matching the event's `p` tag against the tracked pubkey set,
-//! decrypted with the per-channel shared `Keys`, and emitted on the existing
-//! `admin_chat_updates` / `user_order_chat_updates` channels so the
+//! Long-lived dual-read subscriptions (migration window):
+//! * legacy GiftWrap (`kind: 1059`, `#p: [ECDH pubkeys]`)
+//! * gift-wrap-free kind 14 (`authors: [pub(K_sign)]`)
+//!
+//! Incoming events are routed to the owning chat, decrypted with the per-channel
+//! ECDH secret (`K_conv` / `K_sign` derived at unwrap), and emitted on the
+//! existing `admin_chat_updates` / `user_order_chat_updates` channels so the
 //! `apply_*_chat_updates` handlers stay unchanged.
 //!
 //! Lifecycle (see also `docs/DM_LISTENER_FLOW.md`): the task is spawned once at
@@ -25,8 +25,8 @@ use crate::models::Order;
 use crate::ui::helpers::order_chat_since_from_file;
 use crate::ui::{AdminChatUpdate, ChatParty, OrderChatUpdate};
 use crate::util::chat_utils::{
-    derive_shared_key_hex, fetch_gift_wraps_for_shared_key, keys_from_shared_hex,
-    unwrap_giftwrap_with_shared_key,
+    chat_keys_from_ecdh, derive_shared_key_hex, fetch_gift_wraps_for_shared_key,
+    keys_from_shared_hex, unwrap_giftwrap_with_shared_key,
 };
 
 /// Identifies which chat a shared key belongs to.
@@ -58,9 +58,30 @@ pub enum ChatRouterCmd {
 /// Per-tracked-key routing metadata.
 struct ChatTarget {
     key_id: ChatKeyId,
+    /// ECDH IKM keys (persisted hex); GiftWrap `#p` lookup uses [`Keys::public_key`].
     shared_keys: Keys,
+    /// `pub(K_sign)` — kind-14 outer author used for live `authors` filter / routing.
+    sign_pubkey: PublicKey,
     /// Order chat only; enables echo-skip in `apply_user_order_chat_updates`.
     local_trade_pubkey: Option<PublicKey>,
+}
+
+/// Live subscription ids for the dual-read migration window.
+#[derive(Default)]
+struct LiveSubs {
+    giftwrap: Option<SubscriptionId>,
+    kind14: Option<SubscriptionId>,
+}
+
+impl LiveSubs {
+    async fn clear(&mut self, client: &Client) {
+        if let Some(id) = self.giftwrap.take() {
+            client.unsubscribe(&id).await;
+        }
+        if let Some(id) = self.kind14.take() {
+            client.unsubscribe(&id).await;
+        }
+    }
 }
 
 /// Global sender published for track/untrack helpers, mirroring the DM router's
@@ -203,64 +224,99 @@ fn emit_messages(
     }
 }
 
-/// Rebuild the single batched live subscription from the current tracked set.
+/// Rebuild live subscriptions from the current tracked set.
 ///
-/// Subscribes to `kind: 1059` gift wraps addressed to all tracked shared pubkeys
-/// and, **only once the replacement subscription is live**, unsubscribes the
-/// previous one (make-before-break). Uses `.limit(0)` (live-only, same as the DM
-/// listener's `LiveOnly` mode); startup history is hydrated separately per key.
-///
-/// Make-before-break guarantees a transient subscribe failure can never leave
-/// shared-key chat offline: on failure the existing subscription (if any) stays
-/// alive and the next command or reconnect retries the rebuild. Subscribe is also
-/// retried with backoff to smooth over transient relay errors. The brief window
-/// where both subscriptions are live only yields duplicate events, which are
-/// deduped downstream by the last-seen cursors.
+/// Dual-read: GiftWrap `#p` (legacy) and kind-14 `authors = [pub(K_sign)]`.
+/// Make-before-break: only drop previous subscriptions after the replacements
+/// are live. Uses `.limit(0)` (live-only); history is hydrated separately.
 async fn resubscribe(
     client: &Client,
     targets: &HashMap<PublicKey, ChatTarget>,
-    current_sub: &mut Option<SubscriptionId>,
+    current_subs: &mut LiveSubs,
 ) {
-    // No keys remain: tear down the live subscription and return.
     if targets.is_empty() {
-        if let Some(id) = current_sub.take() {
-            client.unsubscribe(&id).await;
-        }
+        current_subs.clear(client).await;
         return;
     }
-    let pubkeys: Vec<PublicKey> = targets.keys().copied().collect();
-    let filter = Filter::new().kind(Kind::GiftWrap).pubkeys(pubkeys).limit(0);
+
+    let ecdh_pubkeys: Vec<PublicKey> = targets.keys().copied().collect();
+    let sign_pubkeys: Vec<PublicKey> = targets.values().map(|t| t.sign_pubkey).collect();
+
+    let giftwrap_filter = Filter::new()
+        .kind(Kind::GiftWrap)
+        .pubkeys(ecdh_pubkeys)
+        .limit(0);
+    let kind14_filter = Filter::new()
+        .kind(Kind::PrivateDirectMessage)
+        .authors(sign_pubkeys)
+        .limit(0);
 
     const MAX_ATTEMPTS: u32 = 3;
+    let mut new_giftwrap: Option<SubscriptionId> = None;
+    let mut new_kind14: Option<SubscriptionId> = None;
+
     for attempt in 1..=MAX_ATTEMPTS {
-        match client.subscribe(filter.clone(), None).await {
+        match client.subscribe(giftwrap_filter.clone(), None).await {
             Ok(output) => {
-                log::debug!(
-                    "[chat_live] subscribed to {} shared-key chat(s) subscription_id={}",
-                    targets.len(),
-                    output.val
-                );
-                // Replacement is live; only now drop the previous subscription so a
-                // failed subscribe never leaves shared-key chat disconnected.
-                if let Some(old_id) = current_sub.replace(output.val) {
-                    client.unsubscribe(&old_id).await;
-                }
-                return;
+                new_giftwrap = Some(output.val);
+                break;
             }
             Err(e) => {
                 if attempt == MAX_ATTEMPTS {
                     log::error!(
-                        "[chat_live] failed to subscribe shared-key chats after {MAX_ATTEMPTS} attempts: {e}; keeping previous subscription alive"
+                        "[chat_live] failed to subscribe GiftWrap chats after {MAX_ATTEMPTS} attempts: {e}; keeping previous subscriptions alive"
                     );
-                } else {
-                    let delay_ms = 250u64 * (1 << (attempt - 1)); // 250ms, 500ms
-                    log::warn!(
-                        "[chat_live] subscribe attempt {attempt}/{MAX_ATTEMPTS} failed: {e}; retrying in {delay_ms}ms"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    return;
                 }
+                let delay_ms = 250u64 * (1 << (attempt - 1));
+                log::warn!(
+                    "[chat_live] GiftWrap subscribe attempt {attempt}/{MAX_ATTEMPTS} failed: {e}; retrying in {delay_ms}ms"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             }
         }
+    }
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match client.subscribe(kind14_filter.clone(), None).await {
+            Ok(output) => {
+                new_kind14 = Some(output.val);
+                break;
+            }
+            Err(e) => {
+                if attempt == MAX_ATTEMPTS {
+                    log::error!(
+                        "[chat_live] failed to subscribe kind-14 chats after {MAX_ATTEMPTS} attempts: {e}; rolling back new GiftWrap sub"
+                    );
+                    if let Some(id) = new_giftwrap.take() {
+                        client.unsubscribe(&id).await;
+                    }
+                    return;
+                }
+                let delay_ms = 250u64 * (1 << (attempt - 1));
+                log::warn!(
+                    "[chat_live] kind-14 subscribe attempt {attempt}/{MAX_ATTEMPTS} failed: {e}; retrying in {delay_ms}ms"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+        }
+    }
+
+    log::debug!(
+        "[chat_live] subscribed to {} chat(s) giftwrap={:?} kind14={:?}",
+        targets.len(),
+        new_giftwrap,
+        new_kind14
+    );
+
+    if let Some(old_id) = current_subs
+        .giftwrap
+        .replace(new_giftwrap.expect("subscribed"))
+    {
+        client.unsubscribe(&old_id).await;
+    }
+    if let Some(old_id) = current_subs.kind14.replace(new_kind14.expect("subscribed")) {
+        client.unsubscribe(&old_id).await;
     }
 }
 
@@ -305,6 +361,13 @@ fn apply_chat_router_cmd(
                     hydrate: None,
                 };
             };
+            let Some((_conv, sign)) = chat_keys_from_ecdh(&shared_keys) else {
+                log::warn!("[chat_live] failed to derive K_sign for {key_id:?}; not tracking");
+                return CmdOutcome {
+                    needs_resubscribe: false,
+                    hydrate: None,
+                };
+            };
             let target_pubkey = shared_keys.public_key();
             // Idempotent: skip redundant history fetch + resubscribe if already tracked.
             if targets
@@ -321,6 +384,7 @@ fn apply_chat_router_cmd(
                 ChatTarget {
                     key_id,
                     shared_keys: shared_keys.clone(),
+                    sign_pubkey: sign.public_key(),
                     local_trade_pubkey,
                 },
             );
@@ -379,7 +443,7 @@ async fn hydrate_history(
 ///
 /// Spawned once at startup and respawned on client reload/reconnect (mirrors
 /// `listen_for_order_messages`). Consumes [`ChatRouterCmd`] for track/untrack and
-/// routes live `kind: 1059` gift wraps by `p` tag to the owning chat.
+/// routes live GiftWrap (`#p`) and kind-14 (`authors = pub(K_sign)`) events.
 ///
 /// Multiple buffered track/untrack commands are drained and applied before a single
 /// [`resubscribe`], so startup bursts (e.g. [`crate::ui::helpers::track_startup_chats`])
@@ -393,16 +457,14 @@ pub async fn listen_for_chat_messages(
     // Create the notification receiver BEFORE subscribing so no live event is missed.
     let mut notifications = client.notifications();
     let mut targets: HashMap<PublicKey, ChatTarget> = HashMap::new();
-    let mut current_sub: Option<SubscriptionId> = None;
+    let mut current_subs = LiveSubs::default();
 
     loop {
         tokio::select! {
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else {
                     // Sender dropped (respawn/shutdown): unsubscribe and exit.
-                    if let Some(id) = current_sub.take() {
-                        client.unsubscribe(&id).await;
-                    }
+                    current_subs.clear(&client).await;
                     break;
                 };
                 let CmdOutcome {
@@ -418,7 +480,7 @@ pub async fn listen_for_chat_messages(
                     pending_hydration.extend(outcome.hydrate);
                 }
                 if needs_resubscribe {
-                    resubscribe(&client, &targets, &mut current_sub).await;
+                    resubscribe(&client, &targets, &mut current_subs).await;
                 }
                 // Subscribe-first, then backfill: the live filter now covers the newly
                 // tracked keys, so messages published during hydration are captured
@@ -444,14 +506,7 @@ pub async fn listen_for_chat_messages(
                         continue;
                     }
                 };
-                if event.kind != Kind::GiftWrap {
-                    continue;
-                }
-                // Gift wrap recipient is the shared-key pubkey in the `p` tag.
-                let Some(target_pubkey) = event.tags.public_keys().next().copied() else {
-                    continue;
-                };
-                let Some(target) = targets.get(&target_pubkey) else {
+                let Some(target) = resolve_chat_target(&targets, &event) else {
                     continue;
                 };
                 match unwrap_giftwrap_with_shared_key(&target.shared_keys, &event, None).await {
@@ -464,12 +519,27 @@ pub async fn listen_for_chat_messages(
                         );
                     }
                     Err(e) => log::warn!(
-                        "[chat_live] failed to unwrap chat gift wrap {}: {e}",
+                        "[chat_live] failed to unwrap chat event {}: {e}",
                         event.id
                     ),
                 }
             }
         }
+    }
+}
+
+/// Route a live event to its tracked chat (GiftWrap by `#p`, kind 14 by author).
+fn resolve_chat_target<'a>(
+    targets: &'a HashMap<PublicKey, ChatTarget>,
+    event: &Event,
+) -> Option<&'a ChatTarget> {
+    match event.kind {
+        Kind::GiftWrap => {
+            let target_pubkey = event.tags.public_keys().next().copied()?;
+            targets.get(&target_pubkey)
+        }
+        Kind::PrivateDirectMessage => targets.values().find(|t| t.sign_pubkey == event.pubkey),
+        _ => None,
     }
 }
 
@@ -600,5 +670,31 @@ mod tests {
 
         assert!(!outcome.needs_resubscribe);
         assert!(outcome.hydrate.is_none());
+    }
+
+    #[test]
+    fn resolve_chat_target_routes_kind14_by_sign_author() {
+        let mut targets: HashMap<PublicKey, ChatTarget> = HashMap::new();
+        let shared_hex = sample_shared_hex();
+        let _ = apply_chat_router_cmd(
+            ChatRouterCmd::TrackChatKey {
+                key_id: ChatKeyId::Order("order-1".to_string()),
+                shared_key_hex: shared_hex,
+                local_trade_pubkey: None,
+                since: None,
+            },
+            &mut targets,
+        );
+        let target = targets.values().next().expect("tracked");
+        let (_conv, sign) = chat_keys_from_ecdh(&target.shared_keys).expect("chat keys");
+        // Outer kind-14 authored by K_sign
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, "ciphertext")
+            .tag(Tag::public_key(Keys::generate().public_key()))
+            .sign_with_keys(&sign)
+            .expect("sign");
+
+        let resolved = resolve_chat_target(&targets, &event).expect("route kind14");
+        assert_eq!(resolved.key_id, ChatKeyId::Order("order-1".to_string()));
+        assert_eq!(resolved.sign_pubkey, event.pubkey);
     }
 }

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -454,7 +454,7 @@ pub async fn listen_for_chat_messages(
                 let Some(target) = targets.get(&target_pubkey) else {
                     continue;
                 };
-                match unwrap_giftwrap_with_shared_key(&target.shared_keys, &event).await {
+                match unwrap_giftwrap_with_shared_key(&target.shared_keys, &event, None).await {
                     Ok((content, ts, sender)) => {
                         emit_messages(
                             target,

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -227,23 +227,16 @@ pub async fn fetch_chat_messages_for_shared_key(
         .since(since)
         .limit(100);
 
-    let mut events: Vec<Event> = client
+    // Run both fetches independently so a transient failure of either query does
+    // not hide history still available on the other envelope during migration.
+    let kind14_result = client
         .fetch_events(kind14_filter, FETCH_EVENTS_TIMEOUT)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch kind-14 chat events: {e}"))?
-        .into_iter()
-        .collect();
-
-    if let Ok(legacy) = client
+        .await;
+    let legacy_result = client
         .fetch_events(giftwrap_filter, FETCH_EVENTS_TIMEOUT)
-        .await
-    {
-        for ev in legacy {
-            if events.iter().all(|e| e.id != ev.id) {
-                events.push(ev);
-            }
-        }
-    }
+        .await;
+
+    let events = merge_dual_read_events(kind14_result, legacy_result)?;
 
     let mut messages = Vec::new();
     for wrapped in events.iter() {
@@ -258,6 +251,38 @@ pub async fn fetch_chat_messages_for_shared_key(
     }
     messages.sort_by_key(|(_, ts, _)| *ts);
     Ok(messages)
+}
+
+/// Merge kind-14 and legacy GiftWrap fetch results for dual-read hydration.
+///
+/// Succeeds if either source returns events; errors only when both fetches fail.
+/// Event ids are deduplicated (kind-14 first, then legacy).
+pub(crate) fn merge_dual_read_events(
+    kind14: Result<impl IntoIterator<Item = Event>, impl std::fmt::Display>,
+    legacy: Result<impl IntoIterator<Item = Event>, impl std::fmt::Display>,
+) -> Result<Vec<Event>> {
+    match (kind14, legacy) {
+        (Ok(a), Ok(b)) => {
+            let mut events: Vec<Event> = a.into_iter().collect();
+            for ev in b {
+                if events.iter().all(|e| e.id != ev.id) {
+                    events.push(ev);
+                }
+            }
+            Ok(events)
+        }
+        (Ok(a), Err(e)) => {
+            log::warn!("legacy GiftWrap chat fetch failed (using kind-14 only): {e}");
+            Ok(a.into_iter().collect())
+        }
+        (Err(e), Ok(b)) => {
+            log::warn!("kind-14 chat fetch failed (using legacy GiftWrap only): {e}");
+            Ok(b.into_iter().collect())
+        }
+        (Err(e14), Err(e_legacy)) => Err(anyhow::anyhow!(
+            "Failed to fetch chat events (kind-14: {e14}; giftwrap: {e_legacy})"
+        )),
+    }
 }
 
 /// Fetch and collect new messages for a single (dispute, party) shared key.
@@ -515,5 +540,64 @@ mod tests {
             .expect("from ecdh");
         assert_eq!(conv.public_key(), conv2.public_key());
         assert_eq!(sign.public_key(), sign2.public_key());
+    }
+
+    fn sample_text_event(keys: &Keys, content: &str) -> Event {
+        EventBuilder::text_note(content)
+            .sign_with_keys(keys)
+            .expect("sign event")
+    }
+
+    #[test]
+    fn merge_dual_read_keeps_legacy_when_kind14_fails() {
+        let keys = Keys::generate();
+        let legacy_ev = sample_text_event(&keys, "legacy");
+        let merged = merge_dual_read_events(
+            Err::<Vec<Event>, _>("kind14 down"),
+            Ok::<Vec<Event>, &str>(vec![legacy_ev.clone()]),
+        )
+        .expect("legacy alone succeeds");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].id, legacy_ev.id);
+    }
+
+    #[test]
+    fn merge_dual_read_keeps_kind14_when_legacy_fails() {
+        let keys = Keys::generate();
+        let kind14_ev = sample_text_event(&keys, "kind14");
+        let merged = merge_dual_read_events(
+            Ok::<Vec<Event>, &str>(vec![kind14_ev.clone()]),
+            Err::<Vec<Event>, _>("giftwrap down"),
+        )
+        .expect("kind14 alone succeeds");
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].id, kind14_ev.id);
+    }
+
+    #[test]
+    fn merge_dual_read_errors_when_both_fail() {
+        let err = merge_dual_read_events(
+            Err::<Vec<Event>, _>("kind14 down"),
+            Err::<Vec<Event>, _>("giftwrap down"),
+        )
+        .expect_err("both failed");
+        let msg = err.to_string();
+        assert!(msg.contains("kind14 down"));
+        assert!(msg.contains("giftwrap down"));
+    }
+
+    #[test]
+    fn merge_dual_read_dedupes_by_event_id() {
+        let keys = Keys::generate();
+        let shared = sample_text_event(&keys, "same");
+        let other = sample_text_event(&keys, "other");
+        let merged = merge_dual_read_events(
+            Ok::<Vec<Event>, &str>(vec![shared.clone()]),
+            Ok::<Vec<Event>, &str>(vec![shared.clone(), other.clone()]),
+        )
+        .expect("merge");
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].id, shared.id);
+        assert_eq!(merged[1].id, other.id);
     }
 }

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::Result;
-use mostro_core::chat::{chat_filter, unwrap_chat_message, wrap_chat_message, SharedKey};
+use mostro_core::chat::{
+    chat_filter, unwrap_chat_message, unwrap_giftwrap_chat_message, wrap_chat_message, SharedKey,
+};
 use mostro_core::prelude::DisputeStatus;
 use mostro_core::prelude::SmallOrder;
+use nostr_sdk::nips::nip44;
 use nostr_sdk::prelude::*;
 
 use crate::models::{AdminDispute, Order};
@@ -16,17 +19,14 @@ use crate::util::mostro_info::MostroInstanceInfo;
 type AdminChatByKey = HashMap<(String, ChatParty), Vec<(String, i64, PublicKey)>>;
 
 // ---------------------------------------------------------------------------
-// Shared-key helpers (ECDH derivation, hex conversion)
+// Shared-key helpers (ECDH IKM + K_conv / K_sign)
 // ---------------------------------------------------------------------------
 
-/// Derive the per-channel shared key (ECDH) for a chat counterparty.
+/// Derive the per-channel ECDH shared secret for a chat counterparty.
 ///
-/// This is **not** a normal identity/trade key: it is the 32-byte ECDH output
-/// between the local secret key and the counterparty pubkey (see
-/// `mostro_core::chat::SharedKey`). Both peers derive the same value, and the
-/// corresponding **shared pubkey** is used as the GiftWrap `p` tag and recipient.
-///
-/// Mostrix keeps the return type as `Keys` to avoid churn in existing call sites.
+/// This is the 32-byte ECDH output used as HKDF IKM for `K_conv` / `K_sign`
+/// (see `mostro_core::chat`). Mostrix persists that secret as hex; wire
+/// addressing uses `pub(K_conv)` / `pub(K_sign)` from [`chat_keys_from_ecdh`].
 ///
 /// Returns `None` if either argument is missing or derivation fails.
 pub fn derive_shared_keys(
@@ -40,12 +40,10 @@ pub fn derive_shared_keys(
         .map(|shared| shared.keys().clone())
 }
 
-/// Derive a shared key and return its secret as hex for DB persistence.
+/// Derive a shared ECDH secret and return it as hex for DB persistence.
 ///
-/// The persisted hex represents the **shared secret**, not a user’s secret key.
-/// It round-trips via `keys_from_shared_hex`.
-///
-/// Returns `None` when derivation is not possible.
+/// The persisted hex is the ECDH IKM, not `K_conv` / `K_sign`. It round-trips
+/// via [`keys_from_shared_hex`] then [`chat_keys_from_ecdh`].
 pub fn derive_shared_key_hex(
     admin_keys: Option<&Keys>,
     counterparty_pubkey_str: Option<&str>,
@@ -58,21 +56,28 @@ pub fn derive_shared_key_hex(
         .map(|shared| shared.to_hex())
 }
 
-/// Rebuild a `Keys` from a stored shared-key hex string.
-///
-/// The persisted hex is the `SharedKey` secret (ECDH output), not a normal
-/// user/trade secret key.
+/// Rebuild ECDH `Keys` from a stored shared-key hex string.
 pub fn keys_from_shared_hex(hex: &str) -> Option<Keys> {
     SharedKey::from_hex(hex)
         .ok()
         .map(|shared| shared.keys().clone())
 }
 
+/// Derive `(K_conv, K_sign)` from ECDH keys rebuilt via [`keys_from_shared_hex`].
+pub fn chat_keys_from_ecdh(ecdh_keys: &Keys) -> Option<(Keys, Keys)> {
+    SharedKey::from_keys(ecdh_keys.clone()).chat_keys().ok()
+}
+
+/// Derive `(K_conv, K_sign)` from a persisted ECDH hex string.
+pub fn chat_keys_from_shared_hex(hex: &str) -> Option<(Keys, Keys)> {
+    SharedKey::from_hex(hex).ok()?.chat_keys().ok()
+}
+
 /// 32-byte ChaCha20 key for decrypting order-chat attachments (shared ECDH secret).
 pub fn order_chat_decryption_key_bytes(order: &Order) -> Option<Vec<u8>> {
     if let Some(hex) = order.order_chat_shared_key_hex.as_deref() {
         if let Some(keys) = keys_from_shared_hex(hex) {
-            return Some(keys.secret_key().secret_bytes().to_vec());
+            return Some(keys.secret_key().to_secret_bytes().to_vec());
         }
     }
     let trade_keys_hex = order.trade_keys.as_deref()?;
@@ -81,10 +86,10 @@ pub fn order_chat_decryption_key_bytes(order: &Order) -> Option<Vec<u8>> {
     let cp = order.counterparty_pubkey.as_deref()?;
     let cp_pk = PublicKey::parse(cp).ok()?;
     derive_shared_keys(Some(&trade_keys), Some(&cp_pk))
-        .map(|k| k.secret_key().secret_bytes().to_vec())
+        .map(|k| k.secret_key().to_secret_bytes().to_vec())
 }
 
-/// Resolve the order-chat counterparty pubkey and the shared-key hex used for chat GiftWraps.
+/// Resolve the order-chat counterparty pubkey and the ECDH shared-key hex.
 ///
 /// This is only possible once `SmallOrder` includes both `buyer_trade_pubkey` and
 /// `seller_trade_pubkey`, and the local `trade_keys` matches one of them.
@@ -116,13 +121,10 @@ pub fn order_chat_counterparty_and_shared_hex(
     Some((counterparty_str, shared_hex))
 }
 
-/// Send one admin dispute chat message via the per-dispute shared key.
+/// Send one admin dispute chat message via the per-dispute ECDH shared secret.
 ///
-/// The GiftWrap is addressed to the **shared pubkey** (`SharedKey.public_key()`),
-/// allowing both sides (admin and counterparty) to fetch the same events and
-/// decrypt them by deriving/rebuilding the same shared secret.
-///
-/// `shared_keys` is the `Keys` instance rebuilt from the stored shared-key hex.
+/// Wraps with the gift-wrap-free envelope: kind 14 signed by `K_sign`, encrypted
+/// under `K_conv`. `shared_keys` is the ECDH `Keys` from stored hex.
 pub async fn send_admin_chat_message_via_shared_key(
     client: &Client,
     admin_keys: &Keys,
@@ -134,11 +136,11 @@ pub async fn send_admin_chat_message_via_shared_key(
     if content.is_empty() {
         return Err(anyhow::anyhow!("Cannot send empty admin chat message"));
     }
-    let shared_pubkey = shared_keys.public_key();
-    let event = wrap_chat_message(admin_keys, &shared_pubkey, content)
+    let (conv, sign) = chat_keys_from_ecdh(shared_keys)
+        .ok_or_else(|| anyhow::anyhow!("Failed to derive K_conv / K_sign from shared key"))?;
+    let event = wrap_chat_message(admin_keys, &conv, &sign, content)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to wrap admin chat message: {e}"))?;
-    // Send the event to the relay
     client
         .send_event(&event)
         .await
@@ -146,54 +148,111 @@ pub async fn send_admin_chat_message_via_shared_key(
     Ok(())
 }
 
-/// Unwrap a Mostro P2P chat GiftWrap addressed to a shared key.
+/// Unwrap a chat envelope addressed via the channel ECDH secret.
 ///
-/// Uses `mostro_core::chat::unwrap_chat_message`, which decrypts and verifies the
-/// inner kind-1 signature so the returned sender pubkey can be trusted.
+/// Accepts the new kind-14 form and, during migration, legacy GiftWrap.
+/// When `allowed_signers` is `None`, any verified inner signer is accepted
+/// (observer / hydration paths that do not yet know both party pubkeys).
 pub async fn unwrap_giftwrap_with_shared_key(
     shared_keys: &Keys,
     event: &Event,
+    allowed_signers: Option<&[PublicKey]>,
 ) -> Result<(String, i64, PublicKey)> {
-    let msg = unwrap_chat_message(shared_keys, event)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to unwrap chat gift wrap: {e}"))?;
+    if event.kind == Kind::GiftWrap {
+        let msg = unwrap_giftwrap_chat_message(shared_keys, event)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to unwrap chat gift wrap: {e}"))?;
+        if let Some(allowed) = allowed_signers {
+            if !allowed.contains(&msg.sender) {
+                return Err(anyhow::anyhow!(
+                    "inner gift-wrap signer is not a party to this conversation"
+                ));
+            }
+        }
+        return Ok((msg.content, msg.created_at.as_secs() as i64, msg.sender));
+    }
+
+    let (conv, sign) = chat_keys_from_ecdh(shared_keys)
+        .ok_or_else(|| anyhow::anyhow!("Failed to derive K_conv / K_sign from shared key"))?;
+    let sign_pk = sign.public_key();
+    let now = Timestamp::now();
+
+    let allowed_owned: Vec<PublicKey>;
+    let allowed: &[PublicKey] = match allowed_signers {
+        Some(s) => s,
+        None => {
+            // Learn the inner signer cheaply, then run the full normative unwrap.
+            let decrypted = nip44::decrypt(conv.secret_key(), &conv.public_key(), &event.content)
+                .map_err(|e| anyhow::anyhow!("K_conv decrypt failed: {e}"))?;
+            let inner = Event::from_json(&decrypted)
+                .map_err(|e| anyhow::anyhow!("malformed inner chat event: {e}"))?;
+            allowed_owned = vec![inner.pubkey];
+            &allowed_owned
+        }
+    };
+
+    let msg = unwrap_chat_message(&conv, &sign_pk, allowed, event, now)
+        .map_err(|e| anyhow::anyhow!("Failed to unwrap chat event: {e}"))?;
     Ok((msg.content, msg.created_at.as_secs() as i64, msg.sender))
 }
 
-/// Fetch recent chat GiftWrap events for a shared key and return decoded messages.
+/// Fetch recent chat events for a shared ECDH key and return decoded messages.
 ///
-/// This uses a wide (7 day) lookback for resiliency on restart / relay lag, and
-/// then unwraps each event with `unwrap_chat_message`.
+/// Subscribes by `authors = [pub(K_sign)]` (kind 14). Also tries the legacy
+/// gift-wrap `#p` filter so dual-read hydration still works during migration.
 pub async fn fetch_gift_wraps_for_shared_key(
     client: &Client,
     shared_keys: &Keys,
 ) -> Result<Vec<(String, i64, PublicKey)>> {
+    fetch_chat_messages_for_shared_key(client, shared_keys, None).await
+}
+
+/// Like [`fetch_gift_wraps_for_shared_key`], with optional inner-signer allow-list.
+pub async fn fetch_chat_messages_for_shared_key(
+    client: &Client,
+    shared_keys: &Keys,
+    allowed_signers: Option<&[PublicKey]>,
+) -> Result<Vec<(String, i64, PublicKey)>> {
     let now = Timestamp::now().as_secs();
     let seven_days_secs: u64 = 7 * 24 * 60 * 60;
     let wide_since = now.saturating_sub(seven_days_secs);
+    let since = Timestamp::from(wide_since);
 
-    let shared_pubkey = shared_keys.public_key();
-    let filter = chat_filter(shared_pubkey)
-        .since(Timestamp::from(wide_since))
+    let (_conv, sign) = chat_keys_from_ecdh(shared_keys)
+        .ok_or_else(|| anyhow::anyhow!("Failed to derive K_conv / K_sign from shared key"))?;
+
+    let kind14_filter = chat_filter(sign.public_key()).since(since).limit(100);
+    // Dual-read: legacy gift wraps addressed to the ECDH pubkey (superseded p tag).
+    let giftwrap_filter = mostro_core::chat::giftwrap_chat_filter(shared_keys.public_key())
+        .since(since)
         .limit(100);
 
-    let events = client
-        .fetch_events(filter, FETCH_EVENTS_TIMEOUT)
+    let mut events: Vec<Event> = client
+        .fetch_events(kind14_filter, FETCH_EVENTS_TIMEOUT)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch admin chat events for shared key: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to fetch kind-14 chat events: {e}"))?
+        .into_iter()
+        .collect();
+
+    if let Ok(legacy) = client
+        .fetch_events(giftwrap_filter, FETCH_EVENTS_TIMEOUT)
+        .await
+    {
+        for ev in legacy {
+            if events.iter().all(|e| e.id != ev.id) {
+                events.push(ev);
+            }
+        }
+    }
 
     let mut messages = Vec::new();
     for wrapped in events.iter() {
-        match unwrap_giftwrap_with_shared_key(shared_keys, wrapped).await {
+        match unwrap_giftwrap_with_shared_key(shared_keys, wrapped, allowed_signers).await {
             Ok((content, ts, sender_pubkey)) => {
                 messages.push((content, ts, sender_pubkey));
             }
             Err(e) => {
-                log::warn!(
-                    "Failed to unwrap gift wrap for shared key {}: {}",
-                    wrapped.id,
-                    e
-                );
+                log::warn!("Failed to unwrap chat event {}: {}", wrapped.id, e);
             }
         }
     }
@@ -202,9 +261,6 @@ pub async fn fetch_gift_wraps_for_shared_key(
 }
 
 /// Fetch and collect new messages for a single (dispute, party) shared key.
-///
-/// Rebuilds `Keys` from the stored hex, fetches gift wraps addressed to that
-/// shared key's pubkey, filters by `last_seen`, and appends results to `by_key`.
 async fn fetch_party_messages(
     client: &Client,
     dispute_id: &str,
@@ -234,11 +290,6 @@ async fn fetch_party_messages(
 }
 
 /// Fetch admin chat updates for all active disputes using per-dispute shared keys.
-///
-/// For each (dispute, party) that has a stored `shared_key_hex`, we rebuild the
-/// `Keys`, fetch gift wrap events addressed to the shared key's public key, and
-/// apply `last_seen_timestamp` filtering. Messages are grouped into
-/// `AdminChatUpdate` results the same way as before.
 pub async fn fetch_admin_chat_updates(
     client: &Client,
     disputes: &[AdminDispute],
@@ -247,7 +298,6 @@ pub async fn fetch_admin_chat_updates(
     let mut by_key: AdminChatByKey = HashMap::new();
 
     for d in disputes {
-        // Only fetch for InProgress disputes
         let is_in_progress = d
             .status
             .as_deref()
@@ -283,11 +333,11 @@ pub async fn fetch_admin_chat_updates(
     Ok(updates)
 }
 
-/// Fetch chat messages for the Observer tab using a pasted shared key hex.
+/// Fetch chat messages for the Observer tab using a pasted ECDH shared key hex.
 ///
-/// Converts the hex to `Keys`, fetches gift wraps from the last 7 days,
-/// decrypts them, assigns Buyer/Seller/Admin roles by pubkey order, and
-/// returns `DisputeChatMessage` items ready for display.
+/// Derives `K_conv` / `K_sign` for fetch/decrypt. Observer UX that accepts
+/// `K_conv`-only disclosure is Step 6; this path still expects the ECDH secret
+/// Mostrix stores today (which can derive both keys).
 pub async fn fetch_observer_chat(
     client: &Client,
     shared_key_hex: &str,
@@ -302,7 +352,6 @@ pub async fn fetch_observer_chat(
 
     let raw = fetch_gift_wraps_for_shared_key(client, &shared_keys).await?;
 
-    // Map pubkeys to roles: admin (if known) → Admin, first unknown → Buyer, second → Seller
     let mut role_map: HashMap<PublicKey, ChatSender> = HashMap::new();
     if let Some(apk) = admin_pubkey {
         role_map.insert(*apk, ChatSender::Admin);
@@ -435,18 +484,36 @@ mod tests {
         let receiver = Keys::generate();
         let shared = SharedKey::derive(sender.secret_key(), &receiver.public_key())
             .expect("shared key derives");
-        let shared_pubkey = shared.public_key();
+        let (conv, sign) = shared.chat_keys().expect("chat keys");
 
         let content = "hello from test";
-        let wrapped = wrap_chat_message(&sender, &shared_pubkey, content)
+        let wrapped = wrap_chat_message(&sender, &conv, &sign, content)
             .await
             .expect("wrap_chat_message succeeds");
 
-        let unwrapped = unwrap_chat_message(shared.keys(), &wrapped)
-            .await
-            .expect("unwrap_chat_message succeeds");
+        assert_eq!(wrapped.kind, Kind::PrivateDirectMessage);
+        assert_eq!(wrapped.pubkey, sign.public_key());
 
-        assert_eq!(unwrapped.sender, sender.public_key());
-        assert_eq!(unwrapped.content, content);
+        let allowed = [sender.public_key(), receiver.public_key()];
+        let unwrapped = unwrap_giftwrap_with_shared_key(shared.keys(), &wrapped, Some(&allowed))
+            .await
+            .expect("unwrap succeeds");
+
+        assert_eq!(unwrapped.2, sender.public_key());
+        assert_eq!(unwrapped.0, content);
+    }
+
+    #[test]
+    fn chat_keys_from_shared_hex_matches_derive() {
+        let a = Keys::generate();
+        let b = Keys::generate();
+        let hex = derive_shared_key_hex(Some(&a), Some(b.public_key().to_string().as_str()))
+            .expect("hex");
+        let (conv, sign) = chat_keys_from_shared_hex(&hex).expect("chat keys");
+        let (conv2, sign2) = derive_shared_keys(Some(&a), Some(&b.public_key()))
+            .and_then(|ecdh| chat_keys_from_ecdh(&ecdh))
+            .expect("from ecdh");
+        assert_eq!(conv.public_key(), conv2.public_key());
+        assert_eq!(sign.public_key(), sign2.public_key());
     }
 }

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -28,6 +28,7 @@ pub fn filter_protocol_dm_from_mostro(
     mostro_pubkey: PublicKey,
     trade_pubkey: PublicKey,
 ) -> Filter {
+    #[allow(deprecated)]
     match transport {
         Transport::GiftWrap => filter_giftwrap_to_recipient(trade_pubkey),
         Transport::Nip44Direct if mostro_pubkey == trade_pubkey => Filter::new()
@@ -68,6 +69,7 @@ pub fn create_filter(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use mostro_core::prelude::Transport;

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -162,6 +162,7 @@ pub fn instance_bonds_enabled(instance: Option<&MostroInstanceInfo>) -> bool {
 pub fn transport_from_instance(info: Option<&MostroInstanceInfo>) -> Transport {
     match info.and_then(|i| i.protocol_version) {
         Some(2) => Transport::Nip44Direct,
+        #[allow(deprecated)]
         _ => Transport::GiftWrap,
     }
 }
@@ -311,6 +312,7 @@ pub async fn fetch_mostro_instance_info_from_settings(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use mostro_core::prelude::Transport;

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -83,5 +83,8 @@ pub fn get_cant_do_description(reason: &CantDoReason) -> String {
         CantDoReason::CashuSignatureMissing => {
             "Cashu signature missing from the request".to_string()
         }
+        CantDoReason::PriceTooStale => {
+            "Price quote is too stale — refresh the rate and try again".to_string()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Pin `mostro-core` to [f2f4480](https://github.com/MostroP2P/mostro-core/commit/f2f4480ccf1374076985547b6f82c630d359bd9f) (PR [#160](https://github.com/MostroP2P/mostro-core/pull/160)) via git rev — crates.io `0.14.1` still ships GiftWrap chat.
- Adapt [`src/util/chat_utils.rs`](src/util/chat_utils.rs): ECDH hex → `K_conv`/`K_sign`, kind-14 wrap/unwrap, `authors` fetch filter, dual-read legacy GiftWrap hydrate.
- Small bump fallout: `CantDoReason::PriceTooStale` string + `#[allow(deprecated)]` for protocol v1 `Transport::GiftWrap` until that path is removed.

Part of [mostrix#102](https://github.com/MostroP2P/mostrix/issues/102). **Does not** rewrite `chat_listener` live sub (still GiftWrap `#p`) — that is Step 3.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (249 lib + integration)
- [ ] Manual: send still publishes kind 14; live receive needs Step 3


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat encryption and key handling for improved security.
  * Added support for reading both new encrypted messages and legacy chat messages.
  * Added optional validation of chat message senders.

* **Bug Fixes**
  * Improved chat message retrieval, deduplication, and resilience when some sources are unavailable.
  * Added a clear message when prices are outdated, prompting users to refresh the rate and retry.
  * Maintained compatibility with legacy protocol behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->