### PR TITLE
Feat(ui): Add dispute action to my trades

### DIFF
--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -94,6 +94,7 @@ pub const HELP_MY_TRADES_SHIFT_I: &str = "Shift+I: Enable/disable message input"
 pub const HELP_MY_TRADES_SHIFT_C_CANCEL: &str = "Shift+C: Cancel order (cooperative cancel)";
 pub const HELP_MY_TRADES_SHIFT_F_FIAT_SENT: &str = "Shift+F: Mark fiat as sent (FiatSent message)";
 pub const HELP_MY_TRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats (Release message)";
+pub const HELP_MY_TRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Open dispute";
 pub const HELP_MY_TRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty (open rating popup)";
 pub const HELP_MY_TRADES_SHIFT_H_HELP: &str = "Shift+H: Show shortcuts help";
 pub const HELP_MY_TRADES_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment (choose from list)";
@@ -108,6 +109,8 @@ pub const HELP_MY_TRADES_FIAT_SENT_MSG: &str =
     "Confirm fiat sent for this order? This sends a FiatSent message.";
 pub const HELP_MY_TRADES_RELEASE_MSG: &str =
     "Release sats for this order? This sends a Release message.";
+pub const HELP_MY_TRADES_DISPUTE_MSG: &str =
+    "Open a dispute for this order? This sends a Dispute message to Mostro.";
 
 /// Multi-line body for Messages-tab confirmation when Mostro reports hold invoice paid (`HoldInvoicePaymentAccepted`).
 /// Last line matches [`HELP_MY_TRADES_CANCEL_MSG`] (cooperative cancel).
@@ -170,6 +173,7 @@ pub const FOOTER_MYTRADES_SHIFT_I_ENABLE: &str = "Shift+I: Enable input";
 pub const FOOTER_MYTRADES_SHIFT_C_CANCEL: &str = "Shift+C: Cancel order";
 pub const FOOTER_MYTRADES_SHIFT_F_FIAT_SENT: &str = "Shift+F: Mark fiat sent";
 pub const FOOTER_MYTRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats";
