### PR TITLE
fix(ui): show premium in offers and take-order confirmation

### DIFF
--- a/src/ui/helpers/formatting.rs
+++ b/src/ui/helpers/formatting.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use mostro_core::prelude::UserInfo;
+use ratatui::style::Color;
 
 use crate::models::AdminDispute;
 
@@ -33,6 +34,16 @@ pub fn format_order_id(order_id: Option<uuid::Uuid>) -> String {
         )
     } else {
         "Order: Unknown".to_string()
+    }
+}
+
+/// Formats an order premium with an explicit sign and its semantic UI color.
+#[must_use]
+pub fn format_premium(premium: i64) -> (String, Color) {
+    match premium {
+        0 => ("0%".to_string(), Color::Gray),
+        value if value > 0 => (format!("+{value}%"), Color::Green),
+        value => (format!("{value}%"), Color::Red),
     }
 }
 
@@ -128,5 +139,17 @@ mod relative_time_tests {
     #[test]
     fn future_timestamp_clamps_to_just_now() {
         assert_eq!(relative_time_compact_from(2_000, 1_000), "just now");
+    }
+}
+
+#[cfg(test)]
+mod premium_tests {
+    use super::*;
+
+    #[test]
+    fn preserves_sign_and_uses_semantic_color() {
+        assert_eq!(format_premium(2), ("+2%".to_string(), Color::Green));
+        assert_eq!(format_premium(-3), ("-3%".to_string(), Color::Red));
+        assert_eq!(format_premium(0), ("0%".to_string(), Color::Gray));
     }
 }

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -28,8 +28,8 @@ pub use chat_visibility::{
     get_selected_chat_message, get_visible_attachment_messages, message_visible_for_party,
 };
 pub use formatting::{
-    format_order_id, format_user_rating, is_dispute_finalized, relative_time_compact,
-    short_order_id,
+    format_order_id, format_premium, format_user_rating, is_dispute_finalized,
+    relative_time_compact, short_order_id,
 };
 pub use layout::{
     create_centered_popup, render_help_text, render_yes_no_buttons, render_yes_no_cancel_buttons,

--- a/src/ui/order_take.rs
+++ b/src/ui/order_take.rs
@@ -7,6 +7,7 @@ use crate::ui::helpers::format_premium;
 
 use super::{TakeOrderState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
+/// Renders the Take Order confirmation, using a compact layout on short terminals.
 pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
     let area = f.area();
     let popup_width = area.width.saturating_sub(area.width / 4);
@@ -15,12 +16,14 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
     // Base constraints: spacer(1) + title(2) + separator(1) + kind(1) + currency(1) + fiat(1) + payment(1) + premium(1) + buttons(3) + help(1) = 13
     // For range: + label(1) + input(3) + error(1) + spacer(1) = +6 (always reserve error space to prevent resizing)
     // Popup border and vertical breathing room: +4
-    // IMPORTANT: Always use fixed height for range orders to prevent popup from moving when typing
-    let popup_height = if take_state.is_range_order {
-        23 // Base(13) + range(6) + popup space(4) = 23 (fixed, never changes)
+    // Keep these preferred heights stable while space permits; short terminals use a compact view.
+    let preferred_popup_height = if take_state.is_range_order {
+        23 // Base(13) + range(6) + popup space(4) = 23
     } else {
         17 // Base(13) + popup space(4) = 17
     };
+    let popup_height = preferred_popup_height.min(area.height);
+    let compact = popup_height < preferred_popup_height;
     // Center the popup using Flex::Center
     let popup = {
         let [popup] = Layout::horizontal([Constraint::Length(popup_width)])
@@ -34,6 +37,18 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
 
     // Clear the popup area to make it fully opaque
     f.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title("📥 Take Order")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
+    let popup_inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    if compact {
+        render_compact_order_take(f, popup_inner, take_state);
+        return;
+    }
 
     let mut constraints = vec![
         Constraint::Length(1), // spacer
@@ -61,12 +76,6 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
     constraints.push(Constraint::Length(1)); // help text
 
     let inner_chunks = Layout::new(Direction::Vertical, constraints).split(popup);
-
-    let block = Block::default()
-        .title("📥 Take Order")
-        .borders(Borders::ALL)
-        .style(Style::default().bg(BACKGROUND_COLOR).fg(PRIMARY_COLOR));
-    f.render_widget(block, popup);
 
     // Title
     f.render_widget(
@@ -245,97 +254,7 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
 
     // YES/NO buttons - center them in the popup
     let button_area = inner_chunks[button_idx];
-
-    // Calculate button width (each button + separator)
-    // Each button should be about 12-15 chars wide, plus 1 for separator
-    let button_width = 15; // Width for each button
-    let separator_width = 1;
-    let total_button_width = (button_width * 2) + separator_width;
-
-    // Center the buttons horizontally
-    let button_x = button_area.x + (button_area.width.saturating_sub(total_button_width)) / 2;
-    let centered_button_area = Rect {
-        x: button_x,
-        y: button_area.y,
-        width: total_button_width.min(button_area.width),
-        height: button_area.height,
-    };
-
-    let button_chunks = Layout::new(
-        Direction::Horizontal,
-        [
-            Constraint::Length(button_width),
-            Constraint::Length(separator_width), // separator
-            Constraint::Length(button_width),
-        ],
-    )
-    .split(centered_button_area);
-
-    // YES button
-    let yes_style = if take_state.selected_button {
-        Style::default()
-            .bg(Color::Green)
-            .fg(Color::Black)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-            .fg(Color::Green)
-            .add_modifier(Modifier::BOLD)
-    };
-
-    let yes_block = Block::default().borders(Borders::ALL).style(yes_style);
-    f.render_widget(yes_block, button_chunks[0]);
-
-    let yes_inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
-        .margin(1)
-        .split(button_chunks[0]);
-
-    f.render_widget(
-        Paragraph::new(Line::from(vec![Span::styled(
-            "✓ YES",
-            Style::default()
-                .fg(if take_state.selected_button {
-                    Color::Black
-                } else {
-                    Color::Green
-                })
-                .add_modifier(Modifier::BOLD),
-        )]))
-        .alignment(ratatui::layout::Alignment::Center),
-        yes_inner[0],
-    );
-
-    // NO button
-    let no_style = if !take_state.selected_button {
-        Style::default()
-            .bg(Color::Red)
-            .fg(Color::Black)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-    };
-
-    let no_block = Block::default().borders(Borders::ALL).style(no_style);
-    f.render_widget(no_block, button_chunks[2]);
-
-    let no_inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
-        .margin(1)
-        .split(button_chunks[2]);
-
-    f.render_widget(
-        Paragraph::new(Line::from(vec![Span::styled(
-            "✗ NO",
-            Style::default()
-                .fg(if !take_state.selected_button {
-                    Color::Black
-                } else {
-                    Color::Red
-                })
-                .add_modifier(Modifier::BOLD),
-        )]))
-        .alignment(ratatui::layout::Alignment::Center),
-        no_inner[0],
-    );
+    render_take_buttons(f, button_area, take_state.selected_button);
 
     // Help text - comes after buttons and optional spacer
     let help_idx = if take_state.is_range_order {
@@ -369,6 +288,182 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
     }
 }
 
+fn render_compact_order_take(f: &mut ratatui::Frame, area: Rect, take_state: &TakeOrderState) {
+    let [details_area, button_area] = Layout::vertical([
+        Constraint::Min(0),
+        Constraint::Length(3), // always reserve YES/NO controls
+    ])
+    .areas(area);
+    let detailed_range_input = take_state.is_range_order && details_area.height >= 6;
+    let compact_range_input = take_state.is_range_order && !detailed_range_input;
+    let mut constraints = vec![
+        Constraint::Length(1), // fiat amount
+        Constraint::Length(1), // premium
+    ];
+    if detailed_range_input {
+        constraints.push(Constraint::Length(1)); // amount label
+        constraints.push(Constraint::Length(3)); // amount input
+    } else if compact_range_input {
+        constraints.push(Constraint::Length(1)); // compact amount input
+    }
+    let chunks = Layout::new(Direction::Vertical, constraints).split(details_area);
+    let fiat = if take_state.is_range_order {
+        format!(
+            "{}-{} {}",
+            take_state.order.min_amount.unwrap_or(0),
+            take_state.order.max_amount.unwrap_or(0),
+            take_state.order.fiat_code
+        )
+    } else {
+        format!(
+            "{} {}",
+            take_state.order.fiat_amount, take_state.order.fiat_code
+        )
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("Fiat: "),
+            Span::styled(fiat, Style::default().fg(PRIMARY_COLOR)),
+        ]))
+        .alignment(ratatui::layout::Alignment::Center),
+        chunks[0],
+    );
+
+    let (premium_text, premium_color) = format_premium(take_state.order.premium);
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("Premium: "),
+            Span::styled(premium_text, Style::default().fg(premium_color)),
+        ]))
+        .alignment(ratatui::layout::Alignment::Center),
+        chunks[1],
+    );
+
+    if detailed_range_input {
+        let min = take_state.order.min_amount.unwrap_or(0);
+        let max = take_state.order.max_amount.unwrap_or(0);
+        let currency = &take_state.order.fiat_code;
+        f.render_widget(
+            Paragraph::new(format!("Enter amount ({min}-{max} {currency}):"))
+                .alignment(ratatui::layout::Alignment::Center),
+            chunks[2],
+        );
+
+        let input_text = if take_state.amount_input.is_empty() {
+            min.to_string()
+        } else {
+            take_state.amount_input.clone()
+        };
+        f.render_widget(
+            Paragraph::new(format!("{input_text} {currency}"))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(Block::default().borders(Borders::ALL)),
+            chunks[3],
+        );
+    } else if compact_range_input && chunks.len() > 2 {
+        let min = take_state.order.min_amount.unwrap_or(0);
+        let input_text = if take_state.amount_input.is_empty() {
+            min.to_string()
+        } else {
+            take_state.amount_input.clone()
+        };
+        f.render_widget(
+            Paragraph::new(format!(
+                "Amount: {input_text} {}",
+                take_state.order.fiat_code
+            ))
+            .alignment(ratatui::layout::Alignment::Center),
+            chunks[2],
+        );
+    }
+
+    render_take_buttons(f, button_area, take_state.selected_button);
+}
+
+fn render_take_buttons(f: &mut ratatui::Frame, area: Rect, selected_button: bool) {
+    let separator_width = 1;
+    let button_width = ((area.width.saturating_sub(separator_width)) / 2).min(15);
+    let total_button_width = (button_width * 2) + separator_width;
+    let button_x = area.x + (area.width.saturating_sub(total_button_width)) / 2;
+    let centered_button_area = Rect {
+        x: button_x,
+        y: area.y,
+        width: total_button_width.min(area.width),
+        height: area.height,
+    };
+    let button_chunks = Layout::new(
+        Direction::Horizontal,
+        [
+            Constraint::Length(button_width),
+            Constraint::Length(separator_width),
+            Constraint::Length(button_width),
+        ],
+    )
+    .split(centered_button_area);
+
+    let yes_style = if selected_button {
+        Style::default()
+            .bg(Color::Green)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    };
+    f.render_widget(
+        Block::default().borders(Borders::ALL).style(yes_style),
+        button_chunks[0],
+    );
+    let yes_inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
+        .margin(1)
+        .split(button_chunks[0]);
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "✓ YES",
+            Style::default()
+                .fg(if selected_button {
+                    Color::Black
+                } else {
+                    Color::Green
+                })
+                .add_modifier(Modifier::BOLD),
+        )]))
+        .alignment(ratatui::layout::Alignment::Center),
+        yes_inner[0],
+    );
+
+    let no_style = if !selected_button {
+        Style::default()
+            .bg(Color::Red)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+    };
+    f.render_widget(
+        Block::default().borders(Borders::ALL).style(no_style),
+        button_chunks[2],
+    );
+    let no_inner = Layout::new(Direction::Vertical, [Constraint::Min(0)])
+        .margin(1)
+        .split(button_chunks[2]);
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "✗ NO",
+            Style::default()
+                .fg(if !selected_button {
+                    Color::Black
+                } else {
+                    Color::Red
+                })
+                .add_modifier(Modifier::BOLD),
+        )]))
+        .alignment(ratatui::layout::Alignment::Center),
+        no_inner[0],
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -387,8 +482,8 @@ mod tests {
         flat.contains(needle)
     }
 
