### PR TITLE
fix: silence clippy unneeded_wildcard_pattern on Rust 1.97

### DIFF
--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -89,7 +89,6 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             payment_method,
             premium,
             status,
-            trade_index: _,
             ..
         }) => {
             let block = Block::default()


### PR DESCRIPTION
## Problem

`cargo clippy --all-targets --all-features -- -D warnings` fails on a clean `main` (verified at `3ddffd8`):

```
error: this pattern is unneeded as the `..` pattern can match that element
  --> src/ui/operation_result.rs:92:13
   |
92 | /             trade_index: _,
93 | |             ..
   | |____________^ help: remove it
   |
   = note: `-D clippy::unneeded-wildcard-pattern` implied by `-D warnings`
```

`.github/workflows/ci.yml` uses `dtolnay/rust-toolchain@stable`, not the `1.96.0` pinned in `rust-toolchain.toml`, so CI picks this up as soon as stable moves to 1.97. And because `test` and `build` declare `needs: [fmt, clippy]`, the whole pipeline stops there.

## Fix

`..` already covers `trade_index`, so removing the explicit binding is behaviour-neutral and satisfies both toolchains. One line.

`cargo test --all-features` → 254 passed, 0 failed. `cargo fmt --all -- --check` clean.

Follows the precedent of 6db53d1 ("fix: silence clippy warnings on Rust 1.96").

Worth considering separately: pinning the CI toolchain to `rust-toolchain.toml` instead of `@stable` would stop new stable lints from turning main red without a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)