### PR TITLE
feat(chat): Step 4 — outer LRU, rate limit, durable inner-id dedup

### DIFF
--- a/src/startup.rs
+++ b/src/startup.rs
@@ -52,10 +52,10 @@ pub struct PostTerminalStartupInput<'a> {
     pub message_notification_tx: tokio::sync::mpsc::UnboundedSender<crate::ui::MessageNotification>,
     /// Sender used by the chat router to publish decoded admin dispute chat updates.
     pub admin_chat_updates_tx:
-        tokio::sync::mpsc::UnboundedSender<Result<Vec<crate::ui::AdminChatUpdate>, anyhow::Error>>,
+        tokio::sync::mpsc::Sender<Result<Vec<crate::ui::AdminChatUpdate>, anyhow::Error>>,
     /// Sender used by the chat router to publish decoded user order chat updates.
     pub user_order_chat_updates_tx:
-        tokio::sync::mpsc::UnboundedSender<Result<Vec<crate::ui::OrderChatUpdate>, anyhow::Error>>,
+        tokio::sync::mpsc::Sender<Result<Vec<crate::ui::OrderChatUpdate>, anyhow::Error>>,
 }
 
 pub struct StartupBootstrap {

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use nostr_sdk::prelude::PublicKey;
+use nostr_sdk::prelude::{EventId, PublicKey};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ChatParty {
@@ -86,13 +86,22 @@ pub struct AdminChatLastSeen {
     pub last_seen_timestamp: Option<i64>,
 }
 
+/// A decrypted peer/admin chat message ready for UI merge.
+#[derive(Clone, Debug)]
+pub struct DecodedChatMessage {
+    pub content: String,
+    pub timestamp: i64,
+    pub sender: PublicKey,
+    /// Verified inner kind-1 event id — durable replay protection.
+    pub inner_event_id: EventId,
+}
+
 /// Result of polling for admin chat messages for a single dispute/party.
 #[derive(Clone, Debug)]
 pub struct AdminChatUpdate {
     pub dispute_id: String,
     pub party: ChatParty,
-    /// (content, timestamp, sender_pubkey)
-    pub messages: Vec<(String, i64, PublicKey)>,
+    pub messages: Vec<DecodedChatMessage>,
 }
 
 /// Per-order last-seen timestamp for user order chat.
@@ -107,6 +116,5 @@ pub struct OrderChatUpdate {
     pub order_id: String,
     /// Local trade public key for this order; used to skip relay echoes of our own sends.
     pub local_trade_pubkey: PublicKey,
-    /// (content, timestamp, sender_pubkey)
-    pub messages: Vec<(String, i64, PublicKey)>,
+    pub messages: Vec<DecodedChatMessage>,
 }

--- a/src/ui/helpers/chat_storage.rs
+++ b/src/ui/helpers/chat_storage.rs
@@ -345,6 +345,9 @@ fn append_transcript_block(file_path: &Path, formatted_message: &str, label: &st
             if let Err(e) = file.write_all(formatted_message.as_bytes()) {
                 log::warn!("Failed to write {label} message to file: {e}");
                 false
+            } else if let Err(e) = file.sync_all() {
+                log::warn!("Failed to sync {label} message to file: {e}");
+                false
             } else {
                 log::debug!("Saved {label} message to {:?}", file_path);
                 true
@@ -359,21 +362,39 @@ fn append_transcript_block(file_path: &Path, formatted_message: &str, label: &st
 
 fn write_transcript_file(file_path: &Path, body: &str, label: &str) -> bool {
     let tmp_path = file_path.with_extension("txt.tmp");
-    match fs::write(&tmp_path, body) {
-        Ok(()) => {
-            if let Err(e) = fs::rename(&tmp_path, file_path) {
-                log::warn!("Failed to replace {label} file {:?}: {e}", file_path);
-                let _ = fs::remove_file(&tmp_path);
+    let write_ok = match OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&tmp_path)
+    {
+        Ok(mut file) => {
+            if let Err(e) = file.write_all(body.as_bytes()) {
+                log::warn!("Failed to write {label} temp file {:?}: {e}", tmp_path);
+                false
+            } else if let Err(e) = file.sync_all() {
+                log::warn!("Failed to sync {label} temp file {:?}: {e}", tmp_path);
                 false
             } else {
-                log::debug!("Rewrote {label} transcript {:?}", file_path);
                 true
             }
         }
         Err(e) => {
-            log::warn!("Failed to write {label} temp file {:?}: {e}", tmp_path);
-            false
+            log::warn!("Failed to open {label} temp file {:?}: {e}", tmp_path);
+            return false;
         }
+    };
+    if !write_ok {
+        let _ = fs::remove_file(&tmp_path);
+        return false;
+    }
+    if let Err(e) = fs::rename(&tmp_path, file_path) {
+        log::warn!("Failed to replace {label} file {:?}: {e}", file_path);
+        let _ = fs::remove_file(&tmp_path);
+        false
+    } else {
+        log::debug!("Rewrote {label} transcript {:?}", file_path);
+        true
     }
 }
 

--- a/src/ui/helpers/chat_storage.rs
+++ b/src/ui/helpers/chat_storage.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::{Mutex, OnceLock};
 
 use chrono::DateTime;
 use nostr_sdk::prelude::EventId;
@@ -244,21 +245,24 @@ pub fn load_chat_from_file(dispute_id: &str) -> Option<Vec<DisputeChatMessage>> 
 }
 
 /// Persist one user order chat message into `~/.mostrix/orders_chat/<order_id>.txt`.
-pub fn save_order_chat_message(order_id: &str, message: &UserOrderChatMessage) {
+///
+/// Returns `true` when the message is durably represented on disk (newly written
+/// or already present as the last transcript block). Returns `false` on I/O failure.
+pub fn save_order_chat_message(order_id: &str, message: &UserOrderChatMessage) -> bool {
     let file_path = match chat_file_path(ChatStorageKind::Orders, order_id) {
         Some(path) => path,
         None => {
             log::warn!("Invalid order chat id format, skipping save: {}", order_id);
-            return;
+            return false;
         }
     };
     let Some(chat_dir) = file_path.parent() else {
         log::warn!("Failed to resolve order chat folder for id {}", order_id);
-        return;
+        return false;
     };
     if let Err(e) = fs::create_dir_all(chat_dir) {
         log::warn!("Failed to create order chat folder {:?}: {}", chat_dir, e);
-        return;
+        return false;
     }
 
     let content_block = transcript_body_for_order_message(message);
@@ -277,11 +281,44 @@ pub fn save_order_chat_message(order_id: &str, message: &UserOrderChatMessage) {
                     &last_content,
                     message,
                 ) {
-                    return;
+                    return true;
                 }
             }
         }
     }
+    let formatted_message = format_order_transcript_block(message, &content_block);
+    append_transcript_block(&file_path, &formatted_message, "order chat")
+}
+
+/// Rewrite the full order-chat transcript (used when upgrading a placeholder in place).
+pub fn rewrite_order_chat_messages(order_id: &str, messages: &[UserOrderChatMessage]) -> bool {
+    let file_path = match chat_file_path(ChatStorageKind::Orders, order_id) {
+        Some(path) => path,
+        None => {
+            log::warn!(
+                "Invalid order chat id format, skipping rewrite: {}",
+                order_id
+            );
+            return false;
+        }
+    };
+    let Some(chat_dir) = file_path.parent() else {
+        log::warn!("Failed to resolve order chat folder for id {}", order_id);
+        return false;
+    };
+    if let Err(e) = fs::create_dir_all(chat_dir) {
+        log::warn!("Failed to create order chat folder {:?}: {}", chat_dir, e);
+        return false;
+    }
+    let mut body = String::new();
+    for message in messages {
+        let content_block = transcript_body_for_order_message(message);
+        body.push_str(&format_order_transcript_block(message, &content_block));
+    }
+    write_transcript_file(&file_path, &body, "order chat")
+}
+
+fn format_order_transcript_block(message: &UserOrderChatMessage, content_block: &str) -> String {
     let (date_str, time_str) = DateTime::from_timestamp(message.timestamp, 0)
         .map(|dt| {
             let date = dt.format("%d-%m-%Y").to_string();
@@ -293,23 +330,47 @@ pub fn save_order_chat_message(order_id: &str, message: &UserOrderChatMessage) {
         UserChatSender::You => "You",
         UserChatSender::Peer => "Peer",
     };
-    let formatted_message = format!(
+    format!(
         "{} - {} - {}\n{}\n\n",
         sender_label, date_str, time_str, content_block
-    );
-    match OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&file_path)
-    {
+    )
+}
+
+fn append_transcript_block(file_path: &Path, formatted_message: &str, label: &str) -> bool {
+    match OpenOptions::new().create(true).append(true).open(file_path) {
         Ok(mut file) => {
             if let Err(e) = file.write_all(formatted_message.as_bytes()) {
-                log::warn!("Failed to write order chat message to file: {}", e);
+                log::warn!("Failed to write {label} message to file: {e}");
+                false
             } else {
-                log::debug!("Saved order chat message to {:?}", file_path);
+                log::debug!("Saved {label} message to {:?}", file_path);
+                true
             }
         }
-        Err(e) => log::warn!("Failed to open order chat file {:?}: {}", file_path, e),
+        Err(e) => {
+            log::warn!("Failed to open {label} file {:?}: {e}", file_path);
+            false
+        }
+    }
+}
+
+fn write_transcript_file(file_path: &Path, body: &str, label: &str) -> bool {
+    let tmp_path = file_path.with_extension("txt.tmp");
+    match fs::write(&tmp_path, body) {
+        Ok(()) => {
+            if let Err(e) = fs::rename(&tmp_path, file_path) {
+                log::warn!("Failed to replace {label} file {:?}: {e}", file_path);
+                let _ = fs::remove_file(&tmp_path);
+                false
+            } else {
+                log::debug!("Rewrote {label} transcript {:?}", file_path);
+                true
+            }
+        }
+        Err(e) => {
+            log::warn!("Failed to write {label} temp file {:?}: {e}", tmp_path);
+            false
+        }
     }
 }
 
@@ -349,11 +410,50 @@ pub fn dispute_chat_since_from_file(dispute_id: &str) -> (Option<i64>, Option<i6
 }
 
 /// Saves a dispute chat message to a text file in `~/.mostrix/disputes_chat/<dispute_id>.txt`.
-pub fn save_chat_message(dispute_id: &str, message: &DisputeChatMessage) {
-    save_chat_message_by_kind(ChatStorageKind::Disputes, dispute_id, message);
+///
+/// Returns `true` when durably represented on disk (written or already last block).
+pub fn save_chat_message(dispute_id: &str, message: &DisputeChatMessage) -> bool {
+    save_chat_message_by_kind(ChatStorageKind::Disputes, dispute_id, message)
 }
 
-fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &DisputeChatMessage) {
+/// Rewrite the full dispute-chat transcript (placeholder-in-place upgrades).
+pub fn rewrite_dispute_chat_messages(dispute_id: &str, messages: &[DisputeChatMessage]) -> bool {
+    let file_path = match chat_file_path(ChatStorageKind::Disputes, dispute_id) {
+        Some(path) => path,
+        None => {
+            log::warn!(
+                "Invalid dispute chat id format, skipping rewrite: {}",
+                dispute_id
+            );
+            return false;
+        }
+    };
+    let Some(chat_dir) = file_path.parent() else {
+        log::warn!(
+            "Failed to resolve dispute chat folder for id {}",
+            dispute_id
+        );
+        return false;
+    };
+    if let Err(e) = fs::create_dir_all(chat_dir) {
+        log::warn!("Failed to create dispute chat folder {:?}: {}", chat_dir, e);
+        return false;
+    }
+    let mut body = String::new();
+    for message in messages {
+        body.push_str(&format_dispute_transcript_block(
+            ChatStorageKind::Disputes,
+            message,
+        ));
+    }
+    write_transcript_file(&file_path, &body, "dispute chat")
+}
+
+fn save_chat_message_by_kind(
+    kind: ChatStorageKind,
+    chat_id: &str,
+    message: &DisputeChatMessage,
+) -> bool {
     let file_path = match chat_file_path(kind, chat_id) {
         Some(path) => path,
         None => {
@@ -362,7 +462,7 @@ fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &Dis
                 kind.log_label(),
                 chat_id
             );
-            return;
+            return false;
         }
     };
     let Some(chat_dir) = file_path.parent() else {
@@ -371,7 +471,7 @@ fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &Dis
             kind.log_label(),
             chat_id
         );
-        return;
+        return false;
     };
     if let Err(e) = fs::create_dir_all(chat_dir) {
         log::warn!(
@@ -380,10 +480,8 @@ fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &Dis
             chat_dir,
             e
         );
-        return;
+        return false;
     }
-
-    let content_block = transcript_body_for_dispute_message(message);
 
     if let Ok(existing) = fs::read_to_string(&file_path) {
         if let Some((last_sender, last_target_party, last_ts, last_content)) =
@@ -396,11 +494,17 @@ fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &Dis
                 &last_content,
                 message,
             ) {
-                return;
+                return true;
             }
         }
     }
 
+    let formatted_message = format_dispute_transcript_block(kind, message);
+    append_transcript_block(&file_path, &formatted_message, kind.log_label())
+}
+
+fn format_dispute_transcript_block(kind: ChatStorageKind, message: &DisputeChatMessage) -> String {
+    let content_block = transcript_body_for_dispute_message(message);
     let (date_str, time_str) = DateTime::from_timestamp(message.timestamp, 0)
         .map(|dt| {
             let date = dt.format("%d-%m-%Y").to_string();
@@ -422,36 +526,10 @@ fn save_chat_message_by_kind(kind: ChatStorageKind, chat_id: &str, message: &Dis
             ChatSender::Buyer | ChatSender::Seller => "Peer",
         },
     };
-    let formatted_message = format!(
+    format!(
         "{} - {} - {}\n{}\n\n",
         sender_label, date_str, time_str, content_block
-    );
-
-    match OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&file_path)
-    {
-        Ok(mut file) => {
-            if let Err(e) = file.write_all(formatted_message.as_bytes()) {
-                log::warn!(
-                    "Failed to write {} message to file: {}",
-                    kind.log_label(),
-                    e
-                );
-            } else {
-                log::debug!("Saved {} message to {:?}", kind.log_label(), file_path);
-            }
-        }
-        Err(e) => {
-            log::warn!(
-                "Failed to open {} file {:?}: {}",
-                kind.log_label(),
-                file_path,
-                e
-            );
-        }
-    }
+    )
 }
 
 pub(crate) fn max_party_timestamps(messages: &[DisputeChatMessage]) -> (i64, i64) {
@@ -491,7 +569,7 @@ fn inner_ids_file_path(
     )
 }
 
-fn load_inner_ids_from_path(path: &PathBuf) -> HashSet<EventId> {
+fn load_inner_ids_from_path(path: &Path) -> HashSet<EventId> {
     let Ok(content) = fs::read_to_string(path) else {
         return HashSet::new();
     };
@@ -507,24 +585,62 @@ fn load_inner_ids_from_path(path: &PathBuf) -> HashSet<EventId> {
         .collect()
 }
 
-fn remember_inner_id_at_path(path: &PathBuf, id: &EventId) -> bool {
-    let mut seen = load_inner_ids_from_path(path);
-    if !seen.insert(*id) {
+fn inner_id_cache() -> &'static Mutex<HashMap<PathBuf, HashSet<EventId>>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, HashSet<EventId>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn with_inner_id_set<R>(path: &Path, f: impl FnOnce(&mut HashSet<EventId>) -> R) -> R {
+    let mut guard = match inner_id_cache().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let set = guard
+        .entry(path.to_path_buf())
+        .or_insert_with(|| load_inner_ids_from_path(path));
+    f(set)
+}
+
+fn inner_id_known_at_path(path: &Path, id: &EventId) -> bool {
+    with_inner_id_set(path, |set| set.contains(id))
+}
+
+/// Append `id` to the durable set. Returns `false` if already known.
+///
+/// Uses a process-wide cache so each path is fully parsed at most once; only
+/// newly accepted ids are appended. On append failure the cache insert is rolled
+/// back so a later retry can succeed.
+fn remember_inner_id_at_path(path: &Path, id: &EventId) -> bool {
+    let newly_inserted = with_inner_id_set(path, |set| set.insert(*id));
+    if !newly_inserted {
         return false;
     }
     if let Some(parent) = path.parent() {
         if let Err(e) = fs::create_dir_all(parent) {
             log::warn!("Failed to create chat inner-id dir {:?}: {e}", parent);
-            return true; // still treat as new in-memory this session
+            with_inner_id_set(path, |set| {
+                set.remove(id);
+            });
+            return false;
         }
     }
     match OpenOptions::new().create(true).append(true).open(path) {
         Ok(mut file) => {
             if let Err(e) = writeln!(file, "{}", id.to_hex()) {
                 log::warn!("Failed to append chat inner id to {:?}: {e}", path);
+                with_inner_id_set(path, |set| {
+                    set.remove(id);
+                });
+                return false;
             }
         }
-        Err(e) => log::warn!("Failed to open chat inner-id file {:?}: {e}", path),
+        Err(e) => {
+            log::warn!("Failed to open chat inner-id file {:?}: {e}", path);
+            with_inner_id_set(path, |set| {
+                set.remove(id);
+            });
+            return false;
+        }
     }
     true
 }
@@ -532,8 +648,16 @@ fn remember_inner_id_at_path(path: &PathBuf, id: &EventId) -> bool {
 /// Load durable inner event ids for an order chat (replay protection).
 pub fn load_order_chat_inner_ids(order_id: &str) -> HashSet<EventId> {
     match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
-        Some(path) => load_inner_ids_from_path(&path),
+        Some(path) => with_inner_id_set(&path, |set| set.clone()),
         None => HashSet::new(),
+    }
+}
+
+/// Returns `true` if this inner id was already accepted for the order chat.
+pub fn order_chat_inner_id_known(order_id: &str, id: &EventId) -> bool {
+    match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
+        Some(path) => inner_id_known_at_path(&path, id),
+        None => false,
     }
 }
 
@@ -552,8 +676,20 @@ pub fn load_dispute_chat_inner_ids(dispute_id: &str, party: ChatParty) -> HashSe
         ChatParty::Seller => "seller",
     };
     match inner_ids_file_path(ChatStorageKind::Disputes, dispute_id, Some(sfx)) {
-        Some(path) => load_inner_ids_from_path(&path),
+        Some(path) => with_inner_id_set(&path, |set| set.clone()),
         None => HashSet::new(),
+    }
+}
+
+/// Returns `true` if this inner id was already accepted for the dispute party chat.
+pub fn dispute_chat_inner_id_known(dispute_id: &str, party: ChatParty, id: &EventId) -> bool {
+    let sfx = match party {
+        ChatParty::Buyer => "buyer",
+        ChatParty::Seller => "seller",
+    };
+    match inner_ids_file_path(ChatStorageKind::Disputes, dispute_id, Some(sfx)) {
+        Some(path) => inner_id_known_at_path(&path, id),
+        None => false,
     }
 }
 

--- a/src/ui/helpers/chat_storage.rs
+++ b/src/ui/helpers/chat_storage.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use chrono::DateTime;
+use nostr_sdk::prelude::EventId;
 
 use crate::ui::{ChatParty, ChatSender, DisputeChatMessage, UserChatSender, UserOrderChatMessage};
 
@@ -467,6 +470,105 @@ pub(crate) fn max_party_timestamps(messages: &[DisputeChatMessage]) -> (i64, i64
     (buyer_max, seller_max)
 }
 
+fn inner_ids_file_path(
+    kind: ChatStorageKind,
+    chat_id: &str,
+    party_suffix: Option<&str>,
+) -> Option<PathBuf> {
+    if uuid::Uuid::parse_str(chat_id).is_err() {
+        return None;
+    }
+    let home_dir = dirs::home_dir()?;
+    let name = match party_suffix {
+        Some(sfx) => format!("{chat_id}.{sfx}.inner_ids"),
+        None => format!("{chat_id}.inner_ids"),
+    };
+    Some(
+        home_dir
+            .join(".mostrix")
+            .join(kind.folder_name())
+            .join(name),
+    )
+}
+
+fn load_inner_ids_from_path(path: &PathBuf) -> HashSet<EventId> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return HashSet::new();
+    };
+    content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            EventId::from_str(line).ok()
+        })
+        .collect()
+}
+
+fn remember_inner_id_at_path(path: &PathBuf, id: &EventId) -> bool {
+    let mut seen = load_inner_ids_from_path(path);
+    if !seen.insert(*id) {
+        return false;
+    }
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            log::warn!("Failed to create chat inner-id dir {:?}: {e}", parent);
+            return true; // still treat as new in-memory this session
+        }
+    }
+    match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{}", id.to_hex()) {
+                log::warn!("Failed to append chat inner id to {:?}: {e}", path);
+            }
+        }
+        Err(e) => log::warn!("Failed to open chat inner-id file {:?}: {e}", path),
+    }
+    true
+}
+
+/// Load durable inner event ids for an order chat (replay protection).
+pub fn load_order_chat_inner_ids(order_id: &str) -> HashSet<EventId> {
+    match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
+        Some(path) => load_inner_ids_from_path(&path),
+        None => HashSet::new(),
+    }
+}
+
+/// Persist an accepted order-chat inner id. Returns `false` if already known (replay).
+pub fn remember_order_chat_inner_id(order_id: &str, id: &EventId) -> bool {
+    match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
+        Some(path) => remember_inner_id_at_path(&path, id),
+        None => true,
+    }
+}
+
+/// Load durable inner event ids for one admin↔party dispute channel.
+pub fn load_dispute_chat_inner_ids(dispute_id: &str, party: ChatParty) -> HashSet<EventId> {
+    let sfx = match party {
+        ChatParty::Buyer => "buyer",
+        ChatParty::Seller => "seller",
+    };
+    match inner_ids_file_path(ChatStorageKind::Disputes, dispute_id, Some(sfx)) {
+        Some(path) => load_inner_ids_from_path(&path),
+        None => HashSet::new(),
+    }
+}
+
+/// Persist an accepted dispute-chat inner id. Returns `false` if already known (replay).
+pub fn remember_dispute_chat_inner_id(dispute_id: &str, party: ChatParty, id: &EventId) -> bool {
+    let sfx = match party {
+        ChatParty::Buyer => "buyer",
+        ChatParty::Seller => "seller",
+    };
+    match inner_ids_file_path(ChatStorageKind::Disputes, dispute_id, Some(sfx)) {
+        Some(path) => remember_inner_id_at_path(&path, id),
+        None => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -474,8 +576,22 @@ mod tests {
         ChatAttachment, ChatAttachmentType, ChatSender, DisputeChatMessage, UserChatSender,
         UserOrderChatMessage,
     };
+    use nostr_sdk::prelude::EventId;
 
     use super::super::attachments::serialize_attachment_for_transcript;
+
+    #[test]
+    fn inner_id_replay_rejected_at_path() {
+        let dir = std::env::temp_dir().join(format!("mostrix-inner-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("x.inner_ids");
+        let id = EventId::from_slice(&[9u8; 32]).expect("event id");
+        assert!(remember_inner_id_at_path(&path, &id));
+        assert!(!remember_inner_id_at_path(&path, &id));
+        let loaded = load_inner_ids_from_path(&path);
+        assert!(loaded.contains(&id));
+        let _ = fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn transcript_body_roundtrip_via_message_fields() {

--- a/src/ui/helpers/chat_storage.rs
+++ b/src/ui/helpers/chat_storage.rs
@@ -291,6 +291,9 @@ pub fn save_order_chat_message(order_id: &str, message: &UserOrderChatMessage) -
 }
 
 /// Rewrite the full order-chat transcript (used when upgrading a placeholder in place).
+///
+/// Returns `true` on successful atomic replace; `false` on I/O failure (caller should
+/// not treat the in-memory upgrade as durable).
 pub fn rewrite_order_chat_messages(order_id: &str, messages: &[UserOrderChatMessage]) -> bool {
     let file_path = match chat_file_path(ChatStorageKind::Orders, order_id) {
         Some(path) => path,
@@ -417,6 +420,9 @@ pub fn save_chat_message(dispute_id: &str, message: &DisputeChatMessage) -> bool
 }
 
 /// Rewrite the full dispute-chat transcript (placeholder-in-place upgrades).
+///
+/// Returns `true` on successful atomic replace; `false` on I/O failure (caller should
+/// not treat the in-memory upgrade as durable).
 pub fn rewrite_dispute_chat_messages(dispute_id: &str, messages: &[DisputeChatMessage]) -> bool {
     let file_path = match chat_file_path(ChatStorageKind::Disputes, dispute_id) {
         Some(path) => path,
@@ -646,6 +652,8 @@ fn remember_inner_id_at_path(path: &Path, id: &EventId) -> bool {
 }
 
 /// Load durable inner event ids for an order chat (replay protection).
+///
+/// Reads through a process-wide per-path cache (first touch loads the `.inner_ids` file).
 pub fn load_order_chat_inner_ids(order_id: &str) -> HashSet<EventId> {
     match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
         Some(path) => with_inner_id_set(&path, |set| set.clone()),
@@ -661,7 +669,11 @@ pub fn order_chat_inner_id_known(order_id: &str, id: &EventId) -> bool {
     }
 }
 
-/// Persist an accepted order-chat inner id. Returns `false` if already known (replay).
+/// Persist an accepted order-chat inner id.
+///
+/// Returns `false` if the id was already known, or if the durable append failed
+/// (cache insert is rolled back so a later retry can succeed). Call only after
+/// the matching transcript mutation has succeeded.
 pub fn remember_order_chat_inner_id(order_id: &str, id: &EventId) -> bool {
     match inner_ids_file_path(ChatStorageKind::Orders, order_id, None) {
         Some(path) => remember_inner_id_at_path(&path, id),
@@ -670,6 +682,8 @@ pub fn remember_order_chat_inner_id(order_id: &str, id: &EventId) -> bool {
 }
 
 /// Load durable inner event ids for one admin↔party dispute channel.
+///
+/// Reads through a process-wide per-path cache (first touch loads the `.inner_ids` file).
 pub fn load_dispute_chat_inner_ids(dispute_id: &str, party: ChatParty) -> HashSet<EventId> {
     let sfx = match party {
         ChatParty::Buyer => "buyer",
@@ -693,7 +707,11 @@ pub fn dispute_chat_inner_id_known(dispute_id: &str, party: ChatParty, id: &Even
     }
 }
 
-/// Persist an accepted dispute-chat inner id. Returns `false` if already known (replay).
+/// Persist an accepted dispute-chat inner id.
+///
+/// Returns `false` if the id was already known, or if the durable append failed
+/// (cache insert is rolled back so a later retry can succeed). Call only after
+/// the matching transcript mutation has succeeded.
 pub fn remember_dispute_chat_inner_id(dispute_id: &str, party: ChatParty, id: &EventId) -> bool {
     let sfx = match party {
         ChatParty::Buyer => "buyer",

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -22,10 +22,11 @@ pub use chat_render::{
     ChatScrollViewContent,
 };
 pub use chat_storage::{
-    dispute_chat_since_from_file, load_chat_from_file, load_dispute_chat_inner_ids,
-    load_order_chat_from_file, load_order_chat_inner_ids, order_chat_since_from_file,
-    remember_dispute_chat_inner_id, remember_order_chat_inner_id, save_chat_message,
-    save_order_chat_message,
+    dispute_chat_inner_id_known, dispute_chat_since_from_file, load_chat_from_file,
+    load_dispute_chat_inner_ids, load_order_chat_from_file, load_order_chat_inner_ids,
+    order_chat_inner_id_known, order_chat_since_from_file, remember_dispute_chat_inner_id,
+    remember_order_chat_inner_id, rewrite_dispute_chat_messages, rewrite_order_chat_messages,
+    save_chat_message, save_order_chat_message,
 };
 pub use chat_visibility::{
     count_order_attachments, count_visible_attachments, get_order_attachment_messages,

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -22,8 +22,10 @@ pub use chat_render::{
     ChatScrollViewContent,
 };
 pub use chat_storage::{
-    dispute_chat_since_from_file, load_chat_from_file, load_order_chat_from_file,
-    order_chat_since_from_file, save_chat_message, save_order_chat_message,
+    dispute_chat_since_from_file, load_chat_from_file, load_dispute_chat_inner_ids,
+    load_order_chat_from_file, load_order_chat_inner_ids, order_chat_since_from_file,
+    remember_dispute_chat_inner_id, remember_order_chat_inner_id, save_chat_message,
+    save_order_chat_message,
 };
 pub use chat_visibility::{
     count_order_attachments, count_visible_attachments, get_order_attachment_messages,

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -399,6 +399,10 @@ pub async fn sync_user_order_history_messages_from_db(pool: &SqlitePool, app: &m
 }
 
 /// Merge fetched user order chat updates into app state and persist them to file.
+///
+/// Durable inner-event ids are recorded only after a successful transcript
+/// [`save_order_chat_message`] / [`rewrite_order_chat_messages`]. On write
+/// failure the id is left unrecorded so a later delivery can retry.
 pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui::OrderChatUpdate>) {
     for update in updates {
         let order_id = update.order_id.clone();
@@ -528,6 +532,10 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
 
 /// Apply fetched admin chat updates back into the UI state and persist
 /// last_seen timestamps to the database.
+///
+/// Durable inner-event ids are recorded only after a successful transcript
+/// [`save_chat_message`] / [`rewrite_dispute_chat_messages`]. On write failure
+/// the id is left unrecorded so a later delivery can retry.
 pub async fn apply_admin_chat_updates(
     app: &mut AppState,
     updates: Vec<AdminChatUpdate>,

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -25,7 +25,8 @@ use super::attachments::{
     build_attachment_toast, legacy_placeholder_matches_filename, try_parse_attachment_message,
 };
 use super::chat_storage::{
-    load_chat_from_file, load_order_chat_from_file, max_party_timestamps, save_chat_message,
+    load_chat_from_file, load_order_chat_from_file, max_party_timestamps,
+    remember_dispute_chat_inner_id, remember_order_chat_inner_id, save_chat_message,
     save_order_chat_message,
 };
 
@@ -406,9 +407,22 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
             .get(&order_id)
             .and_then(|s| s.last_seen_timestamp)
             .unwrap_or(0);
-        for (content, ts, sender_pubkey) in update.messages {
+        for msg in update.messages {
+            let content = msg.content;
+            let ts = msg.timestamp;
+            let sender_pubkey = msg.sender;
+            let inner_id = msg.inner_event_id;
+
             // Skip relay echoes of messages we already added locally on send (mirror admin chat).
             if sender_pubkey == update.local_trade_pubkey {
+                if ts > max_ts {
+                    max_ts = ts;
+                }
+                continue;
+            }
+
+            // Durable inner-id replay guard (spec step 12).
+            if !remember_order_chat_inner_id(&order_id, &inner_id) {
                 if ts > max_ts {
                     max_ts = ts;
                 }
@@ -516,7 +530,12 @@ pub async fn apply_admin_chat_updates(
             .and_then(|s| s.last_seen_timestamp)
             .unwrap_or(0);
 
-        for (content, ts, sender_pubkey) in update.messages {
+        for msg in update.messages {
+            let content = msg.content;
+            let ts = msg.timestamp;
+            let sender_pubkey = msg.sender;
+            let inner_id = msg.inner_event_id;
+
             if let Some(admin_pk) = admin_chat_pubkey {
                 if &sender_pubkey == admin_pk {
                     if ts > max_ts {
@@ -524,6 +543,13 @@ pub async fn apply_admin_chat_updates(
                     }
                     continue;
                 }
+            }
+
+            if !remember_dispute_chat_inner_id(&dispute_key, party, &inner_id) {
+                if ts > max_ts {
+                    max_ts = ts;
+                }
+                continue;
             }
 
             let (sender, target_party) = app

--- a/src/ui/helpers/startup.rs
+++ b/src/ui/helpers/startup.rs
@@ -25,9 +25,10 @@ use super::attachments::{
     build_attachment_toast, legacy_placeholder_matches_filename, try_parse_attachment_message,
 };
 use super::chat_storage::{
-    load_chat_from_file, load_order_chat_from_file, max_party_timestamps,
-    remember_dispute_chat_inner_id, remember_order_chat_inner_id, save_chat_message,
-    save_order_chat_message,
+    dispute_chat_inner_id_known, load_chat_from_file, load_order_chat_from_file,
+    max_party_timestamps, order_chat_inner_id_known, remember_dispute_chat_inner_id,
+    remember_order_chat_inner_id, rewrite_dispute_chat_messages, rewrite_order_chat_messages,
+    save_chat_message, save_order_chat_message,
 };
 
 /// Parse `admin_privkey` text and store in [`AppState::admin_keys`].
@@ -421,8 +422,8 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
                 continue;
             }
 
-            // Durable inner-id replay guard (spec step 12).
-            if !remember_order_chat_inner_id(&order_id, &inner_id) {
+            // Durable replay guard: skip if already accepted (do not write again).
+            if order_chat_inner_id_known(&order_id, &inner_id) {
                 if ts > max_ts {
                     max_ts = ts;
                 }
@@ -440,13 +441,22 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
                         && m.attachment.is_none()
                         && legacy_placeholder_matches_filename(&m.content, &att.filename)
                 }) {
-                    let sender = messages_vec[idx].sender;
+                    let previous = messages_vec[idx].clone();
+                    let sender = previous.sender;
                     messages_vec[idx] = UserOrderChatMessage {
                         sender,
                         content: msg_content.clone(),
                         timestamp: ts,
                         attachment: Some(att.clone()),
                     };
+                    if !rewrite_order_chat_messages(&order_id, messages_vec) {
+                        messages_vec[idx] = previous;
+                        log::warn!(
+                            "Failed to persist order chat attachment upgrade for {order_id}; leaving inner id unrecorded"
+                        );
+                        continue;
+                    }
+                    let _ = remember_order_chat_inner_id(&order_id, &inner_id);
                     if ts > max_ts {
                         max_ts = ts;
                     }
@@ -477,6 +487,8 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
                 false
             });
             if is_duplicate {
+                // Content already in the transcript; still record the inner id.
+                let _ = remember_order_chat_inner_id(&order_id, &inner_id);
                 if ts > max_ts {
                     max_ts = ts;
                 }
@@ -493,7 +505,13 @@ pub fn apply_user_order_chat_updates(app: &mut AppState, updates: Vec<crate::ui:
                 timestamp: ts,
                 attachment,
             };
-            save_order_chat_message(&order_id, &msg);
+            if !save_order_chat_message(&order_id, &msg) {
+                log::warn!(
+                    "Failed to persist order chat message for {order_id}; leaving inner id unrecorded"
+                );
+                continue;
+            }
+            let _ = remember_order_chat_inner_id(&order_id, &inner_id);
             messages_vec.push(msg);
             if ts > max_ts {
                 max_ts = ts;
@@ -545,7 +563,7 @@ pub async fn apply_admin_chat_updates(
                 }
             }
 
-            if !remember_dispute_chat_inner_id(&dispute_key, party, &inner_id) {
+            if dispute_chat_inner_id_known(&dispute_key, party, &inner_id) {
                 if ts > max_ts {
                     max_ts = ts;
                 }
@@ -594,6 +612,7 @@ pub async fn apply_admin_chat_updates(
                         && m.attachment.is_none()
                         && legacy_placeholder_matches_filename(&m.content, &att.filename)
                 }) {
+                    let previous = messages_vec[idx].clone();
                     messages_vec[idx] = DisputeChatMessage {
                         sender,
                         content: msg_content.clone(),
@@ -601,6 +620,14 @@ pub async fn apply_admin_chat_updates(
                         target_party,
                         attachment: Some(att.clone()),
                     };
+                    if !rewrite_dispute_chat_messages(&dispute_key, messages_vec) {
+                        messages_vec[idx] = previous;
+                        log::warn!(
+                            "Failed to persist dispute chat attachment upgrade for {dispute_key}; leaving inner id unrecorded"
+                        );
+                        continue;
+                    }
+                    let _ = remember_dispute_chat_inner_id(&dispute_key, party, &inner_id);
                     if ts > max_ts {
                         max_ts = ts;
                     }
@@ -629,6 +656,7 @@ pub async fn apply_admin_chat_updates(
                 false
             });
             if is_duplicate {
+                let _ = remember_dispute_chat_inner_id(&dispute_key, party, &inner_id);
                 if ts > max_ts {
                     max_ts = ts;
                 }
@@ -653,7 +681,13 @@ pub async fn apply_admin_chat_updates(
                 target_party,
                 attachment,
             };
-            save_chat_message(&dispute_key, &msg);
+            if !save_chat_message(&dispute_key, &msg) {
+                log::warn!(
+                    "Failed to persist dispute chat message for {dispute_key}; leaving inner id unrecorded"
+                );
+                continue;
+            }
+            let _ = remember_dispute_chat_inner_id(&dispute_key, party, &inner_id);
             messages_vec.push(msg);
             if ts > max_ts {
                 max_ts = ts;

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -27,7 +27,7 @@ use std::{
     env, fs,
     time::{SystemTime, UNIX_EPOCH},
 };
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use zeroize::Zeroizing;
 
@@ -730,8 +730,8 @@ pub async fn respawn_chat_listener(
     pool: &SqlitePool,
     chat_listener_handle: &mut JoinHandle<()>,
     chat_router_cmd_tx: &mut UnboundedSender<ChatRouterCmd>,
-    admin_chat_updates_tx: &UnboundedSender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    user_order_chat_updates_tx: &UnboundedSender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    admin_chat_updates_tx: &Sender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    user_order_chat_updates_tx: &Sender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
 ) -> Result<(), String> {
     chat_listener_handle.abort();
     // Await the old task so it releases its subscription/state before the new one starts.
@@ -766,10 +766,10 @@ pub struct AppChannels {
     pub seed_words_rx: UnboundedReceiver<Result<Zeroizing<String>, String>>,
     pub message_notification_tx: UnboundedSender<MessageNotification>,
     pub message_notification_rx: UnboundedReceiver<MessageNotification>,
-    pub admin_chat_updates_tx: UnboundedSender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    pub admin_chat_updates_rx: UnboundedReceiver<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    pub user_order_chat_updates_tx: UnboundedSender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
-    pub user_order_chat_updates_rx: UnboundedReceiver<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    pub admin_chat_updates_tx: Sender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    pub admin_chat_updates_rx: Receiver<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    pub user_order_chat_updates_tx: Sender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    pub user_order_chat_updates_rx: Receiver<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
     pub save_attachment_tx: UnboundedSender<(String, ChatAttachment)>,
     pub save_attachment_rx: UnboundedReceiver<(String, ChatAttachment)>,
     pub send_order_attachment_tx: UnboundedSender<crate::util::SendOrderAttachmentJob>,
@@ -798,9 +798,13 @@ pub fn create_app_channels() -> AppChannels {
     let (message_notification_tx, message_notification_rx) =
         tokio::sync::mpsc::unbounded_channel::<MessageNotification>();
     let (admin_chat_updates_tx, admin_chat_updates_rx) =
-        tokio::sync::mpsc::unbounded_channel::<Result<Vec<AdminChatUpdate>, anyhow::Error>>();
+        tokio::sync::mpsc::channel::<Result<Vec<AdminChatUpdate>, anyhow::Error>>(
+            crate::util::chat_security::CHAT_UPDATE_CAPACITY,
+        );
     let (user_order_chat_updates_tx, user_order_chat_updates_rx) =
-        tokio::sync::mpsc::unbounded_channel::<Result<Vec<OrderChatUpdate>, anyhow::Error>>();
+        tokio::sync::mpsc::channel::<Result<Vec<OrderChatUpdate>, anyhow::Error>>(
+            crate::util::chat_security::CHAT_UPDATE_CAPACITY,
+        );
     let (save_attachment_tx, save_attachment_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, ChatAttachment)>();
     let (send_order_attachment_tx, send_order_attachment_rx) =

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,7 +43,7 @@ pub use network_status::NetworkStatus;
 pub use state::{
     apply_kind_color, order_message_to_notification, AdminChatLastSeen, AdminChatUpdate, AdminTab,
     AppState, BuyerInvoicePreference, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
-    DisputeChatMessage, DisputeFilter, FormState, InvoiceInputState,
+    DecodedChatMessage, DisputeChatMessage, DisputeFilter, FormState, InvoiceInputState,
     InvoiceNotificationActionSelection, KeyInputState, LnAddressVerifyResult, MessageNotification,
     MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen,
     OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -3,8 +3,8 @@ pub use crate::ui::admin_state::AddSolverState;
 pub use crate::ui::app_state::{AppState, UiMode};
 pub use crate::ui::chat::{
     AdminChatLastSeen, AdminChatUpdate, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
-    DisputeChatMessage, DisputeFilter, OrderChatLastSeen, OrderChatUpdate, UserChatSender,
-    UserOrderChatMessage,
+    DecodedChatMessage, DisputeChatMessage, DisputeFilter, OrderChatLastSeen, OrderChatUpdate,
+    UserChatSender, UserOrderChatMessage,
 };
 pub use crate::ui::navigation::{AdminTab, Tab, UserRole, UserTab};
 pub use crate::ui::orders::{

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -19,23 +19,28 @@
 //! listener. Chat keys are tracked/untracked via the global command channel
 //! published by [`set_chat_router_cmd_tx`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use nostr_sdk::prelude::*;
-use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::mpsc::{self, Sender};
 use uuid::Uuid;
 
 use crate::models::Order;
-use crate::ui::helpers::order_chat_since_from_file;
-use crate::ui::{AdminChatUpdate, ChatParty, OrderChatUpdate};
+use crate::ui::helpers::{
+    load_dispute_chat_inner_ids, load_order_chat_inner_ids, order_chat_since_from_file,
+};
+use crate::ui::{AdminChatUpdate, ChatParty, DecodedChatMessage, OrderChatUpdate};
+use crate::util::chat_security::{
+    try_emit_chat_update, ChatRateLimiters, OuterIdLru, CHAT_SEEN_OUTER_CAP,
+};
 use crate::util::chat_utils::{
     chat_keys_from_ecdh, clamp_chat_since_cursor_now, derive_shared_key_hex,
     fetch_chat_messages_for_shared_key, keys_from_shared_hex, unwrap_giftwrap_with_shared_key,
 };
 
 /// Identifies which chat a shared key belongs to.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChatKeyId {
     /// User P2P order chat, keyed by order id (UUID string).
     Order(String),
@@ -200,9 +205,9 @@ pub async fn maybe_track_order_chat(pool: &sqlx::SqlitePool, order_id: Uuid, tra
 /// (which dedupe by timestamp/last-seen) are unchanged.
 fn emit_messages(
     target: &ChatTarget,
-    messages: Vec<(String, i64, PublicKey)>,
-    admin_tx: &UnboundedSender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    user_tx: &UnboundedSender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    messages: Vec<DecodedChatMessage>,
+    admin_tx: &Sender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    user_tx: &Sender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
 ) {
     if messages.is_empty() {
         return;
@@ -213,18 +218,26 @@ fn emit_messages(
                 log::warn!("Order chat {order_id} missing local trade pubkey; skipping chat emit");
                 return;
             };
-            let _ = user_tx.send(Ok(vec![OrderChatUpdate {
-                order_id: order_id.clone(),
-                local_trade_pubkey,
-                messages,
-            }]));
+            let _ = try_emit_chat_update(
+                user_tx,
+                vec![OrderChatUpdate {
+                    order_id: order_id.clone(),
+                    local_trade_pubkey,
+                    messages,
+                }],
+                "order-chat",
+            );
         }
         ChatKeyId::Dispute(dispute_id, party) => {
-            let _ = admin_tx.send(Ok(vec![AdminChatUpdate {
-                dispute_id: dispute_id.clone(),
-                party: *party,
-                messages,
-            }]));
+            let _ = try_emit_chat_update(
+                admin_tx,
+                vec![AdminChatUpdate {
+                    dispute_id: dispute_id.clone(),
+                    party: *party,
+                    messages,
+                }],
+                "admin-chat",
+            );
         }
     }
 }
@@ -340,6 +353,10 @@ struct CmdOutcome {
     needs_resubscribe: bool,
     /// A newly tracked key awaiting post-subscribe history hydration.
     hydrate: Option<PendingHydration>,
+    /// Key that was newly tracked (seed durable inner-id set).
+    tracked: Option<ChatKeyId>,
+    /// Key that was removed (drop rate-limit / in-memory inner set).
+    untracked: Option<ChatKeyId>,
 }
 
 /// Apply one track/untrack command to the tracked set.
@@ -364,6 +381,8 @@ fn apply_chat_router_cmd(
                 return CmdOutcome {
                     needs_resubscribe: false,
                     hydrate: None,
+                    tracked: None,
+                    untracked: None,
                 };
             };
             let Some((_conv, sign)) = chat_keys_from_ecdh(&shared_keys) else {
@@ -371,6 +390,8 @@ fn apply_chat_router_cmd(
                 return CmdOutcome {
                     needs_resubscribe: false,
                     hydrate: None,
+                    tracked: None,
+                    untracked: None,
                 };
             };
             let target_pubkey = shared_keys.public_key();
@@ -382,9 +403,12 @@ fn apply_chat_router_cmd(
                 return CmdOutcome {
                     needs_resubscribe: false,
                     hydrate: None,
+                    tracked: None,
+                    untracked: None,
                 };
             }
             let since = since.map(clamp_chat_since_cursor_now);
+            let tracked_id = key_id.clone();
             targets.insert(
                 target_pubkey,
                 ChatTarget {
@@ -401,30 +425,43 @@ fn apply_chat_router_cmd(
                     shared_keys,
                     since,
                 }),
+                tracked: Some(tracked_id),
+                untracked: None,
             }
         }
         ChatRouterCmd::UntrackChatKey { key_id } => {
             let before = targets.len();
             targets.retain(|_, t| t.key_id != key_id);
+            let removed = targets.len() != before;
             CmdOutcome {
-                needs_resubscribe: targets.len() != before,
+                needs_resubscribe: removed,
                 hydrate: None,
+                tracked: None,
+                untracked: removed.then_some(key_id),
             }
         }
+    }
+}
+
+fn load_inner_ids_for_key(key_id: &ChatKeyId) -> HashSet<EventId> {
+    match key_id {
+        ChatKeyId::Order(order_id) => load_order_chat_inner_ids(order_id),
+        ChatKeyId::Dispute(dispute_id, party) => load_dispute_chat_inner_ids(dispute_id, *party),
     }
 }
 
 /// Backfill one newly tracked chat's history **after** the live subscription is
 /// active (relay subscriptions alone don't replay history). Because the live
 /// filter already covers this key, any message published during the fetch is also
-/// delivered live and deduped by the last-seen cursor. No-op if the key was
-/// untracked within the same command burst.
+/// delivered live and deduped by the last-seen cursor / inner-id set. No-op if
+/// the key was untracked within the same command burst.
 async fn hydrate_history(
     client: &Client,
     targets: &HashMap<PublicKey, ChatTarget>,
     pending: &PendingHydration,
-    admin_tx: &UnboundedSender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    user_tx: &UnboundedSender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    seen_inner: &mut HashMap<ChatKeyId, HashSet<EventId>>,
+    admin_tx: &Sender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    user_tx: &Sender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
 ) {
     let Some(target) = targets.get(&pending.target_pubkey) else {
         return;
@@ -434,9 +471,11 @@ async fn hydrate_history(
     {
         Ok(messages) => {
             let cutoff = pending.since.unwrap_or(0);
-            let history: Vec<(String, i64, PublicKey)> = messages
+            let inner = seen_inner.entry(target.key_id.clone()).or_default();
+            let history: Vec<DecodedChatMessage> = messages
                 .into_iter()
-                .filter(|(_, ts, _)| *ts >= cutoff)
+                .filter(|m| m.timestamp >= cutoff)
+                .filter(|m| inner.insert(m.inner_event_id))
                 .collect();
             emit_messages(target, history, admin_tx, user_tx);
         }
@@ -458,14 +497,17 @@ async fn hydrate_history(
 /// do not thrash unsubscribe/subscribe on every key.
 pub async fn listen_for_chat_messages(
     client: Client,
-    admin_chat_updates_tx: UnboundedSender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
-    user_order_chat_updates_tx: UnboundedSender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
+    admin_chat_updates_tx: Sender<Result<Vec<AdminChatUpdate>, anyhow::Error>>,
+    user_order_chat_updates_tx: Sender<Result<Vec<OrderChatUpdate>, anyhow::Error>>,
     mut cmd_rx: mpsc::UnboundedReceiver<ChatRouterCmd>,
 ) {
     // Create the notification receiver BEFORE subscribing so no live event is missed.
     let mut notifications = client.notifications();
     let mut targets: HashMap<PublicKey, ChatTarget> = HashMap::new();
     let mut current_subs = LiveSubs::default();
+    let mut seen_outer = OuterIdLru::new(CHAT_SEEN_OUTER_CAP);
+    let mut rate_limiters: ChatRateLimiters<ChatKeyId> = ChatRateLimiters::default();
+    let mut seen_inner: HashMap<ChatKeyId, HashSet<EventId>> = HashMap::new();
 
     loop {
         tokio::select! {
@@ -475,17 +517,24 @@ pub async fn listen_for_chat_messages(
                     current_subs.clear(&client).await;
                     break;
                 };
-                let CmdOutcome {
-                    mut needs_resubscribe,
-                    hydrate,
-                } = apply_chat_router_cmd(cmd, &mut targets);
-                let mut pending_hydration: Vec<PendingHydration> = hydrate.into_iter().collect();
-                // Drain a burst of pending cmds (startup track set, finalize untracks, etc.)
-                // then rebuild the live filter once, and only then backfill history.
+                let mut outcomes = vec![apply_chat_router_cmd(cmd, &mut targets)];
                 while let Ok(more) = cmd_rx.try_recv() {
-                    let outcome = apply_chat_router_cmd(more, &mut targets);
+                    outcomes.push(apply_chat_router_cmd(more, &mut targets));
+                }
+                let mut needs_resubscribe = false;
+                let mut pending_hydration: Vec<PendingHydration> = Vec::new();
+                for outcome in outcomes {
                     needs_resubscribe |= outcome.needs_resubscribe;
                     pending_hydration.extend(outcome.hydrate);
+                    if let Some(key_id) = outcome.tracked {
+                        seen_inner
+                            .entry(key_id.clone())
+                            .or_insert_with(|| load_inner_ids_for_key(&key_id));
+                    }
+                    if let Some(key_id) = outcome.untracked {
+                        rate_limiters.remove(&key_id);
+                        seen_inner.remove(&key_id);
+                    }
                 }
                 if needs_resubscribe {
                     resubscribe(&client, &targets, &mut current_subs).await;
@@ -498,6 +547,7 @@ pub async fn listen_for_chat_messages(
                         &client,
                         &targets,
                         pending,
+                        &mut seen_inner,
                         &admin_chat_updates_tx,
                         &user_order_chat_updates_tx,
                     )
@@ -517,11 +567,26 @@ pub async fn listen_for_chat_messages(
                 let Some(target) = resolve_chat_target(&targets, &event) else {
                     continue;
                 };
+                // Spec order: outer-id LRU, then rate limit — both before decrypt.
+                if !seen_outer.insert(event.id) {
+                    continue;
+                }
+                if !rate_limiters.allow(&target.key_id) {
+                    log::debug!(
+                        "[chat_live] rate-limited chat event for {:?}",
+                        target.key_id
+                    );
+                    continue;
+                }
                 match unwrap_giftwrap_with_shared_key(&target.shared_keys, &event, None).await {
-                    Ok((content, ts, sender)) => {
+                    Ok(msg) => {
+                        let inner = seen_inner.entry(target.key_id.clone()).or_default();
+                        if !inner.insert(msg.inner_event_id) {
+                            continue;
+                        }
                         emit_messages(
                             target,
-                            vec![(content, ts, sender)],
+                            vec![msg],
                             &admin_chat_updates_tx,
                             &user_order_chat_updates_tx,
                         );

--- a/src/util/chat_security.rs
+++ b/src/util/chat_security.rs
@@ -1,0 +1,207 @@
+//! Caller-owned chat security controls from the Mostro P2P chat spec.
+//!
+//! mostro-core's [`unwrap_chat_message`](mostro_core::chat::unwrap_chat_message)
+//! performs the cheap cryptographic/structural checks. Clients must still:
+//! * drop duplicate **outer** event ids (bounded LRU, pre-decrypt)
+//! * enforce a per-conversation **token bucket** (~30/min, burst 60) before decrypt
+//! * durably dedupe **inner** event ids (see [`crate::ui::helpers::chat_storage`])
+//! * isolate chat flood from the UI / DM path (bounded update channels)
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::Hash;
+use std::time::Instant;
+
+use nostr_sdk::prelude::EventId;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::Sender;
+
+/// Sustained chat event rate per conversation (spec recommendation).
+pub const CHAT_RATE_PER_MINUTE: f64 = 30.0;
+/// Burst capacity for the per-conversation token bucket.
+pub const CHAT_RATE_BURST: f64 = 60.0;
+/// Bounded outer-id LRU capacity (duplicate relay deliveries only).
+pub const CHAT_SEEN_OUTER_CAP: usize = 4096;
+/// Max queued chat-update batches toward the UI; excess is dropped.
+pub const CHAT_UPDATE_CAPACITY: usize = 128;
+
+/// Token bucket that bounds how much decrypt work a counterparty can force.
+#[derive(Debug)]
+pub struct ChatRateLimiter {
+    tokens: f64,
+    last: Instant,
+}
+
+impl ChatRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            tokens: CHAT_RATE_BURST,
+            last: Instant::now(),
+        }
+    }
+
+    /// Returns `true` when one event may proceed to decrypt.
+    pub fn allow(&mut self) -> bool {
+        self.allow_at(Instant::now())
+    }
+
+    /// Testable variant of [`Self::allow`].
+    pub fn allow_at(&mut self, now: Instant) -> bool {
+        let elapsed = now.duration_since(self.last).as_secs_f64();
+        self.last = now;
+        self.tokens = (self.tokens + elapsed * (CHAT_RATE_PER_MINUTE / 60.0)).min(CHAT_RATE_BURST);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for ChatRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-conversation rate limiters keyed by chat identity.
+pub struct ChatRateLimiters<K: Eq + Hash> {
+    buckets: HashMap<K, ChatRateLimiter>,
+}
+
+impl<K: Eq + Hash> Default for ChatRateLimiters<K> {
+    fn default() -> Self {
+        Self {
+            buckets: HashMap::new(),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone> ChatRateLimiters<K> {
+    pub fn allow(&mut self, key: &K) -> bool {
+        self.buckets.entry(key.clone()).or_default().allow()
+    }
+
+    pub fn remove(&mut self, key: &K) {
+        self.buckets.remove(key);
+    }
+}
+
+/// Fixed-capacity set of recently seen outer event ids (oldest evicted first).
+///
+/// Spec: cheap pre-decryption filter against duplicate relay deliveries — not a
+/// security boundary. Dropping old entries is safe.
+#[derive(Debug)]
+pub struct OuterIdLru {
+    set: HashSet<EventId>,
+    order: VecDeque<EventId>,
+    cap: usize,
+}
+
+impl OuterIdLru {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            set: HashSet::new(),
+            order: VecDeque::with_capacity(cap.min(64)),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Records `id`, returning `true` when it had not been seen (or was evicted).
+    pub fn insert(&mut self, id: EventId) -> bool {
+        if !self.set.insert(id) {
+            return false;
+        }
+        self.order.push_back(id);
+        while self.order.len() > self.cap {
+            if let Some(evicted) = self.order.pop_front() {
+                self.set.remove(&evicted);
+            }
+        }
+        true
+    }
+
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+}
+
+impl Default for OuterIdLru {
+    fn default() -> Self {
+        Self::new(CHAT_SEEN_OUTER_CAP)
+    }
+}
+
+/// Try to enqueue a chat update; on a full bounded channel, drop and warn.
+///
+/// Keeps a chat flood from growing unbounded memory or stalling the UI loop.
+pub fn try_emit_chat_update<T: std::fmt::Debug>(
+    tx: &Sender<Result<T, anyhow::Error>>,
+    update: T,
+    label: &str,
+) -> bool {
+    match tx.try_send(Ok(update)) {
+        Ok(()) => true,
+        Err(TrySendError::Full(_)) => {
+            log::warn!("[chat] dropping {label} update: UI queue full (capacity under pressure)");
+            false
+        }
+        Err(TrySendError::Closed(_)) => {
+            log::debug!("[chat] {label} update channel closed");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::prelude::EventId;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    fn fake_event_id(byte: u8) -> EventId {
+        EventId::from_slice(&[byte; 32]).expect("event id")
+    }
+
+    #[test]
+    fn rate_limiter_allows_burst_then_rejects() {
+        let mut lim = ChatRateLimiter::new();
+        let t0 = Instant::now();
+        for _ in 0..(CHAT_RATE_BURST as u32) {
+            assert!(lim.allow_at(t0), "burst should be allowed");
+        }
+        assert!(!lim.allow_at(t0), "over burst must be rejected");
+        // After ~2 seconds at 30/min we regain one token.
+        let later = t0 + Duration::from_secs_f64(2.1);
+        assert!(lim.allow_at(later), "tokens refill over time");
+    }
+
+    #[test]
+    fn outer_lru_rejects_duplicates_and_evicts() {
+        let mut lru = OuterIdLru::new(2);
+        let a = fake_event_id(1);
+        let b = fake_event_id(2);
+        let c = fake_event_id(3);
+        assert!(lru.insert(a));
+        assert!(!lru.insert(a));
+        assert!(lru.insert(b));
+        assert!(lru.insert(c)); // evicts a
+        assert_eq!(lru.len(), 2);
+        assert!(lru.insert(a)); // a was evicted, accepted again
+    }
+
+    #[tokio::test]
+    async fn try_emit_drops_when_queue_full_without_blocking() {
+        let (tx, mut rx) = mpsc::channel::<Result<&'static str, anyhow::Error>>(1);
+        assert!(try_emit_chat_update(&tx, "first", "test"));
+        assert!(!try_emit_chat_update(&tx, "second", "test"));
+        // First item still receivable; flood did not block the caller.
+        assert_eq!(rx.recv().await.unwrap().unwrap(), "first");
+        assert!(try_emit_chat_update(&tx, "third", "test"));
+    }
+}

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -11,12 +11,15 @@ use nostr_sdk::nips::nip44;
 use nostr_sdk::prelude::*;
 
 use crate::models::{AdminDispute, Order};
-use crate::ui::{AdminChatLastSeen, AdminChatUpdate, ChatParty, ChatSender, DisputeChatMessage};
+use crate::ui::{
+    AdminChatLastSeen, AdminChatUpdate, ChatParty, ChatSender, DecodedChatMessage,
+    DisputeChatMessage,
+};
 use crate::util::dm_utils::FETCH_EVENTS_TIMEOUT;
 use crate::util::mostro_info::MostroInstanceInfo;
 
-/// Messages grouped by (dispute_id, party); value is (content, timestamp, sender_pubkey).
-type AdminChatByKey = HashMap<(String, ChatParty), Vec<(String, i64, PublicKey)>>;
+/// Messages grouped by (dispute_id, party).
+type AdminChatByKey = HashMap<(String, ChatParty), Vec<DecodedChatMessage>>;
 
 // ---------------------------------------------------------------------------
 // Shared-key helpers (ECDH IKM + K_conv / K_sign)
@@ -171,7 +174,7 @@ pub async fn unwrap_giftwrap_with_shared_key(
     shared_keys: &Keys,
     event: &Event,
     allowed_signers: Option<&[PublicKey]>,
-) -> Result<(String, i64, PublicKey)> {
+) -> Result<DecodedChatMessage> {
     if event.kind == Kind::GiftWrap {
         let msg = unwrap_giftwrap_chat_message(shared_keys, event)
             .await
@@ -183,7 +186,12 @@ pub async fn unwrap_giftwrap_with_shared_key(
                 ));
             }
         }
-        return Ok((msg.content, msg.created_at.as_secs() as i64, msg.sender));
+        return Ok(DecodedChatMessage {
+            content: msg.content,
+            timestamp: msg.created_at.as_secs() as i64,
+            sender: msg.sender,
+            inner_event_id: msg.inner_event_id,
+        });
     }
 
     let (conv, sign) = chat_keys_from_ecdh(shared_keys)
@@ -207,7 +215,12 @@ pub async fn unwrap_giftwrap_with_shared_key(
 
     let msg = unwrap_chat_message(&conv, &sign_pk, allowed, event, now)
         .map_err(|e| anyhow::anyhow!("Failed to unwrap chat event: {e}"))?;
-    Ok((msg.content, msg.created_at.as_secs() as i64, msg.sender))
+    Ok(DecodedChatMessage {
+        content: msg.content,
+        timestamp: msg.created_at.as_secs() as i64,
+        sender: msg.sender,
+        inner_event_id: msg.inner_event_id,
+    })
 }
 
 /// Fetch recent chat events for a shared ECDH key and return decoded messages.
@@ -217,7 +230,7 @@ pub async fn unwrap_giftwrap_with_shared_key(
 pub async fn fetch_gift_wraps_for_shared_key(
     client: &Client,
     shared_keys: &Keys,
-) -> Result<Vec<(String, i64, PublicKey)>> {
+) -> Result<Vec<DecodedChatMessage>> {
     fetch_chat_messages_for_shared_key(client, shared_keys, None, None).await
 }
 
@@ -229,7 +242,7 @@ pub async fn fetch_chat_messages_for_shared_key(
     shared_keys: &Keys,
     allowed_signers: Option<&[PublicKey]>,
     since: Option<i64>,
-) -> Result<Vec<(String, i64, PublicKey)>> {
+) -> Result<Vec<DecodedChatMessage>> {
     let local_now = Timestamp::now().as_secs() as i64;
     let seven_days_secs: i64 = 7 * 24 * 60 * 60;
     let lookback_floor = local_now.saturating_sub(seven_days_secs);
@@ -266,15 +279,15 @@ pub async fn fetch_chat_messages_for_shared_key(
     let mut messages = Vec::new();
     for wrapped in events.iter() {
         match unwrap_giftwrap_with_shared_key(shared_keys, wrapped, allowed_signers).await {
-            Ok((content, ts, sender_pubkey)) => {
-                messages.push((content, ts, sender_pubkey));
+            Ok(msg) => {
+                messages.push(msg);
             }
             Err(e) => {
                 log::warn!("Failed to unwrap chat event {}: {}", wrapped.id, e);
             }
         }
     }
-    messages.sort_by_key(|(_, ts, _)| *ts);
+    messages.sort_by_key(|m| m.timestamp);
     Ok(messages)
 }
 
@@ -332,14 +345,14 @@ async fn fetch_party_messages(
         return;
     };
 
-    for (content, ts, sender_pubkey) in messages {
-        if ts < last_seen {
+    for msg in messages {
+        if msg.timestamp < last_seen {
             continue;
         }
         by_key
             .entry((dispute_id.to_string(), party))
             .or_default()
-            .push((content, ts, sender_pubkey));
+            .push(msg);
     }
 }
 
@@ -411,34 +424,37 @@ pub async fn fetch_observer_chat(
         role_map.insert(*apk, ChatSender::Admin);
     }
 
-    for (_, _, pk) in &raw {
-        if role_map.contains_key(pk) {
+    for msg in &raw {
+        if role_map.contains_key(&msg.sender) {
             continue;
         }
         let has_buyer = role_map.values().any(|s| *s == ChatSender::Buyer);
         let has_seller = role_map.values().any(|s| *s == ChatSender::Seller);
         if !has_buyer {
-            role_map.insert(*pk, ChatSender::Buyer);
+            role_map.insert(msg.sender, ChatSender::Buyer);
         } else if !has_seller {
-            role_map.insert(*pk, ChatSender::Seller);
+            role_map.insert(msg.sender, ChatSender::Seller);
         } else {
-            role_map.insert(*pk, ChatSender::Admin);
+            role_map.insert(msg.sender, ChatSender::Admin);
         }
     }
 
     let mut messages = Vec::with_capacity(raw.len());
-    for (content, ts, pk) in raw {
-        let sender = role_map.get(&pk).copied().unwrap_or(ChatSender::Admin);
+    for msg in raw {
+        let sender = role_map
+            .get(&msg.sender)
+            .copied()
+            .unwrap_or(ChatSender::Admin);
 
-        let (msg_content, attachment) = match try_parse_attachment_message(&content) {
+        let (msg_content, attachment) = match try_parse_attachment_message(&msg.content) {
             Some((att, display)) => (display, Some(att)),
-            None => (content, None),
+            None => (msg.content, None),
         };
 
         messages.push(DisputeChatMessage {
             sender,
             content: msg_content,
-            timestamp: ts,
+            timestamp: msg.timestamp,
             target_party: None,
             attachment,
         });
@@ -553,8 +569,8 @@ mod tests {
             .await
             .expect("unwrap succeeds");
 
-        assert_eq!(unwrapped.2, sender.public_key());
-        assert_eq!(unwrapped.0, content);
+        assert_eq!(unwrapped.sender, sender.public_key());
+        assert_eq!(unwrapped.content, content);
     }
 
     #[test]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod blossom;
 pub mod chat_listener;
+pub mod chat_security;
 pub mod chat_utils;
 pub mod db_utils;
 pub mod dm_utils;


### PR DESCRIPTION
## Summary
- **Outer-id LRU** (cap 4096) and **token bucket** (~30/min, burst 60) before decrypt in `chat_listener` (matches [protocol](https://mostro.network/protocol/chat.html) / mostro-chat).
- **Durable inner-event-id** files beside transcripts (`*.inner_ids`); seeded on track, checked live/hydrate, persisted on apply.
- **Isolation**: chat update channels are bounded (`CHAT_UPDATE_CAPACITY=128`) with `try_send` drop-under-pressure (DM/UI stay responsive).
- Absolute clock bound already in mostro-core unwrap; cursor clamp from #104 unchanged.

Part of #102 (Step 4). Please review before merge.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test --all-features`
- [x] Unit tests: rate limiter burst, outer LRU eviction, try_emit drop-when-full, inner-id replay at path
- [ ] Manual: flood kind-14 to a tracked chat — UI/DM remain usable; excess dropped (logs)
- [ ] Manual: replay same inner under new outer — second delivery ignored
- [ ] Restart — hydrate does not re-inject already-seen inner ids


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate chat messages after reconnects or history refreshes.
  - Improved replay protection for previously processed updates.
  - Added safeguards against excessive activity and overloaded update queues.
  - Improved chat update reliability during temporary errors or high traffic.

- **Improvements**
  - Chat messages now retain verification and event details for consistent processing.
  - Order and dispute chat history is persisted more reliably across sessions.
  - Failed history writes can be retried without losing updates.
  - Improved handling of chat history synchronization and live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->