-    fn render_take_order(is_range_order: bool) -> ratatui::buffer::Buffer {
-        let backend = TestBackend::new(100, 30);
+    fn render_take_order(width: u16, height: u16, is_range_order: bool) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         let take_state = TakeOrderState {
             order: SmallOrder {
@@ -414,11 +509,26 @@ mod tests {
     #[test]
     fn take_order_shows_premium_for_fixed_and_range_orders() {
         for is_range_order in [false, true] {
-            let buf = render_take_order(is_range_order);
+            let buf = render_take_order(100, 30, is_range_order);
             assert!(buffer_contains(&buf, "Premium:"));
             assert!(buffer_contains(&buf, "-3%"));
             assert!(buffer_contains(&buf, "SPEI"));
             assert!(buffer_contains(&buf, "YES"));
+            assert!(buffer_contains(&buf, "NO"));
+        }
+    }
+
+    #[test]
+    fn short_terminal_keeps_premium_and_actions_visible() {
+        for is_range_order in [false, true] {
+            let buf = render_take_order(60, 10, is_range_order);
+            assert!(buffer_contains(&buf, "Premium:"));
+            assert!(buffer_contains(&buf, "-3%"));
+            assert!(buffer_contains(&buf, "YES"));
+            assert!(buffer_contains(&buf, "NO"));
+            if is_range_order {
+                assert!(buffer_contains(&buf, "500 MXN"));
+            }
         }
     }
 }

--- a/src/ui/order_take.rs
+++ b/src/ui/order_take.rs
@@ -3,21 +3,23 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
+use crate::ui::helpers::format_premium;
+
 use super::{TakeOrderState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
 pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
     let area = f.area();
     let popup_width = area.width.saturating_sub(area.width / 4);
     // Adjust height based on whether it's a range order (needs input field and error)
-    // Calculate total height needed: sum of all constraints + borders (2 lines)
-    // Base constraints: spacer(1) + title(2) + separator(1) + kind(1) + currency(1) + fiat(1) + payment(1) + separator(1) + buttons(5) + help(1) = 15
+    // Calculate total height needed from the fixed constraints and surrounding popup space.
+    // Base constraints: spacer(1) + title(2) + separator(1) + kind(1) + currency(1) + fiat(1) + payment(1) + premium(1) + buttons(3) + help(1) = 13
     // For range: + label(1) + input(3) + error(1) + spacer(1) = +6 (always reserve error space to prevent resizing)
-    // Borders: top(1) + bottom(1) = 2
+    // Popup border and vertical breathing room: +4
     // IMPORTANT: Always use fixed height for range orders to prevent popup from moving when typing
     let popup_height = if take_state.is_range_order {
-        23 // Base(15) + range(6) + borders(2) = 23 (fixed, never changes)
+        23 // Base(13) + range(6) + popup space(4) = 23 (fixed, never changes)
     } else {
-        17 // Base(15) + borders(2) = 17
+        17 // Base(13) + popup space(4) = 17
     };
     // Center the popup using Flex::Center
     let popup = {
@@ -41,6 +43,7 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
         Constraint::Length(1), // currency
         Constraint::Length(1), // fiat amount (or range)
         Constraint::Length(1), // payment method
+        Constraint::Length(1), // premium
     ];
 
     // Add input field and error for range orders
@@ -51,7 +54,6 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
         constraints.push(Constraint::Length(1)); // error message (always reserve space, even if empty)
     }
 
-    constraints.push(Constraint::Length(1)); // separator
     constraints.push(Constraint::Length(3)); // YES/NO buttons (need space for borders, margins, and content)
     if take_state.is_range_order {
         constraints.push(Constraint::Length(1)); // spacer for buttons
@@ -138,14 +140,24 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
         inner_chunks[6],
     );
 
+    let (premium_text, premium_color) = format_premium(take_state.order.premium);
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw("Premium: "),
+            Span::styled(premium_text, Style::default().fg(premium_color)),
+        ]))
+        .alignment(ratatui::layout::Alignment::Center),
+        inner_chunks[7],
+    );
+
     // Input field for range orders