+pub const FOOTER_MYTRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Dispute";
 pub const FOOTER_MYTRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty";
 pub const FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT: &str = "PgUp/PgDn: Scroll chat";
 pub const FOOTER_MYTRADES_END_BOTTOM: &str = "End: Bottom";

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -371,6 +371,7 @@ fn help_content(app: &AppState, tab: Tab) -> (String, Vec<String>) {
                 HELP_MY_TRADES_ENTER_SEND.to_string(),
                 HELP_MY_TRADES_SHIFT_I.to_string(),
                 HELP_MY_TRADES_SHIFT_C_CANCEL.to_string(),
+                HELP_MY_TRADES_SHIFT_D_DISPUTE.to_string(),
                 HELP_MY_TRADES_SHIFT_F_FIAT_SENT.to_string(),
                 HELP_MY_TRADES_SHIFT_R_RELEASE.to_string(),
                 HELP_MY_TRADES_SHIFT_V_RATE.to_string(),

--- a/src/ui/key_handler/message_handlers.rs
+++ b/src/ui/key_handler/message_handlers.rs
@@ -216,8 +216,10 @@ pub fn handle_enter_viewing_message(
         Action::BuyerTookOrder => Action::Cancel,
         Action::FiatSentOk => Action::Release,
         Action::CooperativeCancelInitiatedByPeer => Action::Cancel,
-        // For Shift+C/F/R confirmations, the action is already the one we want to send.
-        Action::Cancel | Action::FiatSent | Action::Release => view_state.action.clone(),
+        // For My Trades confirmations, the action is already the one we want to send.
+        Action::Cancel | Action::FiatSent | Action::Release | Action::Dispute => {
+            view_state.action.clone()
+        }
         _ => {
             // This view is sometimes used as a generic "view message" popup; if the message
             // doesn't map to a sendable action, just dismiss without error.
@@ -288,6 +290,8 @@ pub fn handle_enter_viewing_message(
                     }
                 } else if sent_cooperative_cancel_request {
                     OperationResult::Info("Cooperative cancel request sent.".to_string())
+                } else if source_action == Action::Dispute {
+                    OperationResult::Info("Dispute opened.".to_string())
                 } else {
                     OperationResult::Info("Message sent successfully".to_string())
                 };

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -1060,6 +1060,12 @@ pub fn handle_key_event(
                     }
                 }
                 KeyCode::Char('d') | KeyCode::Char('D') => {
+                    if !matches!(
+                        app.mode,
+                        UiMode::Normal | UiMode::UserMode(UserMode::Normal)
+                    ) {
+                        return Some(true);
+                    }
                     if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
                         if is_terminal_order_status(status) {
                             app.mode = UiMode::operation_result(OperationResult::Info(

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -147,7 +147,7 @@ fn handle_user_order_chat_input(
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::SHIFT);
             if has_shift {
-                // Let Shift+I/C/F/R/V/H be handled by shortcut logic
+                // Let Shift+I/C/F/R/D/V/H be handled by shortcut logic
                 if matches!(
                     code,
                     KeyCode::Char('i')
@@ -158,6 +158,8 @@ fn handle_user_order_chat_input(
                         | KeyCode::Char('F')
                         | KeyCode::Char('r')
                         | KeyCode::Char('R')
+                        | KeyCode::Char('d')
+                        | KeyCode::Char('D')
                         | KeyCode::Char('v')
                         | KeyCode::Char('V')
                         | KeyCode::Char('h')
@@ -1051,6 +1053,24 @@ pub fn handle_key_event(
                         let view_state = build_order_action_view_state(
                             order_id,
                             Action::Release,
+                            msg.to_string(),
+                        );
+                        app.mode = UiMode::ViewingMessage(view_state);
+                        return Some(true);
+                    }
+                }
+                KeyCode::Char('d') | KeyCode::Char('D') => {
+                    if let Some((order_id, status)) = resolve_selected_mytrades_order_status(app) {
+                        if is_terminal_order_status(status) {
+                            app.mode = UiMode::operation_result(OperationResult::Info(
+                                "Dispute is disabled for terminal orders.".to_string(),
+                            ));
+                            return Some(true);
+                        }
+                        let msg = crate::ui::constants::HELP_MY_TRADES_DISPUTE_MSG;
+                        let view_state = build_order_action_view_state(
+                            order_id,
+                            Action::Dispute,
                             msg.to_string(),
                         );
                         app.mode = UiMode::ViewingMessage(view_state);

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -148,6 +148,152 @@ fn build_order_chat_content(
     (lines, content_width.max(1), starts)
 }
 
+fn order_footer_lines(
+    footer_width: u16,
+    hint_lines: u16,
+    input_enabled: bool,
+    attach_hints: &str,
+) -> Vec<String> {
+    if footer_width < 50 {
+        return vec![format!("{HELP_KEY} | Shift+C Cancel | Shift+D Dispute")];
+    }
+
+    if footer_width < 96 {
+        let input_hint = if input_enabled {
+            "Shift+I"
+        } else {
+            "Shift+I Enable"
+        };
+        if hint_lines >= 3 {
+            return vec![
+                format!("Ctrl+H | Up/Down | Enter | {input_hint}"),
+                "Shift+C Cancel | Shift+D Dispute".to_string(),
+                "Shift+F Fiat | Shift+R Release | Shift+V Rate".to_string(),
+            ];
+        }
+        if hint_lines >= 2 {
+            return vec![
+                format!("Ctrl+H | Up/Down | Enter | {input_hint}"),
+                "Shift+C Cancel | Shift+D Dispute".to_string(),
+            ];
+        }
+        return vec![format!("Ctrl+H | Shift+C Cancel | Shift+D Dispute")];
+    }
+
+    if hint_lines >= 3 {
+        if input_enabled {
+            vec![
+                format!(
+                    "{} | {} | {} | {}",
+                    HELP_KEY,
+                    FOOTER_MYTRADES_SELECT_ORDER,
+                    FOOTER_MYTRADES_ENTER_SEND,
+                    FOOTER_MYTRADES_SHIFT_I_DISABLE,
+                ),
+                format!(
+                    "{} | {} | {} | {}",
+                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
+                ),
+                format!(
+                    "{} | {} | {}{}",
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
+                    FOOTER_MYTRADES_SHIFT_V_RATE,
+                    attach_hints,
+                ),
+            ]
+        } else {
+            vec![
+                format!(
+                    "{} | {} | {}",
+                    HELP_KEY, FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_I_ENABLE,
+                ),
+                format!(
+                    "{} | {} | {} | {}",
+                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
+                ),
+                format!(
+                    "{} | {} | {}{}",
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
+                    FOOTER_MYTRADES_SHIFT_V_RATE,
+                    attach_hints,
+                ),
+            ]
+        }
+    } else if hint_lines >= 2 {
+        if input_enabled {
+            vec![
+                format!(
+                    "{} | {} | {} | {} | {} | {}",
+                    HELP_KEY,
+                    FOOTER_MYTRADES_SELECT_ORDER,
+                    FOOTER_MYTRADES_ENTER_SEND,
+                    FOOTER_MYTRADES_SHIFT_I_DISABLE,
+                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+                ),
+                format!(
+                    "{} | {} | {} | {} | {}{}",
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
+                    FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
+                    attach_hints,
+                ),
+            ]
+        } else {
+            vec![
+                format!(
+                    "{} | {} | {} | {} | {}",
+                    HELP_KEY,
+                    FOOTER_MYTRADES_SELECT_ORDER,
+                    FOOTER_MYTRADES_SHIFT_I_ENABLE,
+                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+                ),
+                format!(
+                    "{} | {} | {} | {} | {}{}",
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
+                    FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
+                    attach_hints,
+                ),
+            ]
+        }
+    } else if input_enabled {
+        vec![format!(
+            "{} | {} | {} | {} | {} | {}{}",
+            HELP_KEY,
+            FOOTER_MYTRADES_SELECT_ORDER,
+            FOOTER_MYTRADES_ENTER_SEND,
+            FOOTER_MYTRADES_SHIFT_I_DISABLE,
+            FOOTER_MYTRADES_SHIFT_C_CANCEL,
+            FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+            attach_hints,
+        )]
+    } else {
+        vec![format!(
+            "{} | {} | {} | {} | {}{}",
+            HELP_KEY,
+            FOOTER_MYTRADES_SELECT_ORDER,
+            FOOTER_MYTRADES_SHIFT_I_ENABLE,
+            FOOTER_MYTRADES_SHIFT_C_CANCEL,
+            FOOTER_MYTRADES_SHIFT_D_DISPUTE,
+            attach_hints,
+        )]
+    }
+}
+
 pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut AppState) {
     let active_orders = active_order_chat_list_snapshot(app);
 
@@ -521,121 +667,17 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     let has_toast = app.attachment_toast.is_some();
     let hint_lines = base_footer_lines;
 
-    let footer_body: Text<'static> = if footer_width < 50 {
-        Text::raw(format!("{HELP_KEY}{attach_hints}"))
-    } else if hint_lines >= 3 {
-        if app.order_chat_input_enabled {
-            Text::from(vec![
-                Line::from(format!(
-                    "{} | {} | {} | {}",
-                    HELP_KEY,
-                    FOOTER_MYTRADES_SELECT_ORDER,
-                    FOOTER_MYTRADES_ENTER_SEND,
-                    FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {} | {}",
-                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {}{}",
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
-                    FOOTER_MYTRADES_SHIFT_V_RATE,
-                    attach_hints,
-                )),
-            ])
-        } else {
-            Text::from(vec![
-                Line::from(format!(
-                    "{} | {} | {}",
-                    HELP_KEY, FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_I_ENABLE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {} | {}",
-                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {}{}",
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
-                    FOOTER_MYTRADES_SHIFT_V_RATE,
-                    attach_hints,
-                )),
-            ])
-        }
-    } else if hint_lines >= 2 {
-        if app.order_chat_input_enabled {
-            Text::from(vec![
-                Line::from(format!(
-                    "{} | {} | {} | {} | {} | {}",
-                    HELP_KEY,
-                    FOOTER_MYTRADES_SELECT_ORDER,
-                    FOOTER_MYTRADES_ENTER_SEND,
-                    FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {} | {} | {}{}",
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
-                    FOOTER_MYTRADES_SHIFT_V_RATE,
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
-                    attach_hints,
-                )),
-            ])
-        } else {
-            Text::from(vec![
-                Line::from(format!(
-                    "{} | {} | {} | {} | {}",
-                    HELP_KEY,
-                    FOOTER_MYTRADES_SELECT_ORDER,
-                    FOOTER_MYTRADES_SHIFT_I_ENABLE,
-                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
-                )),
-                Line::from(format!(
-                    "{} | {} | {} | {} | {}{}",
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_SHIFT_R_RELEASE,
-                    FOOTER_MYTRADES_SHIFT_V_RATE,
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
-                    attach_hints,
-                )),
-            ])
-        }
-    } else {
-        let base = if app.order_chat_input_enabled {
-            format!(
-                "{} | {} | {} | {} | {} | {}",
-                HELP_KEY,
-                FOOTER_MYTRADES_SELECT_ORDER,
-                FOOTER_MYTRADES_ENTER_SEND,
-                FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                FOOTER_MYTRADES_SHIFT_D_DISPUTE
-            )
-        } else {
-            format!(
-                "{} | {} | {} | {} | {}",
-                HELP_KEY,
-                FOOTER_MYTRADES_SELECT_ORDER,
-                FOOTER_MYTRADES_SHIFT_I_ENABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                FOOTER_MYTRADES_SHIFT_D_DISPUTE
-            )
-        };
-        Text::raw(format!("{base}{attach_hints}"))
-    };
+    let footer_body: Text<'static> = Text::from(
+        order_footer_lines(
+            footer_width,
+            hint_lines,
+            app.order_chat_input_enabled,
+            attach_hints,
+        )
+        .into_iter()
+        .map(Line::from)
+        .collect::<Vec<_>>(),
+    );
 
     if has_toast {
         let chunks = Layout::new(
@@ -681,4 +723,36 @@ pub fn push_local_order_chat_message(
         .or_default()
         .push(msg.clone());
     msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::order_footer_lines;
+    use ratatui::text::Span;
+
+    fn assert_footer_lines_fit(width: u16, hint_lines: u16) {
+        let lines = order_footer_lines(width, hint_lines, true, "");
+        assert!(lines.len() <= hint_lines as usize);
+        assert!(lines
+            .iter()
+            .any(|line| line.contains("Shift+C") && line.contains("Shift+D")));
+        for line in lines {
+            assert!(
+                Span::raw(line.as_str()).width() <= width as usize,
+                "footer line exceeds width {width}: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn compact_footer_lines_fit_narrow_terminals() {
+        assert_footer_lines_fit(50, 3);
+        assert_footer_lines_fit(60, 2);
+        assert_footer_lines_fit(80, 3);
+    }
+
+    #[test]
+    fn compact_footer_keeps_cancel_and_dispute_visible_when_short() {
+        assert_footer_lines_fit(50, 1);
+    }
 }

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::ui::constants::{
     FOOTER_CTRL_O_SEND_FILE, FOOTER_CTRL_SHIFT_O_RETRY, FOOTER_CTRL_S_SAVE_FILE,
     FOOTER_MYTRADES_END_BOTTOM, FOOTER_MYTRADES_ENTER_SEND, FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-    FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_C_CANCEL,
+    FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_C_CANCEL, FOOTER_MYTRADES_SHIFT_D_DISPUTE,
     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT, FOOTER_MYTRADES_SHIFT_I_DISABLE,
     FOOTER_MYTRADES_SHIFT_I_ENABLE, FOOTER_MYTRADES_SHIFT_R_RELEASE, FOOTER_MYTRADES_SHIFT_V_RATE,
     FOOTER_SENDING_ATTACHMENT, HELP_KEY,
@@ -534,8 +534,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SHIFT_I_DISABLE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}",
+                    "{} | {} | {} | {}",
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
@@ -554,8 +555,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     HELP_KEY, FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_I_ENABLE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}",
+                    "{} | {} | {} | {}",
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
@@ -572,20 +574,21 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         if app.order_chat_input_enabled {
             Text::from(vec![
                 Line::from(format!(
-                    "{} | {} | {} | {} | {}",
+                    "{} | {} | {} | {} | {} | {}",
                     HELP_KEY,
                     FOOTER_MYTRADES_SELECT_ORDER,
                     FOOTER_MYTRADES_ENTER_SEND,
                     FOOTER_MYTRADES_SHIFT_I_DISABLE,
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                 )),
                 Line::from(format!(
                     "{} | {} | {} | {} | {}{}",
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
                     attach_hints,
                 )),
             ])
@@ -597,14 +600,15 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SELECT_ORDER,
                     FOOTER_MYTRADES_SHIFT_I_ENABLE,
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {} | {}{}",
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
+                    "{} | {} | {} | {} | {}{}",
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
+                    FOOTER_MYTRADES_END_BOTTOM,
                     attach_hints,
                 )),
             ])
@@ -612,20 +616,22 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     } else {
         let base = if app.order_chat_input_enabled {
             format!(
-                "{} | {} | {} | {} | {}",
+                "{} | {} | {} | {} | {} | {}",
                 HELP_KEY,
                 FOOTER_MYTRADES_SELECT_ORDER,
                 FOOTER_MYTRADES_ENTER_SEND,
                 FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL
+                FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                FOOTER_MYTRADES_SHIFT_D_DISPUTE
             )
         } else {
             format!(
-                "{} | {} | {} | {}",
+                "{} | {} | {} | {} | {}",
                 HELP_KEY,
                 FOOTER_MYTRADES_SELECT_ORDER,
                 FOOTER_MYTRADES_SHIFT_I_ENABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL
+                FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                FOOTER_MYTRADES_SHIFT_D_DISPUTE
             )
         };
         Text::raw(format!("{base}{attach_hints}"))

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -115,6 +115,7 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             | Action::Cancel
             | Action::FiatSent
             | Action::Release
+            | Action::Dispute
     );
 
     let hold_invoice_trinary = matches!(view_state.action, Action::HoldInvoicePaymentAccepted)

--- a/src/ui/tabs/tab_content.rs
+++ b/src/ui/tabs/tab_content.rs
@@ -101,6 +101,38 @@ pub fn render_exit_tab(f: &mut ratatui::Frame, area: Rect) {
     render_centered_lines(f, inner_area, &line_refs, style_exit_logo_line);
 }
 
+fn wrapped_message_line_count(content: &str, width: u16) -> u16 {
+    let max_width = width.max(1) as usize;
+    let mut total = 0u16;
+
+    for source_line in content.lines() {
+        if source_line.is_empty() {
+            total = total.saturating_add(1);
+            continue;
+        }
+
+        let mut current_width = 0usize;
+        for word in source_line.split_whitespace() {
+            let word_width = Span::raw(word).width();
+            let space_width = usize::from(current_width > 0);
+            if current_width > 0 && current_width + space_width + word_width > max_width {
+                total = total.saturating_add(1);
+                current_width = word_width;
+            } else {
+                current_width += space_width + word_width;
+            }
+
+            while current_width > max_width {
+                total = total.saturating_add(1);
+                current_width = current_width.saturating_sub(max_width);
+            }
+        }
+        total = total.saturating_add(1);
+    }
+
+    total.max(1)
+}
+
 pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState) {
     let area = f.area();
     let popup_width = area.width.saturating_sub(area.width / 4);
@@ -124,12 +156,12 @@ pub fn render_message_view(f: &mut ratatui::Frame, view_state: &MessageViewState
             ViewingMessageButtonSelection::Three(_)
         );
 
-    // Multiline body: hold-invoice trinary, or `BuyerTookOrder` (CANCEL / NO for cooperative cancel).
-    let multiline_message_body =
-        hold_invoice_trinary || matches!(view_state.action, Action::BuyerTookOrder);
+    // Multiline body: previews with enough text to require wrapping on normal terminals.
+    let multiline_message_body = hold_invoice_trinary
+        || matches!(view_state.action, Action::BuyerTookOrder | Action::Dispute);
 
     let content_line_count = if multiline_message_body {
-        view_state.message_content.lines().count().max(1) as u16
+        wrapped_message_line_count(&view_state.message_content, popup_width.saturating_sub(4))
     } else {
         0
     };
@@ -437,4 +469,59 @@ pub fn render_rating_order(f: &mut ratatui::Frame, state: &RatingOrderState) {
         .alignment(ratatui::layout::Alignment::Center),
         chunks[4],
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_message_view;
+    use crate::ui::constants::HELP_MY_TRADES_DISPUTE_MSG;
+    use crate::ui::{MessageViewState, ViewingMessageButtonSelection};
+    use mostro_core::prelude::Action;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use uuid::Uuid;
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        buffer_text(buf).contains(needle)
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        let mut flat = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                flat.push_str(buf[(x, y)].symbol());
+            }
+            flat.push('\n');
+        }
+        flat
+    }
+
+    #[test]
+    fn dispute_confirmation_wraps_complete_message() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let view_state = MessageViewState {
+            message_content: HELP_MY_TRADES_DISPUTE_MSG.to_string(),
+            order_id: Some(Uuid::nil()),
+            action: Action::Dispute,
+            button_selection: ViewingMessageButtonSelection::Two { yes_selected: true },
+        };
+
+        terminal
+            .draw(|frame| render_message_view(frame, &view_state))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+
+        let rendered = buffer_text(buffer);
+        assert!(
+            rendered.contains("Open a dispute for this order?"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("This sends"), "{rendered}");
+        assert!(rendered.contains("Dispute"), "{rendered}");
+        assert!(rendered.contains("message to Mostro."), "{rendered}");
+        assert!(rendered.contains("Mostro."), "{rendered}");
+        assert!(buffer_contains(buffer, "YES"));
+        assert!(buffer_contains(buffer, "NO"));
+    }
 }

--- a/src/util/order_utils/execute_send_msg.rs
+++ b/src/util/order_utils/execute_send_msg.rs
@@ -141,6 +141,13 @@ pub async fn execute_send_msg(
                 inner_message.action
             )),
         },
+        Action::Dispute => match inner_message.action {
+            Action::DisputeInitiatedByYou | Action::DisputeInitiatedByPeer => Ok(()),
+            _ => Err(anyhow::anyhow!(
+                "Unexpected action in response: {:?}",
+                inner_message.action
+            )),
+        },
         _ => Err(anyhow::anyhow!("Unsupported action: {:?}", action)),
     }
 }


### PR DESCRIPTION
  ## Summary

  This PR adds a user-side option to open a dispute from the My Trades order chat.

  - Adds `Shift+D` as a My Trades shortcut to open a dispute.
  - Places the dispute shortcut next to the cooperative cancel shortcut in the footer and help popup.
  - Shows a confirmation popup before sending the dispute request.
  - Sends `Action::Dispute` through the existing order message path.
  - Accepts `DisputeInitiatedByYou` and `DisputeInitiatedByPeer` as successful Mostro responses.
  - Keeps compact footer behavior unchanged for narrow and short terminals.

  ## Testing

  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test --all-features`
  - `cargo build --all-features`

  All checks pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shift+D shortcut in My Trades to initiate disputes for eligible orders.
  * Added a confirmation prompt with YES/NO controls before opening a dispute.
  * Added dispute guidance and shortcut hints in help and footer areas.
  * Added clear notifications when a dispute is opened.

* **Bug Fixes**
  * Terminal orders now show an informational message instead of starting an unavailable dispute flow.
  * Improved handling of dispute responses in trade conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->