### PR TITLE
feat(chat): Step 3 — clamp since cursor + mostro-core 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -976,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2138,8 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.14.1"
-source = "git+https://github.com/MostroP2P/mostro-core?rev=f2f4480ccf1374076985547b6f82c630d359bd9f#f2f4480ccf1374076985547b6f82c630d359bd9f"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e1f5305546178ad152a715a39274870cc707a8d402ae404d85fc9693b56ac1"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -2472,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3212,7 +3213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3271,7 +3272,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3578,7 +3579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4874,7 +4875,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = { git = "https://github.com/MostroP2P/mostro-core", rev = "f2f4480ccf1374076985547b6f82c630d359bd9f" }
+mostro-core = "0.14.2"
 nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.5", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/src/ui/helpers/chat_storage.rs
+++ b/src/ui/helpers/chat_storage.rs
@@ -316,20 +316,29 @@ pub fn load_order_chat_from_file(order_id: &str) -> Option<Vec<UserOrderChatMess
 }
 
 /// Max message timestamp from the on-disk order chat transcript (cursor for relay hydrate).
+///
+/// Clamped to local now so a far-future transcript timestamp cannot poison `since`.
 pub fn order_chat_since_from_file(order_id: &str) -> Option<i64> {
-    load_order_chat_from_file(order_id).and_then(|msgs| msgs.iter().map(|m| m.timestamp).max())
+    load_order_chat_from_file(order_id)
+        .and_then(|msgs| msgs.iter().map(|m| m.timestamp).max())
+        .map(crate::util::chat_utils::clamp_chat_since_cursor_now)
 }
 
 /// Per-party max timestamps from the on-disk dispute transcript (cursor for relay hydrate).
 ///
 /// Returns `(buyer_since, seller_since)`; a side with no messages yields `None`.
+/// Each side is clamped to local now (protocol `since` cursor rule).
 pub fn dispute_chat_since_from_file(dispute_id: &str) -> (Option<i64>, Option<i64>) {
     match load_chat_from_file(dispute_id) {
         Some(msgs) => {
             let (buyer_max, seller_max) = max_party_timestamps(&msgs);
             (
-                (buyer_max > 0).then_some(buyer_max),
-                (seller_max > 0).then_some(seller_max),
+                (buyer_max > 0).then_some(crate::util::chat_utils::clamp_chat_since_cursor_now(
+                    buyer_max,
+                )),
+                (seller_max > 0).then_some(crate::util::chat_utils::clamp_chat_since_cursor_now(
+                    seller_max,
+                )),
             )
         }
         None => (None, None),

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -17,7 +17,7 @@ use crate::ui::{
 };
 use crate::util::{
     chat_listener::{track_dispute_chat, track_order_chat},
-    chat_utils::derive_shared_key_hex,
+    chat_utils::{clamp_chat_since_cursor_now, derive_shared_key_hex},
     seed_admin_chat_last_seen,
 };
 
@@ -88,7 +88,7 @@ fn update_last_seen_timestamp(
             last_seen_timestamp: None,
         });
     if buyer_max_timestamp > buyer_entry.last_seen_timestamp.unwrap_or(0) {
-        buyer_entry.last_seen_timestamp = Some(buyer_max_timestamp);
+        buyer_entry.last_seen_timestamp = Some(clamp_chat_since_cursor_now(buyer_max_timestamp));
     }
 
     let seller_entry = admin_chat_last_seen
@@ -97,7 +97,7 @@ fn update_last_seen_timestamp(
             last_seen_timestamp: None,
         });
     if seller_max_timestamp > seller_entry.last_seen_timestamp.unwrap_or(0) {
-        seller_entry.last_seen_timestamp = Some(seller_max_timestamp);
+        seller_entry.last_seen_timestamp = Some(clamp_chat_since_cursor_now(seller_max_timestamp));
     }
 }
 
@@ -161,7 +161,8 @@ pub async fn track_startup_chats(pool: &SqlitePool, app: &AppState) {
                 let since = app
                     .order_chat_last_seen
                     .get(&row.id)
-                    .and_then(|s| s.last_seen_timestamp);
+                    .and_then(|s| s.last_seen_timestamp)
+                    .map(clamp_chat_since_cursor_now);
                 track_order_chat(row.id.clone(), shared_hex, trade_keys.public_key(), since);
             }
         }
