### PR TITLE
Fix(ui): Show dispute shortcut in My Trades footer

### DIFF
--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -178,6 +178,7 @@ pub const FOOTER_MYTRADES_ENTER_SEND: &str = "Enter: Send";
 pub const FOOTER_MYTRADES_SHIFT_I_DISABLE: &str = "Shift+I: Disable input";
 pub const FOOTER_MYTRADES_SHIFT_I_ENABLE: &str = "Shift+I: Enable input";
 pub const FOOTER_MYTRADES_SHIFT_C_CANCEL: &str = "Shift+C: Cancel order";
+pub const FOOTER_MYTRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Dispute";
 pub const FOOTER_MYTRADES_SHIFT_F_FIAT_SENT: &str = "Shift+F: Mark fiat sent";
 pub const FOOTER_MYTRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats";
 pub const FOOTER_MYTRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty";

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::ui::constants::{
     FOOTER_CTRL_O_SEND_FILE, FOOTER_CTRL_SHIFT_O_RETRY, FOOTER_CTRL_S_SAVE_FILE,
     FOOTER_MYTRADES_END_BOTTOM, FOOTER_MYTRADES_ENTER_SEND, FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-    FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_C_CANCEL,
+    FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_C_CANCEL, FOOTER_MYTRADES_SHIFT_D_DISPUTE,
     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT, FOOTER_MYTRADES_SHIFT_I_DISABLE,
     FOOTER_MYTRADES_SHIFT_I_ENABLE, FOOTER_MYTRADES_SHIFT_R_RELEASE, FOOTER_MYTRADES_SHIFT_V_RATE,
     FOOTER_SENDING_ATTACHMENT, HELP_KEY,
@@ -559,8 +559,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SHIFT_I_DISABLE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}",
+                    "{} | {} | {} | {}",
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
@@ -579,8 +580,9 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     HELP_KEY, FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_I_ENABLE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}",
+                    "{} | {} | {} | {}",
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
@@ -597,18 +599,17 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
         if app.order_chat_input_enabled {
             Text::from(vec![
                 Line::from(format!(
-                    "{} | {} | {} | {} | {}",
+                    "{} | {} | {} | {}",
                     HELP_KEY,
                     FOOTER_MYTRADES_SELECT_ORDER,
                     FOOTER_MYTRADES_ENTER_SEND,
                     FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
                 )),
                 Line::from(format!(
                     "{} | {} | {} | {} | {}{}",
+                    FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
-                    FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
                     attach_hints,
@@ -622,12 +623,12 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SELECT_ORDER,
                     FOOTER_MYTRADES_SHIFT_I_ENABLE,
                     FOOTER_MYTRADES_SHIFT_C_CANCEL,
-                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
+                    FOOTER_MYTRADES_SHIFT_D_DISPUTE,
                 )),
                 Line::from(format!(
                     "{} | {} | {} | {}{}",
+                    FOOTER_MYTRADES_SHIFT_F_FIAT_SENT,
                     FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
-                    FOOTER_MYTRADES_END_BOTTOM,
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
                     attach_hints,
@@ -637,20 +638,22 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
     } else {
         let base = if app.order_chat_input_enabled {
             format!(
-                "{} | {} | {} | {} | {}",
+                "{} | {} | {} | {} | {} | {}",
                 HELP_KEY,
                 FOOTER_MYTRADES_SELECT_ORDER,
                 FOOTER_MYTRADES_ENTER_SEND,
                 FOOTER_MYTRADES_SHIFT_I_DISABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL
+                FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                FOOTER_MYTRADES_SHIFT_D_DISPUTE
             )
         } else {
             format!(
-                "{} | {} | {} | {}",
+                "{} | {} | {} | {} | {}",
                 HELP_KEY,
                 FOOTER_MYTRADES_SELECT_ORDER,
                 FOOTER_MYTRADES_SHIFT_I_ENABLE,
-                FOOTER_MYTRADES_SHIFT_C_CANCEL
+                FOOTER_MYTRADES_SHIFT_C_CANCEL,
+                FOOTER_MYTRADES_SHIFT_D_DISPUTE
             )
         };
         Text::raw(format!("{base}{attach_hints}"))
@@ -800,6 +803,38 @@ mod tests {
         assert!(!buffer_contains(
             buffer,
             "hidden-prefix-that-should-scroll-away"
+        ));
+    }
+
+    #[test]
+    fn render_footer_lists_dispute_shortcut_next_to_cancel() {
+        let order_id = Uuid::nil().to_string();
+        let mut app = AppState::new(UserRole::User);
+        app.mode = UiMode::UserMode(UserMode::Normal);
+        app.my_trades_maker_book.push(OrderChatListItem {
+            order_id,
+            status: Some(Status::Active),
+            amount: Some(1000),
+            fiat: Some((10, "USD".to_string())),
+            trade_index: Some(1),
+            payment_method: Some("cash".to_string()),
+            premium: Some(0),
+            buyer_trade_pubkey: None,
+            seller_trade_pubkey: None,
+            buyer_reputation: None,
+            seller_reputation: None,
+        });
+
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_order_in_progress(frame, frame.area(), &mut app))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+
+        assert!(buffer_contains(
+            buffer,
+            "Shift+C: Cancel order | Shift+D: Dispute"
         ));
     }
 }


### PR DESCRIPTION
  ## Summary

  - Add the Shift+D dispute shortcut to the visible My Trades footer
  - Place the dispute hint next to the cooperative cancel hint
  - Add render coverage so the footer keeps showing the dispute command

  ## Testing

  - cargo fmt --all -- --check
  - cargo check --all-targets --all-features
  - cargo test --all-features
  - cargo clippy --all-targets --all-features -- -D warnings

All checks passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Shift+D: Dispute” shortcut hint to in-progress order footers.
  * The hint is displayed consistently across supported footer layouts and input states.

* **Tests**
  * Added coverage confirming the dispute shortcut appears alongside the cancel shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->