-    // Calculate button index: buttons come after separator
-    // For range orders: indices 0-6 (base), 7-9 (range fields), 10 (separator), 11 (buttons)
-    // For non-range: indices 0-6 (base), 7 (separator), 8 (buttons)
+    // Calculate button index: buttons come after premium and any range fields
+    // For range orders: indices 0-6 (base), 7 (premium), 8-10 (range fields), 11 (buttons)
+    // For non-range: indices 0-6 (base), 7 (premium), 8 (buttons)
     let button_idx = if take_state.is_range_order {
-        11 // separator at 10, buttons at 11
+        11 // range fields at 8-10, buttons at 11
     } else {
-        8 // separator at 7, buttons at 8
+        8 // premium at 7, buttons at 8
     };
 
     if take_state.is_range_order {
@@ -164,7 +176,7 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
                 Span::raw("):"),
             ]))
             .alignment(ratatui::layout::Alignment::Center),
-            inner_chunks[7],
+            inner_chunks[8],
         );
 
         // Input box with borders
@@ -184,7 +196,7 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
         };
 
         // Create a smaller input box centered in the area
-        let input_area = inner_chunks[8];
+        let input_area = inner_chunks[9];
         let input_width = (input_area.width * 2 / 3).min(30); // Max 30 chars wide, 2/3 of available width
         let input_x = input_area.x + (input_area.width.saturating_sub(input_width)) / 2;
         let input_rect = Rect {
@@ -217,7 +229,7 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
         );
 
         // Error message - always render in reserved space (show empty if no error)
