### PR TITLE
Fix(ui): Display timestamps in local time

### DIFF
--- a/src/ui/dispute_finalization_popup.rs
+++ b/src/ui/dispute_finalization_popup.rs
@@ -1,4 +1,3 @@
-use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -6,7 +5,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use super::dispute_bond_slash_popup;
 use super::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
-use crate::ui::helpers::{format_user_rating, is_dispute_finalized};
+use crate::ui::helpers::{format_local_timestamp, format_user_rating, is_dispute_finalized};
 use crate::util::order_utils::BondSlashChoice;
 
 /// Render the dispute finalization popup with full dispute details and action buttons
@@ -206,14 +205,10 @@ fn render_dispute_details(
     let seller_pubkey_display = truncate_pubkey(seller_pubkey);
 
     // Format timestamps
-    let created_date = DateTime::from_timestamp(dispute.created_at, 0);
-    let created_str = created_date
-        .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
+    let created_str = format_local_timestamp(dispute.created_at, "%Y-%m-%d %H:%M:%S")
         .unwrap_or_else(|| "Unknown".to_string());
 
-    let taken_date = DateTime::from_timestamp(dispute.taken_at, 0);
-    let taken_str = taken_date
-        .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
+    let taken_str = format_local_timestamp(dispute.taken_at, "%Y-%m-%d %H:%M:%S")
         .unwrap_or_else(|| "Unknown".to_string());
 
     // Privacy indicators (Yes = private mode enabled, No = public mode)

--- a/src/ui/helpers/chat_render.rs
+++ b/src/ui/helpers/chat_render.rs
@@ -1,8 +1,8 @@
-use chrono::DateTime;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::ListItem;
 
+use crate::ui::helpers::format_local_timestamp;
 use crate::ui::{ChatParty, ChatSender, DisputeChatMessage};
 
 use super::chat_visibility::message_visible_for_party;
@@ -59,13 +59,10 @@ fn format_message_lines(
     msg: &DisputeChatMessage,
     max_content_width: Option<u16>,
 ) -> Vec<Line<'static>> {
-    let (date_str, time_str) = DateTime::from_timestamp(msg.timestamp, 0)
-        .map(|dt| {
-            let date = dt.format("%d-%m-%Y").to_string();
-            let time = dt.format("%H:%M").to_string();
-            (date, time)
-        })
-        .unwrap_or_else(|| ("??-??-????".to_string(), "??:??".to_string()));
+    let date_str = format_local_timestamp(msg.timestamp, "%d-%m-%Y")
+        .unwrap_or_else(|| "??-??-????".to_string());
+    let time_str =
+        format_local_timestamp(msg.timestamp, "%H:%M").unwrap_or_else(|| "??:??".to_string());
 
     let (sender_label, sender_color, is_right_aligned) = match msg.sender {
         ChatSender::Admin => ("Admin", Color::Cyan, false),

--- a/src/ui/helpers/formatting.rs
+++ b/src/ui/helpers/formatting.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, Local, Utc};
 use mostro_core::prelude::UserInfo;
 use ratatui::style::Color;
 
@@ -55,6 +55,13 @@ pub fn short_order_id(order_id: Option<uuid::Uuid>) -> String {
     order_id
         .map(|id| id.to_string().chars().take(8).collect::<String>())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Formats a Unix timestamp for display in the user's local timezone.
+#[must_use]
+pub fn format_local_timestamp(timestamp: i64, format: &str) -> Option<String> {
+    DateTime::from_timestamp(timestamp, 0)
+        .map(|dt| dt.with_timezone(&Local).format(format).to_string())
 }
 
 /// Compact relative-time label for list rows (e.g. `"3m ago"`, `"2d ago"`), as opposed to the
@@ -139,6 +146,31 @@ mod relative_time_tests {
     #[test]
     fn future_timestamp_clamps_to_just_now() {
         assert_eq!(relative_time_compact_from(2_000, 1_000), "just now");
+    }
+}
+
+#[cfg(test)]
+mod local_timestamp_tests {
+    use super::*;
+
+    #[test]
+    fn formats_valid_timestamp_with_requested_pattern() {
+        let timestamp = 1_700_000_000;
+        let expected = DateTime::from_timestamp(timestamp, 0)
+            .unwrap()
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string();
+
+        assert_eq!(
+            format_local_timestamp(timestamp, "%Y-%m-%d %H:%M"),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn invalid_timestamp_returns_none() {
+        assert_eq!(format_local_timestamp(i64::MAX, "%Y-%m-%d"), None);
     }
 }
 

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -33,8 +33,8 @@ pub use dispute_selection::{
     get_filtered_disputes, move_dispute_selection, selected_display_idx, selected_filtered_dispute,
 };
 pub use formatting::{
-    format_order_id, format_premium, format_user_rating, is_dispute_finalized,
-    relative_time_compact, short_order_id,
+    format_local_timestamp, format_order_id, format_premium, format_user_rating,
+    is_dispute_finalized, relative_time_compact, short_order_id,
 };
 pub use layout::{
     create_centered_popup, render_help_text, render_yes_no_buttons, render_yes_no_cancel_buttons,

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -695,8 +695,7 @@ pub fn order_message_to_notification(msg: &OrderMessage) -> MessageNotification 
 }
 
 fn bond_payout_notification_body(slashed_at: i64) -> String {
-    let anchor = chrono::DateTime::from_timestamp(slashed_at, 0)
-        .map(|d| d.format("%Y-%m-%d %H:%M UTC").to_string())
+    let anchor = crate::ui::helpers::format_local_timestamp(slashed_at, "%Y-%m-%d %H:%M")
         .unwrap_or_else(|| "unknown".to_string());
     format!("Slash recorded: {anchor}. Claim deadline = anchor + instance payout window.")
 }

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -1,6 +1,5 @@
 //! Admin disputes-in-progress UI. The Ctrl+H help overlay is styled in [`crate::ui::help_popup`].
 
-use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -12,8 +11,8 @@ use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::constants::*;
 use crate::ui::helpers::{
-    build_chat_scrollview_content, count_visible_attachments, format_user_rating,
-    get_filtered_disputes, get_selected_chat_message,
+    build_chat_scrollview_content, count_visible_attachments, format_local_timestamp,
+    format_user_rating, get_filtered_disputes, get_selected_chat_message,
 };
 use crate::ui::ChatParty;
 use crate::ui::{AdminMode, AppState, DisputeFilter, UiMode, BACKGROUND_COLOR, PRIMARY_COLOR};
@@ -204,9 +203,7 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         };
 
         // Header - Enhanced with more dispute information
-        let created_date = DateTime::from_timestamp(selected_dispute.created_at, 0);
-        let created_str = created_date
-            .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
+        let created_str = format_local_timestamp(selected_dispute.created_at, "%Y-%m-%d %H:%M:%S")
             .unwrap_or_else(|| "Unknown".to_string());
 
         // Get buyer and seller pubkeys (do not default to initiator_pubkey)
@@ -312,9 +309,7 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         };
 
         // Format additional timestamps for finalized disputes
-        let taken_date = DateTime::from_timestamp(selected_dispute.taken_at, 0);
-        let taken_str = taken_date
-            .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
+        let taken_str = format_local_timestamp(selected_dispute.taken_at, "%Y-%m-%d %H:%M:%S")
             .unwrap_or_else(|| "Unknown".to_string());
 
         // Build header lines - expand for finalized disputes

--- a/src/ui/tabs/disputes_tab.rs
+++ b/src/ui/tabs/disputes_tab.rs
@@ -1,13 +1,13 @@
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-use chrono::DateTime;
 use mostro_core::prelude::*;
 use ratatui::layout::Constraint;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 
+use crate::ui::helpers::format_local_timestamp;
 use crate::ui::{BACKGROUND_COLOR, PRIMARY_COLOR};
 
 /// Render the disputes tab showing a table of active disputes
@@ -89,9 +89,8 @@ pub fn render_disputes_tab(
                 let status_str = dispute.status.clone();
                 let status_cell = Cell::from(status_str);
 
-                let date = DateTime::from_timestamp(dispute.created_at, 0);
                 let date_cell = Cell::from(
-                    date.map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+                    format_local_timestamp(dispute.created_at, "%Y-%m-%d %H:%M")
                         .unwrap_or_else(|| "Invalid date".to_string()),
                 );
 

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -1,6 +1,5 @@
 //! Messages tab: order list sidebar and trade timeline detail panel.
 
-use chrono::{DateTime, Utc};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -401,8 +400,7 @@ fn render_header_card(f: &mut ratatui::Frame, area: Rect, msg: &OrderMessage) {
         Span::styled(status_emoji.to_string(), Style::default().fg(status_color)),
     ]);
 
-    let absolute = DateTime::<Utc>::from_timestamp(msg.timestamp, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+    let absolute = helpers::format_local_timestamp(msg.timestamp, "%Y-%m-%d %H:%M")
         .unwrap_or_else(|| "unknown".to_string());
     let relative = helpers::relative_time_compact(msg.timestamp);
     let line2 = Line::from(Span::styled(

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -1,6 +1,5 @@
 //! My Trades / order chat UI. Ctrl+H and Shift+H help overlays are styled in [`crate::ui::help_popup`].
 
-use chrono::DateTime;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
@@ -18,7 +17,8 @@ use crate::ui::constants::{
     FOOTER_SENDING_ATTACHMENT, HELP_KEY,
 };
 use crate::ui::helpers::{
-    active_order_chat_list_snapshot, count_order_attachments, format_user_rating,
+    active_order_chat_list_snapshot, count_order_attachments, format_local_timestamp,
+    format_user_rating,
 };
 use crate::ui::UserOrderChatMessage;
 use crate::ui::{AppState, UserChatSender};
@@ -115,8 +115,7 @@ fn build_order_chat_content(
         } else {
             color
         };
-        let ts = DateTime::from_timestamp(msg.timestamp, 0)
-            .map(|dt| dt.format("%d-%m-%Y %H:%M").to_string())
+        let ts = format_local_timestamp(msg.timestamp, "%d-%m-%Y %H:%M")
             .unwrap_or_else(|| "unknown time".to_string());
         let header = Span::styled(format!("{label} - {ts}"), Style::default().fg(color));
         let wrapped_lines = wrap_text_to_lines(&msg.content, max_content_width);
@@ -252,8 +251,7 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         .unwrap_or_else(|| "Unknown".to_string());
     let created_str = static_h
         .and_then(|h| h.created_at)
-        .and_then(|ts| DateTime::from_timestamp(ts, 0))
-        .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
+        .and_then(|ts| format_local_timestamp(ts, "%Y-%m-%d %H:%M:%S"))
         .unwrap_or_else(|| "Unknown".to_string());
     let truncate_pubkey = |pubkey: &str| -> String {
         if pubkey.len() > 16 {

--- a/src/ui/tabs/orders_tab.rs
+++ b/src/ui/tabs/orders_tab.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use chrono::DateTime;
 use mostro_core::prelude::*;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -10,7 +9,9 @@ use ratatui::widgets::{
     ScrollbarState, Table,
 };
 
-use crate::ui::helpers::{format_premium, get_filtered_book_orders, selected_book_display_idx};
+use crate::ui::helpers::{
+    format_local_timestamp, format_premium, get_filtered_book_orders, selected_book_display_idx,
+};
 use crate::ui::{apply_kind_color, AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
 
 /// Renders the available orders table, with fewer columns when terminal width is limited.
@@ -156,12 +157,7 @@ pub fn render_orders_tab(
             let date_cell = Cell::from(
                 order
                     .created_at
-                    .and_then(|ts| DateTime::from_timestamp(ts, 0))
-                    .map(|d| {
-                        d.with_timezone(&chrono::Local)
-                            .format("%Y-%m-%d %H:%M")
-                            .to_string()
-                    })
+                    .and_then(|ts| format_local_timestamp(ts, "%Y-%m-%d %H:%M"))
                     .unwrap_or_else(|| "Invalid date".to_string()),
             );
 


### PR DESCRIPTION
  ## Summary

  - Add a shared helper for formatting Unix timestamps in the user's local timezone
  - Use local-time formatting for visible TUI timestamps across orders, messages, and disputes
  - Keep persisted chat transcript timestamp formatting unchanged for compatibility

  ## Testing

  - cargo fmt --all -- --check
  - cargo check --all-targets --all-features
  - cargo test --all-features
  - cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Timestamps for disputes, orders, messages, and notifications now display in the viewer’s local time.
  - Date and time formatting is more consistent across the application.
  - Existing fallback behavior is preserved when timestamps are invalid.

- **Tests**
  - Added coverage for local timestamp formatting, including invalid timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->