### PR TITLE
fix: persist orders table state for smooth scrolling

### DIFF
--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use mostro_core::prelude::{Action, Transport};
 use zeroize::{Zeroize, Zeroizing};
+use ratatui::widgets::TableState;
 
 use crate::models::AdminDispute;
 use crate::ui::admin_state::AdminMode;
@@ -164,6 +165,8 @@ pub struct AppState {
     /// book projection (`helpers/order_selection.rs`). Not a raw index into the
     /// unfiltered in-memory order vec — highlight, ↑↓, and Enter share this id.
     pub selected_order_id: Option<uuid::Uuid>,
+    /// Persistent scroll state for the Orders tab table
+    pub orders_table_state: TableState,
     pub selected_dispute_idx: usize, // Selected dispute in Disputes Pending tab
     /// Disputes In Progress / Finalized selection is by **dispute id**, not a raw
     /// index into `admin_disputes_in_progress` (see `helpers/dispute_selection.rs`).
@@ -274,6 +277,7 @@ impl AppState {
             user_role,
             active_tab: initial_tab,
             selected_order_id: None,
+            orders_table_state: TableState::default(),
             selected_dispute_idx: 0,
             selected_dispute_id: None,
             active_chat_party: ChatParty::Buyer,

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -7,7 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-    ScrollbarState, Table, TableState,
+    ScrollbarState, Table,
 };
 
 use crate::ui::helpers::{format_premium, get_filtered_book_orders, selected_book_display_idx};
@@ -22,7 +22,7 @@ pub fn render_orders_tab(
     f: &mut ratatui::Frame,
     area: Rect,
     orders: &Arc<Mutex<Vec<SmallOrder>>>,
-    app: &AppState,
+    app: &mut AppState,
 ) {
     let orders_lock = match orders.lock() {
         Ok(g) => g,
@@ -222,8 +222,8 @@ pub fn render_orders_tab(
                 .style(Style::default().bg(BACKGROUND_COLOR)),
         );
 
-    let mut table_state = TableState::default().with_selected(Some(display_selected_idx));
-    f.render_stateful_widget(table, area, &mut table_state);
+    app.orders_table_state.select(Some(display_selected_idx));
+    f.render_stateful_widget(table, area, &mut app.orders_table_state);
 
     // Header + borders consume 3 rows; remaining height is the scrollable body.
     let visible_rows = area.height.saturating_sub(3) as usize;
@@ -279,9 +279,9 @@ mod tests {
         let backend = TestBackend::new(width, 6);
         let mut terminal = Terminal::new(backend).unwrap();
         let orders = Arc::new(Mutex::new(vec![sample_order("SEPA", premium)]));
-        let app = AppState::new(UserRole::User);
+        let mut app = AppState::new(UserRole::User);
         terminal
-            .draw(|f| render_orders_tab(f, f.area(), &orders, &app))
+            .draw(|f| render_orders_tab(f, f.area(), &orders, &mut app))
             .unwrap();
         terminal.backend().buffer().clone()
     }
@@ -322,7 +322,7 @@ mod tests {
         let backend = TestBackend::new(130, 10);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| render_orders_tab(f, f.area(), &orders, &app))
+            .draw(|f| render_orders_tab(f, f.area(), &orders, &mut app))
             .unwrap();
 
         let buf = terminal.backend().buffer();
@@ -353,7 +353,7 @@ mod tests {
         let backend = TestBackend::new(130, 10);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| render_orders_tab(f, f.area(), &orders, &app))
+            .draw(|f| render_orders_tab(f, f.area(), &orders, &mut app))
             .unwrap();
 
         let buf = terminal.backend().buffer();
@@ -400,7 +400,7 @@ mod tests {
         let backend = TestBackend::new(130, 8);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| render_orders_tab(f, f.area(), &orders, &app))
+            .draw(|f| render_orders_tab(f, f.area(), &orders, &mut app))
             .unwrap();
 
         let buf = terminal.backend().buffer();


### PR DESCRIPTION
## Summary

This PR fixes the Orders tab table scroll behavior when navigating upwards through the list.

* Persists the `TableState` inside `AppState` to prevent Ratatui from resetting the viewport offset on every frame.
* Ensures the viewport smoothly follows the cursor when scrolling up a long order book.
* Updates `render_orders_tab` to use a mutable `AppState` reference.
* Fixes the corresponding unit tests to reflect the new mutable signature.

## Testing

* `cargo check --all-targets --all-features`
* `cargo test --all-features`
* `cargo clippy --all-targets --all-features -- -D warnings`

All checks passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection handling in the Orders table so the selected row is maintained consistently while navigating the interface.
  * Updated table state management to preserve the current selection during screen updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->