### PR TITLE
fix(ui): admin dispute actions targeted a hidden dispute after finalization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,6 @@ async fn apply_order_result(pool: &SqlitePool, app: &mut AppState, result: Opera
         match AdminDispute::get_all(pool).await {
             Ok(all_disputes) => {
                 app.admin_disputes_in_progress = all_disputes;
-                app.selected_in_progress_idx = 0;
                 log::info!(
                     "Refreshed admin disputes list: {} total disputes",
                     app.admin_disputes_in_progress.len()

--- a/src/models.rs
+++ b/src/models.rs
@@ -894,7 +894,6 @@ impl AdminDispute {
         let mut disputes = sqlx::query_as::<_, AdminDispute>(
             r#"SELECT * FROM admin_disputes ORDER BY taken_at DESC"#,
         )
-        .bind(DisputeStatus::InProgress.to_string())
         .fetch_all(pool)
         .await?;
 

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -162,10 +162,10 @@ pub struct AppState {
     pub active_tab: Tab,
     pub selected_order_idx: usize,
     pub selected_dispute_idx: usize, // Selected dispute in Disputes Pending tab
-    pub selected_in_progress_idx: usize, // Selected dispute in Disputes in Progress tab
-    pub active_chat_party: ChatParty, // Which party the admin is currently chatting with
-    pub admin_chat_input: String,    // Current message being typed by admin
-    pub admin_chat_input_enabled: bool, // Whether chat input is enabled (toggle with Shift+I)
+    pub selected_dispute_id: Option<String>, // Selected dispute (by dispute id) in Disputes in Progress tab
+    pub active_chat_party: ChatParty,        // Which party the admin is currently chatting with
+    pub admin_chat_input: String,            // Current message being typed by admin
+    pub admin_chat_input_enabled: bool,      // Whether chat input is enabled (toggle with Shift+I)
     pub admin_dispute_chats: HashMap<String, Vec<DisputeChatMessage>>, // Chat messages per dispute ID
     pub admin_chat_scrollview_state: tui_scrollview::ScrollViewState,
     /// Selected message index for chat navigation (Up/Down) and footer hint; Save Attachment popup uses its own selection.
@@ -270,7 +270,7 @@ impl AppState {
             active_tab: initial_tab,
             selected_order_idx: 0,
             selected_dispute_idx: 0,
-            selected_in_progress_idx: 0,
+            selected_dispute_id: None,
             active_chat_party: ChatParty::Buyer,
             admin_chat_input: String::new(),
             admin_chat_input_enabled: true, // Chat input enabled by default
@@ -358,7 +358,7 @@ impl AppState {
         self.mode = UiMode::default_for_role(new_role);
         self.selected_dispute_idx = 0;
         self.selected_settings_option = 0;
-        self.selected_in_progress_idx = 0;
+        self.selected_dispute_id = None;
         self.active_chat_party = ChatParty::Buyer;
         self.admin_chat_input.clear();
         self.offline_overlay_message = None;

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -303,10 +303,8 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
 fn help_content(app: &AppState, tab: Tab) -> (String, Vec<String>) {
     match tab {
         Tab::Admin(AdminTab::DisputesInProgress) => {
-            let is_finalized = app
-                .admin_disputes_in_progress
-                .get(app.selected_in_progress_idx)
-                .and_then(crate::ui::helpers::is_dispute_finalized)
+            let is_finalized = crate::ui::helpers::selected_filtered_dispute(app)
+                .and_then(|d| crate::ui::helpers::is_dispute_finalized(&d))
                 .unwrap_or(false);
             let filter_hint = match app.dispute_filter {
                 DisputeFilter::InProgress => FILTER_VIEW_FINALIZED,

--- a/src/ui/helpers/dispute_selection.rs
+++ b/src/ui/helpers/dispute_selection.rs
@@ -31,3 +31,44 @@ pub fn get_filtered_disputes(app: &AppState) -> Vec<(usize, AdminDispute)> {
         .map(|(i, d)| (i, d.clone()))
         .collect()
 }
+
+/// Display row of the current selection inside `filtered`.
+///
+/// Falls back to the first row when nothing is selected or the selected
+/// dispute is not visible under the current filter. Returns `None` only when
+/// the filtered list is empty.
+pub fn selected_display_idx(app: &AppState, filtered: &[(usize, AdminDispute)]) -> Option<usize> {
+    if filtered.is_empty() {
+        return None;
+    }
+    Some(
+        app.selected_dispute_id
+            .as_deref()
+            .and_then(|id| filtered.iter().position(|(_, d)| d.dispute_id == id))
+            .unwrap_or(0),
+    )
+}
+
+/// The dispute the sidebar currently shows as selected.
+///
+/// Resolves the stored dispute id against the filtered (visible) list, so key
+/// handlers always act on the dispute the UI highlights — never on rows hidden
+/// by the current filter.
+pub fn selected_filtered_dispute(app: &AppState) -> Option<AdminDispute> {
+    let mut filtered = get_filtered_disputes(app);
+    let idx = selected_display_idx(app, &filtered)?;
+    Some(filtered.swap_remove(idx).1)
+}
+
+/// Move the sidebar selection `delta` rows within the filtered list, clamping
+/// at both ends, and store the landing dispute's id as the new selection.
+pub fn move_dispute_selection(app: &mut AppState, delta: isize) {
+    let filtered = get_filtered_disputes(app);
+    let Some(idx) = selected_display_idx(app, &filtered) else {
+        return;
+    };
+    let new_idx = idx
+        .saturating_add_signed(delta)
+        .min(filtered.len().saturating_sub(1));
+    app.selected_dispute_id = Some(filtered[new_idx].1.dispute_id.clone());
+}

--- a/src/ui/helpers/dispute_selection.rs
+++ b/src/ui/helpers/dispute_selection.rs
@@ -1,0 +1,33 @@
+//! Admin dispute selection helpers shared by rendering and key handling.
+
+use std::str::FromStr;
+
+use mostro_core::prelude::DisputeStatus;
+
+use crate::models::AdminDispute;
+use crate::ui::{AppState, DisputeFilter};
+
+/// Filter disputes based on the current filter state.
+/// Returns owned data so the caller can mutate app (e.g. scroll state) in the same block.
+pub fn get_filtered_disputes(app: &AppState) -> Vec<(usize, AdminDispute)> {
+    app.admin_disputes_in_progress
+        .iter()
+        .enumerate()
+        .filter(|(_, d)| {
+            let status = d
+                .status
+                .as_deref()
+                .and_then(|s| DisputeStatus::from_str(s).ok());
+            match app.dispute_filter {
+                DisputeFilter::InProgress => status == Some(DisputeStatus::InProgress),
+                DisputeFilter::Finalized => matches!(
+                    status,
+                    Some(DisputeStatus::Settled)
+                        | Some(DisputeStatus::SellerRefunded)
+                        | Some(DisputeStatus::Released)
+                ),
+            }
+        })
+        .map(|(i, d)| (i, d.clone()))
+        .collect()
+}

--- a/src/ui/helpers/dispute_selection.rs
+++ b/src/ui/helpers/dispute_selection.rs
@@ -72,3 +72,162 @@ pub fn move_dispute_selection(app: &mut AppState, delta: isize) {
         .min(filtered.len().saturating_sub(1));
     app.selected_dispute_id = Some(filtered[new_idx].1.dispute_id.clone());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::UserRole;
+
+    fn dispute(id: &str, status: &str) -> AdminDispute {
+        AdminDispute {
+            dispute_id: id.to_string(),
+            status: Some(status.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn admin_app(disputes: Vec<AdminDispute>) -> AppState {
+        let mut app = AppState::new(UserRole::Admin);
+        app.admin_disputes_in_progress = disputes;
+        app
+    }
+
+    /// Regression for the wrong-dispute chat/finalization bug: with finalized
+    /// disputes sorted above in-progress ones (taken_at DESC), the resolved
+    /// selection must be the first *visible* dispute, never the hidden row at
+    /// raw index 0.
+    #[test]
+    fn resolves_first_visible_dispute_not_raw_index_zero() {
+        let app = admin_app(vec![
+            dispute("finalized-a", "seller-refunded"),
+            dispute("finalized-b", "seller-refunded"),
+            dispute("in-progress-c", "in-progress"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+
+        let filtered = get_filtered_disputes(&app);
+        let original_indices: Vec<usize> = filtered.iter().map(|(i, _)| *i).collect();
+        assert_eq!(
+            original_indices,
+            vec![2, 3],
+            "only in-progress rows visible"
+        );
+
+        let selected = selected_filtered_dispute(&app).expect("a dispute is selectable");
+        assert_eq!(selected.dispute_id, "in-progress-c");
+    }
+
+    /// Selection stored by id must keep resolving the same dispute after the
+    /// list is refreshed and re-ordered (e.g. a newly taken dispute lands at
+    /// the top).
+    #[test]
+    fn selection_by_id_survives_list_reorder() {
+        let mut app = admin_app(vec![
+            dispute("in-progress-c", "in-progress"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+        app.selected_dispute_id = Some("in-progress-d".to_string());
+
+        app.admin_disputes_in_progress = vec![
+            dispute("finalized-a", "seller-refunded"),
+            dispute("in-progress-new", "in-progress"),
+            dispute("in-progress-d", "in-progress"),
+            dispute("in-progress-c", "in-progress"),
+        ];
+
+        let selected = selected_filtered_dispute(&app).expect("selection resolves");
+        assert_eq!(selected.dispute_id, "in-progress-d");
+    }
+
+    /// When the selected dispute stops being visible under the current filter
+    /// (e.g. it was just finalized), resolution falls back to the first
+    /// visible row instead of a hidden one.
+    #[test]
+    fn hidden_selection_falls_back_to_first_visible() {
+        let mut app = admin_app(vec![
+            dispute("in-progress-c", "in-progress"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+        app.selected_dispute_id = Some("in-progress-c".to_string());
+
+        app.admin_disputes_in_progress[0] = dispute("in-progress-c", "seller-refunded");
+
+        let filtered = get_filtered_disputes(&app);
+        assert_eq!(selected_display_idx(&app, &filtered), Some(0));
+        let selected = selected_filtered_dispute(&app).expect("fallback resolves");
+        assert_eq!(selected.dispute_id, "in-progress-d");
+    }
+
+    /// The Finalized filter shows only settled/refunded/released disputes and
+    /// resolves the selection among them.
+    #[test]
+    fn finalized_filter_resolves_finalized_rows() {
+        let mut app = admin_app(vec![
+            dispute("finalized-a", "seller-refunded"),
+            dispute("in-progress-c", "in-progress"),
+            dispute("finalized-b", "settled"),
+        ]);
+        app.dispute_filter = DisputeFilter::Finalized;
+
+        let filtered = get_filtered_disputes(&app);
+        let ids: Vec<&str> = filtered
+            .iter()
+            .map(|(_, d)| d.dispute_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["finalized-a", "finalized-b"]);
+
+        let selected = selected_filtered_dispute(&app).expect("selection resolves");
+        assert_eq!(selected.dispute_id, "finalized-a");
+    }
+
+    /// Up/Down moves within the visible list only — hidden rows are skipped —
+    /// and clamps at both ends.
+    #[test]
+    fn move_selection_skips_hidden_rows_and_clamps() {
+        let mut app = admin_app(vec![
+            dispute("finalized-a", "seller-refunded"),
+            dispute("in-progress-c", "in-progress"),
+            dispute("finalized-b", "settled"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+
+        move_dispute_selection(&mut app, 1);
+        assert_eq!(app.selected_dispute_id.as_deref(), Some("in-progress-d"));
+
+        move_dispute_selection(&mut app, 1);
+        assert_eq!(
+            app.selected_dispute_id.as_deref(),
+            Some("in-progress-d"),
+            "clamped at the bottom of the visible list"
+        );
+
+        move_dispute_selection(&mut app, -1);
+        assert_eq!(app.selected_dispute_id.as_deref(), Some("in-progress-c"));
+
+        move_dispute_selection(&mut app, -1);
+        assert_eq!(
+            app.selected_dispute_id.as_deref(),
+            Some("in-progress-c"),
+            "clamped at the top of the visible list"
+        );
+    }
+
+    /// With nothing visible under the current filter there is no selection to
+    /// resolve, and navigation is a no-op.
+    #[test]
+    fn empty_filtered_list_yields_no_selection() {
+        let mut app = admin_app(vec![
+            dispute("finalized-a", "seller-refunded"),
+            dispute("finalized-b", "settled"),
+        ]);
+
+        assert!(selected_filtered_dispute(&app).is_none());
+        assert_eq!(
+            selected_display_idx(&app, &get_filtered_disputes(&app)),
+            None
+        );
+
+        move_dispute_selection(&mut app, 1);
+        assert_eq!(app.selected_dispute_id, None, "navigation stays a no-op");
+    }
+}

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -3,6 +3,7 @@ mod attachments;
 mod chat_render;
 mod chat_storage;
 mod chat_visibility;
+mod dispute_selection;
 mod formatting;
 mod layout;
 mod order_chat_projection;
@@ -27,6 +28,7 @@ pub use chat_visibility::{
     count_order_attachments, count_visible_attachments, get_order_attachment_messages,
     get_selected_chat_message, get_visible_attachment_messages, message_visible_for_party,
 };
+pub use dispute_selection::get_filtered_disputes;
 pub use formatting::{
     format_order_id, format_premium, format_user_rating, is_dispute_finalized,
     relative_time_compact, short_order_id,

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -28,7 +28,9 @@ pub use chat_visibility::{
     count_order_attachments, count_visible_attachments, get_order_attachment_messages,
     get_selected_chat_message, get_visible_attachment_messages, message_visible_for_party,
 };
-pub use dispute_selection::get_filtered_disputes;
+pub use dispute_selection::{
+    get_filtered_disputes, move_dispute_selection, selected_display_idx, selected_filtered_dispute,
+};
 pub use formatting::{
     format_order_id, format_premium, format_user_rating, is_dispute_finalized,
     relative_time_compact, short_order_id,

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -598,12 +598,12 @@ pub async fn apply_admin_chat_updates(
 
             if let Some(att) = &attachment {
                 app.attachment_toast = Some(build_attachment_toast(&att.filename));
-                if let Some(idx) = app
+                if app
                     .admin_disputes_in_progress
                     .iter()
-                    .position(|d| d.dispute_id == dispute_key)
+                    .any(|d| d.dispute_id == dispute_key)
                 {
-                    app.selected_in_progress_idx = idx;
+                    app.selected_dispute_id = Some(dispute_key.clone());
                     app.active_chat_party = party;
                 }
             }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1,7 +1,9 @@
 use crate::models::{Order, ORDER_HISTORY_BULK_DELETE_STATUSES};
 use crate::shared::permissions::SolverPermission;
 use crate::ui::admin_state::AddSolverState;
-use crate::ui::helpers::{build_active_order_chat_list, save_order_chat_message};
+use crate::ui::helpers::{
+    build_active_order_chat_list, save_order_chat_message, selected_filtered_dispute,
+};
 use crate::ui::key_handler::chat_helpers::{
     build_order_action_view_state, handle_enter_finalize_popup, message_counter,
     scroll_order_chat_after_send, FinalizeDisputePopupButton,
@@ -299,18 +301,16 @@ fn handle_enter_admin_managing_dispute_chat(app: &mut AppState, ctx: &super::Ent
             content,
         },
         |app| {
-            app.admin_disputes_in_progress
-                .get(app.selected_in_progress_idx)
-                .map(|selected_dispute| {
-                    let shared_key_hex = match app.active_chat_party {
-                        ChatParty::Buyer => selected_dispute.buyer_shared_key_hex.clone(),
-                        ChatParty::Seller => selected_dispute.seller_shared_key_hex.clone(),
-                    };
-                    DisputeChatTarget {
-                        dispute_id_key: selected_dispute.dispute_id.clone(),
-                        shared_key_hex,
-                    }
-                })
+            selected_filtered_dispute(app).map(|selected_dispute| {
+                let shared_key_hex = match app.active_chat_party {
+                    ChatParty::Buyer => selected_dispute.buyer_shared_key_hex.clone(),
+                    ChatParty::Seller => selected_dispute.seller_shared_key_hex.clone(),
+                };
+                DisputeChatTarget {
+                    dispute_id_key: selected_dispute.dispute_id.clone(),
+                    shared_key_hex,
+                }
+            })
         },
         |app, target, content| {
             prepare_admin_chat_message(&target.dispute_id_key, content, app);

--- a/src/ui/key_handler/input_helpers.rs
+++ b/src/ui/key_handler/input_helpers.rs
@@ -139,9 +139,10 @@ pub fn send_admin_chat_message_via_shared_key(
     let client = client.clone();
     let admin_keys = admin_keys.clone();
     let message_content = message_content.trim().to_string();
+    let dispute_id_key = dispute_id_key.to_string();
 
     tokio::spawn(async move {
-        if let Err(e) = crate::util::send_admin_chat_message_via_shared_key(
+        match crate::util::send_admin_chat_message_via_shared_key(
             &client,
             &admin_keys,
             &shared_keys,
@@ -150,7 +151,12 @@ pub fn send_admin_chat_message_via_shared_key(
         )
         .await
         {
-            log::error!("Failed to send admin chat message: {}", e);
+            Ok(()) => log::info!("Admin chat message sent for dispute {}", dispute_id_key),
+            Err(e) => log::error!(
+                "Failed to send admin chat message for dispute {}: {}",
+                dispute_id_key,
+                e
+            ),
         }
     });
 }

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -19,7 +19,7 @@ use crate::ui::key_handler::chat_helpers::{
 use crate::ui::{
     helpers::{
         active_order_chat_list_snapshot, get_order_attachment_messages,
-        get_visible_attachment_messages, is_dispute_finalized,
+        get_visible_attachment_messages, is_dispute_finalized, selected_filtered_dispute,
     },
     send_attachment_picker::{
         close_user_send_attachment_picker, explorer_selection_is_sendable_file,
@@ -520,10 +520,8 @@ pub fn handle_key_event(
 
     // Save attachment popup: Up/Down to select, Enter to save, Esc to cancel
     if matches!(app.mode, UiMode::SaveAttachmentPopup(_)) {
-        let dispute_id_key = app
-            .admin_disputes_in_progress
-            .get(app.selected_in_progress_idx)
-            .map(|d| d.dispute_id.clone());
+        let selected_dispute = selected_filtered_dispute(app);
+        let dispute_id_key = selected_dispute.as_ref().map(|d| d.dispute_id.clone());
         let list_len = dispute_id_key
             .as_ref()
             .map(|id| get_visible_attachment_messages(app, id).len())
@@ -556,8 +554,7 @@ pub fn handle_key_event(
             KeyCode::Enter => {
                 if let (Some(tx), Some(dispute), Some(id)) = (
                     save_attachment_tx,
-                    app.admin_disputes_in_progress
-                        .get(app.selected_in_progress_idx),
+                    selected_dispute.as_ref(),
                     dispute_id_key.as_ref(),
                 ) {
                     let list = get_visible_attachment_messages(app, id);
@@ -792,10 +789,7 @@ pub fn handle_key_event(
     if key_event.modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('s') {
         if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
             if matches!(app.mode, UiMode::AdminMode(AdminMode::ManagingDispute)) {
-                if let Some(dispute) = app
-                    .admin_disputes_in_progress
-                    .get(app.selected_in_progress_idx)
-                {
+                if let Some(dispute) = selected_filtered_dispute(app) {
                     let list = get_visible_attachment_messages(app, &dispute.dispute_id);
                     if !list.is_empty() {
                         app.mode = UiMode::SaveAttachmentPopup(0);
@@ -931,10 +925,7 @@ pub fn handle_key_event(
             // Only handle if we're in ManagingDispute mode
             if matches!(app.mode, UiMode::AdminMode(AdminMode::ManagingDispute)) {
                 // Open finalization popup if a dispute is selected
-                if let Some(selected_dispute) = app
-                    .admin_disputes_in_progress
-                    .get(app.selected_in_progress_idx)
-                {
+                if let Some(selected_dispute) = selected_filtered_dispute(app) {
                     if let Ok(dispute_id) = uuid::Uuid::parse_str(&selected_dispute.dispute_id) {
                         app.mode = UiMode::AdminMode(AdminMode::ReviewingDisputeForFinalization {
                             dispute_id,
@@ -956,8 +947,8 @@ pub fn handle_key_event(
                 DisputeFilter::InProgress => DisputeFilter::Finalized,
                 DisputeFilter::Finalized => DisputeFilter::InProgress,
             };
-            // Reset selection index when switching filters
-            app.selected_in_progress_idx = 0;
+            // Reset selection when switching filters
+            app.selected_dispute_id = None;
             return Some(true);
         }
 
@@ -1220,10 +1211,7 @@ pub fn handle_key_event(
             if matches!(app.mode, UiMode::AdminMode(AdminMode::ManagingDispute)) {
                 if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
                     if !app.admin_chat_input_enabled {
-                        let dispute_id_key = app
-                            .admin_disputes_in_progress
-                            .get(app.selected_in_progress_idx)
-                            .map(|d| d.dispute_id.clone());
+                        let dispute_id_key = selected_filtered_dispute(app).map(|d| d.dispute_id);
                         if let Some(dispute_id_key) = dispute_id_key {
                             if chat_helpers::navigate_chat_messages(app, &dispute_id_key, code) {
                                 return Some(true);
@@ -1255,10 +1243,7 @@ pub fn handle_key_event(
             // Handle chat scrolling in ManagingDispute mode using ListState
             if matches!(app.mode, UiMode::AdminMode(AdminMode::ManagingDispute)) {
                 if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
-                    let dispute_id_key = app
-                        .admin_disputes_in_progress
-                        .get(app.selected_in_progress_idx)
-                        .map(|d| d.dispute_id.clone());
+                    let dispute_id_key = selected_filtered_dispute(app).map(|d| d.dispute_id);
                     if let Some(dispute_id_key) = dispute_id_key {
                         if chat_helpers::scroll_chat_messages(app, &dispute_id_key, code) {
                             return Some(true);
@@ -1325,10 +1310,7 @@ pub fn handle_key_event(
             // Jump to bottom of chat (latest messages)
             if matches!(app.mode, UiMode::AdminMode(AdminMode::ManagingDispute)) {
                 if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
-                    let dispute_id_key = app
-                        .admin_disputes_in_progress
-                        .get(app.selected_in_progress_idx)
-                        .map(|d| d.dispute_id.clone());
+                    let dispute_id_key = selected_filtered_dispute(app).map(|d| d.dispute_id);
                     if let Some(dispute_id_key) = dispute_id_key {
                         if chat_helpers::jump_to_chat_bottom(app, &dispute_id_key) {
                             return Some(true);

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -1,4 +1,4 @@
-use crate::ui::helpers::active_order_chat_list_len;
+use crate::ui::helpers::{active_order_chat_list_len, move_dispute_selection};
 use crate::ui::orders::strip_new_order_messages_and_clamp_selected;
 use crate::ui::{
     AdminMode, AdminTab, AppState, FormState, Tab, UiMode, UserMode, UserRole, UserTab,
@@ -225,9 +225,7 @@ fn handle_up_key(
                         .min(initiated_count.saturating_sub(1));
                 }
             } else if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
-                if !app.admin_disputes_in_progress.is_empty() && app.selected_in_progress_idx > 0 {
-                    app.selected_in_progress_idx -= 1;
-                }
+                move_dispute_selection(app, -1);
             } else if let Tab::User(UserTab::Messages) = app.active_tab {
                 let mut messages = match app.messages.lock() {
                     Ok(g) => g,
@@ -375,12 +373,7 @@ fn handle_down_key(
                         .min(initiated_count.saturating_sub(1));
                 }
             } else if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
-                if !app.admin_disputes_in_progress.is_empty()
-                    && app.selected_in_progress_idx
-                        < app.admin_disputes_in_progress.len().saturating_sub(1)
-                {
-                    app.selected_in_progress_idx += 1;
-                }
+                move_dispute_selection(app, 1);
             } else if let Tab::User(UserTab::Messages) = app.active_tab {
                 let mut messages = match app.messages.lock() {
                     Ok(g) => g,
@@ -434,12 +427,7 @@ fn handle_down_key(
         UiMode::AdminMode(AdminMode::ManagingDispute) => {
             // Navigate within disputes in progress list
             if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
-                if !app.admin_disputes_in_progress.is_empty()
-                    && app.selected_in_progress_idx
-                        < app.admin_disputes_in_progress.len().saturating_sub(1)
-                {
-                    app.selected_in_progress_idx += 1;
-                }
+                move_dispute_selection(app, 1);
             }
         }
         UiMode::UserMode(UserMode::ConfirmingOrder { .. })

--- a/src/ui/save_attachment_popup.rs
+++ b/src/ui/save_attachment_popup.rs
@@ -6,7 +6,9 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use crate::ui::helpers::{get_order_attachment_messages, get_visible_attachment_messages};
+use crate::ui::helpers::{
+    get_order_attachment_messages, get_visible_attachment_messages, selected_filtered_dispute,
+};
 use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
 use super::chat::ChatAttachmentType;
@@ -18,13 +20,10 @@ const TITLE: &str = "📎 Save attachment";
 /// Renders the Save Attachment popup with a selectable list.
 /// `selected_idx` is the index into the visible attachment list (clamped inside).
 pub fn render_save_attachment_popup(f: &mut ratatui::Frame, app: &AppState, selected_idx: usize) {
-    let dispute_id_key = match app
-        .admin_disputes_in_progress
-        .get(app.selected_in_progress_idx)
-    {
-        Some(d) => d.dispute_id.as_str(),
-        None => return,
+    let Some(selected_dispute) = selected_filtered_dispute(app) else {
+        return;
     };
+    let dispute_id_key = selected_dispute.dispute_id.as_str();
 
     let list = get_visible_attachment_messages(app, dispute_id_key);
     if list.is_empty() {

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -1,7 +1,5 @@
 //! Admin disputes-in-progress UI. The Ctrl+H help overlay is styled in [`crate::ui::help_popup`].
 
-use std::str::FromStr;
-
 use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
@@ -12,11 +10,10 @@ use tui_scrollview::{ScrollView, ScrollbarVisibility};
 use crate::ui::constants::*;
 use crate::ui::helpers::{
     build_chat_scrollview_content, count_visible_attachments, format_user_rating,
-    get_selected_chat_message,
+    get_filtered_disputes, get_selected_chat_message,
 };
 use crate::ui::ChatParty;
 use crate::ui::{AdminMode, AppState, DisputeFilter, UiMode, BACKGROUND_COLOR, PRIMARY_COLOR};
-use mostro_core::prelude::*;
 
 fn should_auto_scroll_chat(
     tracker: Option<&(String, ChatParty, usize)>,
@@ -30,31 +27,6 @@ fn should_auto_scroll_chat(
             tracked_dispute != dispute_id || *tracked_party != party || visible_count > *last_count
         }
     }
-}
-
-/// Filter disputes based on the current filter state.
-/// Returns owned data so the caller can mutate app (e.g. scroll state) in the same block.
-fn get_filtered_disputes(app: &AppState) -> Vec<(usize, crate::models::AdminDispute)> {
-    app.admin_disputes_in_progress
-        .iter()
-        .enumerate()
-        .filter(|(_, d)| {
-            let status = d
-                .status
-                .as_deref()
-                .and_then(|s| DisputeStatus::from_str(s).ok());
-            match app.dispute_filter {
-                DisputeFilter::InProgress => status == Some(DisputeStatus::InProgress),
-                DisputeFilter::Finalized => matches!(
-                    status,
-                    Some(DisputeStatus::Settled)
-                        | Some(DisputeStatus::SellerRefunded)
-                        | Some(DisputeStatus::Released)
-                ),
-            }
-        })
-        .map(|(i, d)| (i, d.clone()))
-        .collect()
 }
 
 /// Render the "Disputes in Progress" tab for admin mode

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -45,14 +45,9 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
     // Filter disputes based on current filter
     let filtered_disputes = get_filtered_disputes(app);
 
-    // Ensure selected index is within bounds of filtered list
-    // Use a local variable to avoid borrow checker issues
-    let valid_selected_idx = if filtered_disputes.is_empty() {
-        0
-    } else {
-        app.selected_in_progress_idx
-            .min(filtered_disputes.len().saturating_sub(1))
-    };
+    // Resolve the selected dispute id to its display row in the filtered list
+    let valid_selected_idx =
+        crate::ui::helpers::selected_display_idx(app, &filtered_disputes).unwrap_or(0);
 
     // 1. Sidebar - Dispute List
     let sidebar_title = match app.dispute_filter {
@@ -806,9 +801,6 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                 }
             }
         }
-
-        // Update the selected index after rendering is complete (to avoid borrow checker issues)
-        app.selected_in_progress_idx = valid_selected_idx;
     } else {
         // No disputes available - show empty message with footer
         // Render the outer block first, then content inside it
@@ -851,9 +843,6 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         };
         let footer = Paragraph::new(footer_text);
         f.render_widget(footer, inner_chunks[1]);
-
-        // Reset index when no disputes are available
-        app.selected_in_progress_idx = 0;
     }
 }
 


### PR DESCRIPTION
## Problem

After finalizing recent disputes, admin chat messages stopped reaching users. The
messages were silently sent to the wrong dispute: they were encrypted with another
dispute's shared key, saved under that dispute's transcript, and never appeared in
the chat the admin was looking at.

## Root cause

The Disputes In Progress tab renders a **filtered** list (only InProgress, or only
Finalized with Shift+C), but the selection state (`selected_in_progress_idx`) was
applied by key handlers to the **unfiltered** list loaded from the database (all
statuses, ordered by `taken_at DESC`).

As soon as finalized disputes sorted above in-progress ones, display row N and raw
index N pointed at different disputes. Selecting the first visible dispute made
every action resolve the hidden finalized dispute at raw index 0 instead:

- chat messages were wrapped with the wrong dispute's shared key (the intended
  recipient could never receive them, and the wrong dispute's party could read them),
- the finalization popup (Shift+F) captured the wrong dispute id, so admin
  settle/cancel could have targeted the wrong dispute,
- attachment saving (Ctrl+S) and chat scrolling operated on the wrong dispute.

The list refresh also reset the selection to index 0 on every dispute event, so the
selection could silently retarget mid-chat.

## Fix

Selection is now stored as a **dispute id** (`selected_dispute_id: Option<String>`)
and resolved through shared helpers against the same filtered list the sidebar
renders, so key handlers can only ever act on the dispute the UI highlights:

- `selected_filtered_dispute` / `selected_display_idx` resolve the selection within
  the visible list, falling back to the first visible row when the stored id is
  hidden by the current filter;
- `move_dispute_selection` moves Up/Down across visible rows only, clamping at both
  ends;
- the selection survives list refreshes and re-ordering (no more reset to 0);
- attachment auto-select stores the dispute id directly.

Also includes cleanup: a leftover `.bind()` in `AdminDispute::get_all` (the query
has no placeholder), and the admin chat send task now logs the target dispute id on
success and failure so misdirected sends are diagnosable from `app.log`.

## Testing

- 6 new regression tests in `ui/helpers/dispute_selection.rs` covering: resolution
  with finalized rows sorted above in-progress ones, id selection surviving
  re-ordering, fallback when the selected dispute becomes hidden, the Finalized
  filter, navigation skipping hidden rows and clamping, and empty filtered lists.
- Full suite: 265 tests passing, clippy clean, `cargo fmt` applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected dispute when dispute lists refresh or are reordered.
  * Improved selection behavior when switching between in-progress and finalized disputes.
  * Ensured actions, chat, attachments, and finalization apply to the currently visible dispute.
  * Added safer navigation across filtered lists, including empty lists and boundary selections.
  * Corrected dispute refresh and attachment handling without losing the active selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->