-        let error_chunk = inner_chunks[9];
+        let error_chunk = inner_chunks[10];
         if let Some(error_msg) = &take_state.validation_error {
             f.render_widget(
                 Paragraph::new(Line::from(vec![Span::styled(
@@ -354,5 +366,59 @@ pub fn render_order_take(f: &mut ratatui::Frame, take_state: &TakeOrderState) {
             .alignment(ratatui::layout::Alignment::Center),
             inner_chunks[help_idx],
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mostro_core::prelude::SmallOrder;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        let mut flat = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                flat.push_str(buf[(x, y)].symbol());
+            }
+            flat.push('\n');
+        }
+        flat.contains(needle)
+    }
+
+    fn render_take_order(is_range_order: bool) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let take_state = TakeOrderState {
+            order: SmallOrder {
+                fiat_code: "MXN".to_string(),
+                fiat_amount: 500,
+                min_amount: is_range_order.then_some(500),
+                max_amount: is_range_order.then_some(1_000),
+                premium: -3,
+                payment_method: "SPEI".to_string(),
+                ..Default::default()
+            },
+            amount_input: String::new(),
+            is_range_order,
+            validation_error: None,
+            selected_button: true,
+        };
+        terminal
+            .draw(|f| render_order_take(f, &take_state))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn take_order_shows_premium_for_fixed_and_range_orders() {
+        for is_range_order in [false, true] {
+            let buf = render_take_order(is_range_order);
+            assert!(buffer_contains(&buf, "Premium:"));
+            assert!(buffer_contains(&buf, "-3%"));
+            assert!(buffer_contains(&buf, "SPEI"));
+            assert!(buffer_contains(&buf, "YES"));
+        }
     }
 }

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -537,11 +537,7 @@ fn sats_display(order: Option<&SmallOrder>, sat_amount: Option<i64>) -> String {
 fn premium_display(order: Option<&SmallOrder>) -> (String, Color) {
     match order {
         None => ("—".to_string(), Color::DarkGray),
-        Some(order) => match order.premium {
-            0 => ("0%".to_string(), Color::Gray),
-            p if p > 0 => (format!("+{p}%"), Color::Green),
-            p => (format!("{p}%"), Color::Red),
-        },
+        Some(order) => helpers::format_premium(order.premium),
     }
 }
 

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -18,6 +18,7 @@ use crate::ui::orders::{
 };
 use crate::ui::{OrderMessage, BACKGROUND_COLOR, PRIMARY_COLOR};
 
+/// Renders the order-message list and the selected trade timeline.
 pub fn render_messages_tab(
     f: &mut ratatui::Frame,
     area: Rect,

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -10,6 +10,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 use crate::ui::helpers::format_premium;
 use crate::ui::{apply_kind_color, AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
+/// Renders the available orders table, with fewer columns when terminal width is limited.
 pub fn render_orders_tab(
     f: &mut ratatui::Frame,
     area: Rect,
@@ -77,17 +78,26 @@ pub fn render_orders_tab(
             }
         };
 
-        let header_cells = vec![
-            Cell::from("📈 Kind").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("🆔 Order Id").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("📊 Status").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("₿ Amount").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("💱 Fiat").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("💵 Fiat Amt").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("± Premium").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("💳 Payment Method").style(Style::default().add_modifier(Modifier::BOLD)),
-            Cell::from("📅 Created").style(Style::default().add_modifier(Modifier::BOLD)),
-        ];
+        let compact = area.width < 100;
+        let header_labels = if compact {
+            vec!["📈 Kind", "💵 Fiat Amt", "± Premium", "💳 Payment"]
+        } else {
+            vec![
+                "📈 Kind",
+                "🆔 Order Id",
+                "📊 Status",
+                "₿ Amount",
+                "💱 Fiat",
+                "💵 Fiat Amt",
+                "± Premium",
+                "💳 Payment Method",
+                "📅 Created",
+            ]
+        };
+        let header_cells = header_labels
+            .into_iter()
+            .map(|label| Cell::from(label).style(Style::default().add_modifier(Modifier::BOLD)))
+            .collect::<Vec<_>>();
         let header = Row::new(header_cells);
 
         let rows: Vec<Row> = orders_lock
@@ -125,17 +135,17 @@ pub fn render_orders_tab(
 
                 let fiat_code_cell = Cell::from(order.fiat_code.clone());
 
-                let fiat_amount_cell = if order.min_amount.is_none() && order.max_amount.is_none() {
-                    Cell::from(order.fiat_amount.to_string())
+                let fiat_amount_text = if order.min_amount.is_none() && order.max_amount.is_none() {
+                    order.fiat_amount.to_string()
                 } else {
-                    let range_str = match (order.min_amount, order.max_amount) {
+                    match (order.min_amount, order.max_amount) {
                         (Some(min), Some(max)) => format!("{}-{}", min, max),
                         (Some(min), None) => format!("{}-?", min),
                         (None, Some(max)) => format!("?-{}", max),
                         (None, None) => "?".to_string(),
-                    };
-                    Cell::from(range_str)
+                    }
                 };
+                let fiat_amount_cell = Cell::from(fiat_amount_text.clone());
 
                 let payment_method_cell = Cell::from(order.payment_method.clone());
                 let premium_cell = premium_cell(order.premium);
@@ -153,17 +163,26 @@ pub fn render_orders_tab(
                         .unwrap_or_else(|| "Invalid date".to_string()),
                 );
 
-                let row = Row::new(vec![
-                    kind_cell,
-                    id_cell,
-                    status_cell,
-                    amount_cell,
-                    fiat_code_cell,
-                    fiat_amount_cell,
-                    premium_cell,
-                    payment_method_cell,
-                    date_cell,
-                ]);
+                let row = if compact {
+                    Row::new(vec![
+                        kind_cell,
+                        Cell::from(format!("{} {}", fiat_amount_text, order.fiat_code)),
+                        premium_cell,
+                        payment_method_cell,
+                    ])
+                } else {
+                    Row::new(vec![
+                        kind_cell,
+                        id_cell,
+                        status_cell,
+                        amount_cell,
+                        fiat_code_cell,
+                        fiat_amount_cell,
+                        premium_cell,
+                        payment_method_cell,
+                        date_cell,
+                    ])
+                };
 
                 Some(if i == selected_order_idx {
                     row.style(Style::default().bg(PRIMARY_COLOR).fg(Color::Black))
@@ -173,9 +192,15 @@ pub fn render_orders_tab(
             })
             .collect();
 
-        let table = Table::new(
-            rows,
-            &[
+        let widths = if compact {
+            vec![
+                Constraint::Max(8),
+                Constraint::Max(18),
+                Constraint::Max(10),
+                Constraint::Min(12),
+            ]
+        } else {
+            vec![
                 Constraint::Max(8),
                 Constraint::Max(15),
                 Constraint::Max(10),
@@ -185,10 +210,9 @@ pub fn render_orders_tab(
                 Constraint::Max(10),
                 Constraint::Min(15),
                 Constraint::Max(18),
-            ],
-        )
-        .header(header)
-        .block(
+            ]
+        };
+        let table = Table::new(rows, widths).header(header).block(
             Block::default()
                 .title("Orders")
                 .borders(Borders::ALL)
@@ -249,5 +273,15 @@ mod tests {
         assert!(buffer_contains(&buf, "Premium"));
         assert!(buffer_contains(&buf, "-3%"));
         assert!(buffer_contains(&buf, "SEPA"));
+    }
+
+    #[test]
+    fn narrow_orders_table_keeps_premium_readable() {
+        let buf = render_at_width(60, -3);
+        assert!(buffer_contains(&buf, "Premium"));
+        assert!(buffer_contains(&buf, "-3%"));
+        assert!(buffer_contains(&buf, "100 USD"));
+        assert!(buffer_contains(&buf, "SEPA"));
+        assert!(!buffer_contains(&buf, "Created"));
     }
 }

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -7,6 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
+use crate::ui::helpers::format_premium;
 use crate::ui::{apply_kind_color, AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
 pub fn render_orders_tab(
@@ -83,6 +84,7 @@ pub fn render_orders_tab(
             Cell::from("₿ Amount").style(Style::default().add_modifier(Modifier::BOLD)),
             Cell::from("💱 Fiat").style(Style::default().add_modifier(Modifier::BOLD)),
             Cell::from("💵 Fiat Amt").style(Style::default().add_modifier(Modifier::BOLD)),
+            Cell::from("± Premium").style(Style::default().add_modifier(Modifier::BOLD)),
             Cell::from("💳 Payment Method").style(Style::default().add_modifier(Modifier::BOLD)),
             Cell::from("📅 Created").style(Style::default().add_modifier(Modifier::BOLD)),
         ];
@@ -136,6 +138,7 @@ pub fn render_orders_tab(
                 };
 
                 let payment_method_cell = Cell::from(order.payment_method.clone());
+                let premium_cell = premium_cell(order.premium);
 
                 // Missing created_at must not fall back to epoch (unwrap_or(0)); propagate None.
                 let date_cell = Cell::from(
@@ -157,6 +160,7 @@ pub fn render_orders_tab(
                     amount_cell,
                     fiat_code_cell,
                     fiat_amount_cell,
+                    premium_cell,
                     payment_method_cell,
                     date_cell,
                 ]);
@@ -178,6 +182,7 @@ pub fn render_orders_tab(
                 Constraint::Max(12),
                 Constraint::Max(10),
                 Constraint::Max(12),
+                Constraint::Max(10),
                 Constraint::Min(15),
                 Constraint::Max(18),
             ],
@@ -192,5 +197,57 @@ pub fn render_orders_tab(
                 .style(Style::default().bg(BACKGROUND_COLOR)),
         );
         f.render_widget(table, area);
+    }
+}
+
+fn premium_cell(premium: i64) -> Cell<'static> {
+    let (text, color) = format_premium(premium);
+    Cell::from(text).style(Style::default().fg(color))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    use crate::ui::UserRole;
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        let mut flat = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                flat.push_str(buf[(x, y)].symbol());
+            }
+            flat.push('\n');
+        }
+        flat.contains(needle)
+    }
+
+    fn render_at_width(width: u16, premium: i64) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let orders = Arc::new(Mutex::new(vec![SmallOrder {
+            kind: Some(mostro_core::order::Kind::Buy),
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            amount: 50_000,
+            premium,
+            payment_method: "SEPA".to_string(),
+            ..Default::default()
+        }]));
+        let app = AppState::new(UserRole::User);
+        terminal
+            .draw(|f| render_orders_tab(f, f.area(), &orders, 0, &app))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn orders_table_renders_premium_column() {
+        let buf = render_at_width(130, -3);
+        assert!(buffer_contains(&buf, "Premium"));
+        assert!(buffer_contains(&buf, "-3%"));
+        assert!(buffer_contains(&buf, "SEPA"));
     }
 }


### PR DESCRIPTION
## Summary

This PR makes the order premium visible before taking an offer.

- Adds a `Premium` column to the order list.
- Shows the premium in the **Take Order** confirmation popup.
- Preserves the existing popup dimensions by reusing the former separator row.
- Displays positive premiums as `+N%` in green, negative premiums as `-N%` in red, and zero as `0%` in gray.
- Centralizes premium formatting so the order list, Take Order popup, and Messages tab use the same presentation.

## Before and after

### Order list

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/11d5ef81-afa5-42b2-bea2-5b88963bbbff" alt="Order list without premium column" width="480" /> | <img src="https://github.com/user-attachments/assets/02d15b00-95c5-46c8-acf4-31651791195d" alt="Order list with premium column" width="480" /> |

### Take Order confirmation

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/4c2b1707-df91-40f0-9362-7314326d74b1" alt="Take Order confirmation without premium" width="480" /> | <img src="https://github.com/user-attachments/assets/410b1b80-a35f-4c0b-8356-43c26fced85c" alt="Take Order confirmation with premium" width="480" /> |

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --all-features`

All checks pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added premium information to order details and the orders table.
  - Premium values display explicit positive signs with color coding: green for positive, red for negative, and gray for zero.
  - Orders tables now adapt to narrow terminals with a compact layout.
  - Order details preserve key information and actions when terminal space is limited.

- **Bug Fixes**
  - Improved consistency of premium formatting across order screens.

- **Tests**
  - Added coverage for premium formatting and fixed, range, full-width, and compact order displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->