@@ -185,7 +186,8 @@ pub async fn track_startup_chats(pool: &SqlitePool, app: &AppState) {
                     let since = app
                         .admin_chat_last_seen
                         .get(&(dispute.dispute_id.clone(), party))
-                        .and_then(|s| s.last_seen_timestamp);
+                        .and_then(|s| s.last_seen_timestamp)
+                        .map(clamp_chat_since_cursor_now);
                     track_dispute_chat(dispute.dispute_id.clone(), party, hex.to_string(), since);
                 }
             }
@@ -214,7 +216,7 @@ pub async fn load_user_order_chats_at_startup(pool: &SqlitePool, app: &mut AppSt
             app.order_chat_last_seen.insert(
                 order_id.clone(),
                 OrderChatLastSeen {
-                    last_seen_timestamp: Some(max_ts),
+                    last_seen_timestamp: Some(clamp_chat_since_cursor_now(max_ts)),
                 },
             );
         }
@@ -475,7 +477,7 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
         app.order_chat_last_seen.insert(
             order_id,
             OrderChatLastSeen {
-                last_seen_timestamp: Some(max_ts),
+                last_seen_timestamp: Some(clamp_chat_since_cursor_now(max_ts)),
             },
         );
     }
@@ -627,15 +629,16 @@ pub async fn apply_admin_chat_updates(
             .or_insert_with(|| AdminChatLastSeen {
                 last_seen_timestamp: None,
             });
-        if max_ts > entry.last_seen_timestamp.unwrap_or(0) {
-            entry.last_seen_timestamp = Some(max_ts);
+        let clamped_max = clamp_chat_since_cursor_now(max_ts);
+        if clamped_max > entry.last_seen_timestamp.unwrap_or(0) {
+            entry.last_seen_timestamp = Some(clamped_max);
         }
 
-        if max_ts > 0 {
+        if clamped_max > 0 {
             if let Err(e) = AdminDispute::update_chat_last_seen_by_dispute_id(
                 pool,
                 &dispute_key,
-                max_ts,
+                clamped_max,
                 party == ChatParty::Buyer,
             )
             .await

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -87,8 +87,14 @@ fn update_last_seen_timestamp(
         .or_insert_with(|| AdminChatLastSeen {
             last_seen_timestamp: None,
         });
-    if buyer_max_timestamp > buyer_entry.last_seen_timestamp.unwrap_or(0) {
-        buyer_entry.last_seen_timestamp = Some(clamp_chat_since_cursor_now(buyer_max_timestamp));
+    // Normalize the stored cursor too so a stale future value can't outrank real messages.
+    let buyer_existing = buyer_entry
+        .last_seen_timestamp
+        .map(clamp_chat_since_cursor_now)
+        .unwrap_or(0);
+    let buyer_new = buyer_existing.max(clamp_chat_since_cursor_now(buyer_max_timestamp));
+    if buyer_new > 0 {
+        buyer_entry.last_seen_timestamp = Some(buyer_new);
     }
 
     let seller_entry = admin_chat_last_seen
@@ -96,8 +102,13 @@ fn update_last_seen_timestamp(
         .or_insert_with(|| AdminChatLastSeen {
             last_seen_timestamp: None,
         });
-    if seller_max_timestamp > seller_entry.last_seen_timestamp.unwrap_or(0) {
-        seller_entry.last_seen_timestamp = Some(clamp_chat_since_cursor_now(seller_max_timestamp));
+    let seller_existing = seller_entry
+        .last_seen_timestamp
+        .map(clamp_chat_since_cursor_now)
+        .unwrap_or(0);
+    let seller_new = seller_existing.max(clamp_chat_since_cursor_now(seller_max_timestamp));
+    if seller_new > 0 {
+        seller_entry.last_seen_timestamp = Some(seller_new);
     }
 }
 
@@ -630,15 +641,18 @@ pub async fn apply_admin_chat_updates(
                 last_seen_timestamp: None,
             });
         let clamped_max = clamp_chat_since_cursor_now(max_ts);
-        if clamped_max > entry.last_seen_timestamp.unwrap_or(0) {
-            entry.last_seen_timestamp = Some(clamped_max);
-        }
-
-        if clamped_max > 0 {
+        // Normalize the stored cursor so a stale future value can't outrank real messages.
+        let existing = entry
+            .last_seen_timestamp
+            .map(clamp_chat_since_cursor_now)
+            .unwrap_or(0);
+        let new_last_seen = existing.max(clamped_max);
+        if new_last_seen > 0 {
+            entry.last_seen_timestamp = Some(new_last_seen);
             if let Err(e) = AdminDispute::update_chat_last_seen_by_dispute_id(
                 pool,
                 &dispute_key,
-                clamped_max,
+                new_last_seen,
                 party == ChatParty::Buyer,
             )
             .await

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -4,9 +4,14 @@
 //! * legacy GiftWrap (`kind: 1059`, `#p: [ECDH pubkeys]`)
 //! * gift-wrap-free kind 14 (`authors: [pub(K_sign)]`)
 //!
-//! Incoming events are routed to the owning chat, decrypted with the per-channel
-//! ECDH secret (`K_conv` / `K_sign` derived at unwrap), and emitted on the
-//! existing `admin_chat_updates` / `user_order_chat_updates` channels so the
+//! Live kind-14 traffic is routed **only** by outer author ∈ tracked `pub(K_sign)`
+//! (never by `#p` alone). GiftWrap dual-read still matches `#p` = ECDH pubkey.
+//! Hydration and last-seen cursors use `min(accepted_ts, local_now)` so a
+//! far-future timestamp cannot poison `since`.
+//!
+//! Incoming events are decrypted with the per-channel ECDH secret (`K_conv` /
+//! `K_sign` derived at unwrap), and emitted on the existing
+//! `admin_chat_updates` / `user_order_chat_updates` channels so the
 //! `apply_*_chat_updates` handlers stay unchanged.
 //!
 //! Lifecycle (see also `docs/DM_LISTENER_FLOW.md`): the task is spawned once at
@@ -25,8 +30,8 @@ use crate::models::Order;
 use crate::ui::helpers::order_chat_since_from_file;
 use crate::ui::{AdminChatUpdate, ChatParty, OrderChatUpdate};
 use crate::util::chat_utils::{
-    chat_keys_from_ecdh, derive_shared_key_hex, fetch_gift_wraps_for_shared_key,
-    keys_from_shared_hex, unwrap_giftwrap_with_shared_key,
+    chat_keys_from_ecdh, clamp_chat_since_cursor_now, derive_shared_key_hex,
+    fetch_chat_messages_for_shared_key, keys_from_shared_hex, unwrap_giftwrap_with_shared_key,
 };
 
 /// Identifies which chat a shared key belongs to.
@@ -379,6 +384,7 @@ fn apply_chat_router_cmd(
                     hydrate: None,
                 };
             }
+            let since = since.map(clamp_chat_since_cursor_now);
             targets.insert(
                 target_pubkey,
                 ChatTarget {
@@ -423,7 +429,9 @@ async fn hydrate_history(
     let Some(target) = targets.get(&pending.target_pubkey) else {
         return;
     };
-    match fetch_gift_wraps_for_shared_key(client, &pending.shared_keys).await {
+    match fetch_chat_messages_for_shared_key(client, &pending.shared_keys, None, pending.since)
+        .await
+    {
         Ok(messages) => {
             let cutoff = pending.since.unwrap_or(0);
             let history: Vec<(String, i64, PublicKey)> = messages
@@ -696,5 +704,48 @@ mod tests {
         let resolved = resolve_chat_target(&targets, &event).expect("route kind14");
         assert_eq!(resolved.key_id, ChatKeyId::Order("order-1".to_string()));
         assert_eq!(resolved.sign_pubkey, event.pubkey);
+    }
+
+    #[test]
+    fn resolve_chat_target_ignores_kind14_from_unknown_author() {
+        let mut targets: HashMap<PublicKey, ChatTarget> = HashMap::new();
+        let shared_hex = sample_shared_hex();
+        let _ = apply_chat_router_cmd(
+            ChatRouterCmd::TrackChatKey {
+                key_id: ChatKeyId::Order("order-1".to_string()),
+                shared_key_hex: shared_hex,
+                local_trade_pubkey: None,
+                since: None,
+            },
+            &mut targets,
+        );
+        // Junk kind-14: random author, p=pub(K_conv) would still not match by author.
+        let junk = Keys::generate();
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, "ciphertext")
+            .tag(Tag::public_key(Keys::generate().public_key()))
+            .sign_with_keys(&junk)
+            .expect("sign");
+
+        assert!(resolve_chat_target(&targets, &event).is_none());
+    }
+
+    #[test]
+    fn track_clamps_future_since_cursor() {
+        let mut targets: HashMap<PublicKey, ChatTarget> = HashMap::new();
+        let shared_hex = sample_shared_hex();
+        let future = Timestamp::now().as_secs() as i64 + 86_400;
+        let outcome = apply_chat_router_cmd(
+            ChatRouterCmd::TrackChatKey {
+                key_id: ChatKeyId::Order("order-1".to_string()),
+                shared_key_hex: shared_hex,
+                local_trade_pubkey: None,
+                since: Some(future),
+            },
+            &mut targets,
+        );
+        let hydrate = outcome.hydrate.expect("hydrate");
+        let since = hydrate.since.expect("since");
+        assert!(since <= Timestamp::now().as_secs() as i64);
+        assert!(since < future);
     }
 }

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -719,10 +719,12 @@ mod tests {
             },
             &mut targets,
         );
-        // Junk kind-14: random author, p=pub(K_conv) would still not match by author.
+        // Tag `#p` with the tracked target key so this fails if routing ever fell back
+        // to `#p`; the unknown outer author must still be rejected.
+        let target_pubkey = *targets.keys().next().expect("tracked target");
         let junk = Keys::generate();
         let event = EventBuilder::new(Kind::PrivateDirectMessage, "ciphertext")
-            .tag(Tag::public_key(Keys::generate().public_key()))
+            .tag(Tag::public_key(target_pubkey))
             .sign_with_keys(&junk)
             .expect("sign");
 

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -40,6 +40,20 @@ pub fn derive_shared_keys(
         .map(|shared| shared.keys().clone())
 }
 
+/// Clamp a chat `since` cursor to the client's clock.
+///
+/// Protocol requirement: persisted `since` MUST be `min(accepted_ts, local_now)`.
+/// Without this, a counterparty can date a message far in the future, poison the
+/// cursor, and permanently silence the conversation until that date.
+pub fn clamp_chat_since_cursor(accepted_ts: i64, local_now: i64) -> i64 {
+    accepted_ts.min(local_now)
+}
+
+/// [`clamp_chat_since_cursor`] against [`Timestamp::now`].
+pub fn clamp_chat_since_cursor_now(accepted_ts: i64) -> i64 {
+    clamp_chat_since_cursor(accepted_ts, Timestamp::now().as_secs() as i64)
+}
+
 /// Derive a shared ECDH secret and return it as hex for DB persistence.
 ///
 /// The persisted hex is the ECDH IKM, not `K_conv` / `K_sign`. It round-trips
@@ -204,27 +218,34 @@ pub async fn fetch_gift_wraps_for_shared_key(
     client: &Client,
     shared_keys: &Keys,
 ) -> Result<Vec<(String, i64, PublicKey)>> {
-    fetch_chat_messages_for_shared_key(client, shared_keys, None).await
+    fetch_chat_messages_for_shared_key(client, shared_keys, None, None).await
 }
 
-/// Like [`fetch_gift_wraps_for_shared_key`], with optional inner-signer allow-list.
+/// Like [`fetch_gift_wraps_for_shared_key`], with optional inner-signer allow-list
+/// and optional last-seen `since` cursor (clamped to local now; lookback capped
+/// at seven days when the cursor is older or absent).
 pub async fn fetch_chat_messages_for_shared_key(
     client: &Client,
     shared_keys: &Keys,
     allowed_signers: Option<&[PublicKey]>,
+    since: Option<i64>,
 ) -> Result<Vec<(String, i64, PublicKey)>> {
-    let now = Timestamp::now().as_secs();
-    let seven_days_secs: u64 = 7 * 24 * 60 * 60;
-    let wide_since = now.saturating_sub(seven_days_secs);
-    let since = Timestamp::from(wide_since);
+    let local_now = Timestamp::now().as_secs() as i64;
+    let seven_days_secs: i64 = 7 * 24 * 60 * 60;
+    let lookback_floor = local_now.saturating_sub(seven_days_secs);
+    let since_secs = match since {
+        Some(ts) => clamp_chat_since_cursor(ts, local_now).max(lookback_floor),
+        None => lookback_floor,
+    } as u64;
+    let since_ts = Timestamp::from(since_secs);
 
     let (_conv, sign) = chat_keys_from_ecdh(shared_keys)
         .ok_or_else(|| anyhow::anyhow!("Failed to derive K_conv / K_sign from shared key"))?;
 
-    let kind14_filter = chat_filter(sign.public_key()).since(since).limit(100);
+    let kind14_filter = chat_filter(sign.public_key()).since(since_ts).limit(100);
     // Dual-read: legacy gift wraps addressed to the ECDH pubkey (superseded p tag).
     let giftwrap_filter = mostro_core::chat::giftwrap_chat_filter(shared_keys.public_key())
-        .since(since)
+        .since(since_ts)
         .limit(100);
 
     // Run both fetches independently so a transient failure of either query does
@@ -299,7 +320,9 @@ async fn fetch_party_messages(
         return;
     };
 
-    let Ok(messages) = fetch_gift_wraps_for_shared_key(client, &shared_keys).await else {
+    let Ok(messages) =
+        fetch_chat_messages_for_shared_key(client, &shared_keys, None, Some(last_seen)).await
+    else {
         return;
     };
 
@@ -546,6 +569,14 @@ mod tests {
         EventBuilder::text_note(content)
             .sign_with_keys(keys)
             .expect("sign event")
+    }
+
+    #[test]
+    fn clamp_chat_since_cursor_caps_future_poison() {
+        let now = 1_700_000_000_i64;
+        assert_eq!(clamp_chat_since_cursor(now + 86_400, now), now);
+        assert_eq!(clamp_chat_since_cursor(now - 10, now), now - 10);
+        assert_eq!(clamp_chat_since_cursor(now, now), now);
     }
 
     #[test]

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -244,8 +244,12 @@ pub async fn fetch_chat_messages_for_shared_key(
 
     let kind14_filter = chat_filter(sign.public_key()).since(since_ts).limit(100);
     // Dual-read: legacy gift wraps addressed to the ECDH pubkey (superseded p tag).
+    // Outer 1059 created_at is randomized into the past, so tightening to the cursor
+    // would drop still-new messages; keep the wide floor and let callers re-filter on
+    // the canonical inner timestamp after unwrap.
+    let giftwrap_since = Timestamp::from(lookback_floor.max(0) as u64);
     let giftwrap_filter = mostro_core::chat::giftwrap_chat_filter(shared_keys.public_key())
-        .since(since_ts)
+        .since(giftwrap_since)
         .limit(100);
 
     // Run both fetches independently so a transient failure of either query does
@@ -319,6 +323,8 @@ async fn fetch_party_messages(
     let Some(shared_keys) = keys_from_shared_hex(hex) else {
         return;
     };
+    // Normalize a possibly-future stored cursor before it gates the fetch and filter.
+    let last_seen = clamp_chat_since_cursor_now(last_seen);
 
     let Ok(messages) =
         fetch_chat_messages_for_shared_key(client, &shared_keys, None, Some(last_seen)).await

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -106,7 +106,9 @@ pub fn seed_admin_chat_last_seen(app: &mut AppState) {
             app.admin_chat_last_seen.insert(
                 (dispute.dispute_id.clone(), ChatParty::Buyer),
                 AdminChatLastSeen {
-                    last_seen_timestamp: dispute.buyer_chat_last_seen,
+                    last_seen_timestamp: dispute
+                        .buyer_chat_last_seen
+                        .map(crate::util::chat_utils::clamp_chat_since_cursor_now),
                 },
             );
         }
@@ -114,7 +116,9 @@ pub fn seed_admin_chat_last_seen(app: &mut AppState) {
             app.admin_chat_last_seen.insert(
                 (dispute.dispute_id.clone(), ChatParty::Seller),
                 AdminChatLastSeen {
-                    last_seen_timestamp: dispute.seller_chat_last_seen,
+                    last_seen_timestamp: dispute
+                        .seller_chat_last_seen
+                        .map(crate::util::chat_utils::clamp_chat_since_cursor_now),
                 },
             );
         }


### PR DESCRIPTION
## Summary
- Pin `mostro-core` to crates.io **0.14.2** (drops the temporary git rev from Step 2).
- Clamp chat `since` / last-seen cursors to `min(accepted_ts, local_now)` on persist, track, hydrate, and transcript-derived cursors (protocol P1 against far-future DoS).
- Hydration fetch uses the clamped cursor (7-day lookback floor); live kind-14 routing rejects unknown authors (unit-tested).

Part of #102 (Step 3 of the kind-14 chat migration). Dual-read live subscribe landed in #103.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [ ] Smoke: restart with an existing order chat; confirm hydrate uses last-seen and new kind-14 messages still arrive live
- [ ] Confirm `Cargo.lock` resolves `mostro-core` from crates.io (`0.14.2`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented future timestamps from causing missed or incorrectly ordered chat messages.
  * Improved restoration and live updates for order and dispute conversations.
  * Reduced unrelated or unknown messages appearing in chats.

* **Improvements**
  * Limited historical chat recovery to a recent time window for more consistent loading.
  * Enhanced dispute chat hydration when one party has no prior messages.
  * Improved handling across supported chat message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->