### PR TITLE
chore: migrate to nostr-sdk 0.45.1 and mostro-core 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,28 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base58ck"
 version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,8 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -565,15 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -968,7 +935,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1021,12 +988,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "educe"
@@ -1111,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1293,12 +1254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,10 +1379,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1437,11 +1390,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2046,16 +1997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,12 +2174,6 @@ checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -2684,7 +2619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3020,62 +2955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,7 +3240,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3438,12 +3316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,7 +3334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3471,7 +3343,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3499,7 +3370,6 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3521,7 +3391,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3536,7 +3406,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3829,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4160,7 +4029,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5007,16 +4876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,7 +5012,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -55,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -210,6 +220,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -426,7 +442,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -466,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -477,6 +493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -487,11 +504,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.0",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -514,8 +543,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -577,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -765,7 +805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -775,7 +814,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1517,6 +1558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,7 +1747,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1899,6 +1949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,9 +2111,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2140,7 +2199,7 @@ checksum = "73a989342d2e9381c85d381898c3a925bad930958acd480fe0221f680c7856eb"
 dependencies = [
  "aes",
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bech32 0.11.1",
  "bitcoin",
  "cbc",
@@ -2256,9 +2315,9 @@ version = "0.2.4"
 dependencies = [
  "anyhow",
  "arboard",
- "base64",
+ "base64 0.23.1",
  "bip39",
- "chacha20poly1305",
+ "chacha20poly1305 0.11.0",
  "chrono",
  "config",
  "crossterm",
@@ -2279,7 +2338,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tokio",
  "toml",
@@ -2362,13 +2421,13 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dde8c76076d334409d86c2e1db3e97abe5deb8cb92744f939cbc1fa45bd69e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bech32 0.12.0",
  "bip39",
  "bitcoin_hashes 1.2.0",
  "cbc",
  "chacha20 0.9.1",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "faster-hex",
  "opaquerr",
  "rand 0.10.1",
@@ -2877,7 +2936,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -3274,11 +3343,11 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "h2",
@@ -3398,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3801,7 +3870,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -3812,7 +3881,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -3876,7 +3945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
@@ -3918,7 +3987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "crc",
@@ -4122,7 +4191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
@@ -4268,9 +4337,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4576,9 +4645,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -4614,6 +4683,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "universal-time"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,7 +4710,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -5576,13 +5655,13 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -126,20 +126,21 @@ dependencies = [
 
 [[package]]
 name = "async-wsocket"
-version = "0.13.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
+checksum = "2c713e1f14c7b82e32ea159af1c6e2f070cfadbdf23fb2512acce9af0a26f1a2"
 dependencies = [
- "async-utility",
  "futures",
  "futures-util",
  "js-sys",
  "tokio",
+ "tokio-happy-eyeballs",
  "tokio-rustls",
  "tokio-socks",
  "tokio-tungstenite",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -160,12 +161,6 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "atomic-destructor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-waker"
@@ -203,12 +198,11 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -230,12 +224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
+
+[[package]]
 name = "bip39"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
@@ -259,55 +259,77 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck",
- "bech32",
- "bitcoin-internals",
+ "bech32 0.11.1",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.101",
+ "hex-conservative 0.2.2",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.29.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
- "serde",
-]
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5304e53726dbe5f93141535e102ed97b5bf4714fbecefdda8f9fb98d7fdaff0e"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
@@ -333,6 +355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -482,7 +513,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -504,6 +535,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -563,6 +600,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -727,6 +770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +786,15 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -788,7 +849,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -830,10 +891,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -854,7 +927,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -997,7 +1070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1045,6 +1118,16 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -1377,6 +1460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,7 +1568,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1466,7 +1586,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1516,6 +1645,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1774,18 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,13 +1998,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1966,7 +2091,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d83bd798e04ab9eecc8bbef1fa17d3808859bcdc0406bd16c55d51c8834444"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "lightning-types",
 ]
@@ -2016,7 +2141,7 @@ dependencies = [
  "aes",
  "anyhow",
  "base64",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "cbc",
  "email_address",
@@ -2040,12 +2165,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lru"
@@ -2079,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2152,6 +2271,7 @@ dependencies = [
  "lnurl-rs",
  "log",
  "mostro-core",
+ "nostr",
  "nostr-sdk",
  "ratatui",
  "ratatui-explorer",
@@ -2159,7 +2279,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tokio",
  "toml",
@@ -2171,17 +2291,19 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1f5305546178ad152a715a39274870cc707a8d402ae404d85fc9693b56ac1"
+checksum = "976a8cfc914710e7acfe08645f1ec3467672c60d581e73963fbdd13b53a51b15"
 dependencies = [
  "bitcoin",
  "chrono",
- "hkdf",
+ "hkdf 0.13.0",
+ "nostr",
  "nostr-sdk",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "uuid",
  "wasm-bindgen",
 ]
@@ -2236,79 +2358,70 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.2"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
+checksum = "5dde8c76076d334409d86c2e1db3e97abe5deb8cb92744f939cbc1fa45bd69e7"
 dependencies = [
  "base64",
- "bech32",
+ "bech32 0.12.0",
  "bip39",
- "bitcoin_hashes",
+ "bitcoin_hashes 1.2.0",
  "cbc",
  "chacha20 0.9.1",
  "chacha20poly1305",
- "getrandom 0.2.17",
- "hex",
- "instant",
- "scrypt",
- "secp256k1",
+ "faster-hex",
+ "opaquerr",
+ "rand 0.10.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "unicode-normalization",
+ "universal-time",
  "url",
+ "zeroize",
 ]
 
 [[package]]
 name = "nostr-database"
-version = "0.44.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
+checksum = "4b1fdb9fcba732e32719662afad1b267e50322dbe89e506017ec13f24361bddf"
 dependencies = [
- "lru 0.16.4",
  "nostr",
- "tokio",
+ "opaquerr",
 ]
 
 [[package]]
 name = "nostr-gossip"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
+checksum = "fa07539e52a71cb91fe0d693facaa298f03fcf9edcd66a521094e18e286e2336"
 dependencies = [
  "nostr",
-]
-
-[[package]]
-name = "nostr-relay-pool"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1073ccfbaea5549fb914a9d52c68dab2aecda61535e5143dd73e95445a804b"
-dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "hex",
- "lru 0.16.4",
- "negentropy",
- "nostr",
- "nostr-database",
- "tokio",
- "tracing",
+ "opaquerr",
 ]
 
 [[package]]
 name = "nostr-sdk"
-version = "0.44.1"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
+checksum = "26c86342f367bd9b173ec4a697e936e3a82d6dad5b4aa06c0d35d9b4f88a8e72"
 dependencies = [
  "async-utility",
+ "async-wsocket",
+ "faster-hex",
+ "futures",
+ "lru",
+ "negentropy",
  "nostr",
  "nostr-database",
  "nostr-gossip",
- "nostr-relay-pool",
+ "opaquerr",
+ "rand 0.10.1",
  "tokio",
+ "tokio-stream",
  "tracing",
+ "universal-time",
 ]
 
 [[package]]
@@ -2469,6 +2582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "opaquerr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f933a4265d5cdad61d19bbdfc972ea5726d56cd8d3d57b8f2d3c365dd42bee9"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2572,31 +2691,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2653,7 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3033,7 +3131,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "itertools",
  "kasuari",
- "lru 0.18.2",
+ "lru",
  "palette",
  "serde",
  "strum",
@@ -3246,8 +3344,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3295,7 +3393,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3354,7 +3452,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3388,15 +3486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,27 +3510,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "secp256k1-sys",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes 0.14.101",
+ "rand 0.8.6",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -3484,9 +3572,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3506,29 +3594,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3566,7 +3654,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3577,7 +3665,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3623,7 +3722,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3661,7 +3760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3722,7 +3821,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3760,7 +3859,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3782,7 +3881,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3791,8 +3890,8 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -3803,7 +3902,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3829,8 +3928,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -3840,7 +3939,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4041,7 +4140,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -4185,6 +4284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-happy-eyeballs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8564c32dfb6f4257f8bc6edfc178a34af97520e0b7b9815500c55eb3d092f29f"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,13 +4334,14 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -4403,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -4500,9 +4609,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "universal-time"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a939edecc3c5a7b83c02e5f6b3c31d2bc69eabcc9a87ab12c6d37ee6dbc856"
 
 [[package]]
 name = "untrusted"
@@ -4645,9 +4760,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4658,9 +4773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4668,9 +4783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4678,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4691,9 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4804,9 +4919,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4873,7 +4988,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -4959,7 +5074,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,16 @@ description = "Mostro TUI client"
 [dependencies]
 ratatui = "0.30.2"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-mostro-core = "0.14.2"
-nostr-sdk = { version = "0.44.1", features = ["nip06", "nip44", "nip59"] }
+mostro-core = "0.14.3"
+nostr-sdk = { version = "0.45.1" }
+# Enable NIP features on `nostr` (re-exported via nostr-sdk::prelude). nip06 is
+# required for Keys::from_mnemonic_*; nip44/nip59 for DMs and gift wraps.
+nostr = { version = "0.45.1", default-features = false, features = [
+  "std",
+  "nip06",
+  "nip44",
+  "nip59",
+] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls"] }
 tokio = { version = "1.50.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,15 @@ lnurl-rs = { version = "0.10.0", default-features = false, features = ["ureq"] }
 arboard = { version = "3.3", features = ["wayland-data-control"] }
 libc = "0.2.189"
 reqwest = { version = "0.13.4", default-features = false, features = [
-  "rustls",
+  "rustls-no-provider",
   "json",
   "http2",
 ] }
-rustls = { version = "0.23.43", features = ["ring"] }
+rustls = { version = "0.23.43", default-features = false, features = [
+  "ring",
+  "std",
+  "tls12",
+] }
 chacha20poly1305 = "0.11.0"
 sha2 = "0.11.0"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,36 +22,36 @@ nostr = { version = "0.45.1", default-features = false, features = [
 ] }
 bip39 = { version = "2.1.0", features = ["rand"] }
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls"] }
-tokio = { version = "1.50.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 chrono = "0.4.45"
 futures = "0.3.34"
-anyhow = "1.0.98"
+anyhow = "1.0.104"
 dirs = "6.0.0"
 fern = "0.7.1"
 log = "0.4.33"
-config = { version = "0.15.22", features = ["toml"] }
+config = { version = "0.15.25", features = ["toml"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1.4"
-base64 = "0.22.1"
+base64 = "0.23.1"
 uuid = { version = "1.24.0", features = ["v4", "serde"] }
 lightning-invoice = { version = "0.34.1", features = ["std"] }
 lnurl-rs = { version = "0.10.0", default-features = false, features = ["ureq"] }
 arboard = { version = "3.3", features = ["wayland-data-control"] }
-libc = "0.2"
-reqwest = { version = "0.13.2", default-features = false, features = [
+libc = "0.2.189"
+reqwest = { version = "0.13.4", default-features = false, features = [
   "rustls",
   "json",
   "http2",
 ] }
-rustls = { version = "0.23.37", features = ["ring"] }
-chacha20poly1305 = "0.10"
-sha2 = "0.10"
+rustls = { version = "0.23.43", features = ["ring"] }
+chacha20poly1305 = "0.11.0"
+sha2 = "0.11.0"
 hex = "0.4"
 tui-scrollview = "0.6.7"
 ratatui-explorer = "0.3.0"
 zeroize = "1.9"
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13.3"
 
 [package.metadata.release]
 publish = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,8 @@ use crate::ui::ui_draw;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    // Set rustls crypto provider once (required when both ring and aws-lc-rs are in the dependency tree)
+    // Install ring as the rustls crypto provider before any TLS clients are built
+    // (reqwest uses `rustls-no-provider`; without this, Client::new panics).
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("rustls default crypto provider");

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use chrono::Utc;
 use mostro_core::prelude::*;
-use nip06::FromMnemonic;
 use nostr_sdk::prelude::*;
 use sqlx::sqlite::SqlitePool;
 use sqlx::{QueryBuilder, Sqlite};
@@ -677,7 +676,7 @@ impl AdminDispute {
         dispute_info: SolverDisputeInfo,
         dispute_id: String,
         fiat_code_from_relay: Option<String>,
-        admin_keys: Option<&nostr_sdk::Keys>,
+        admin_keys: Option<&Keys>,
     ) -> Result<Self> {
         // Validate required fields
         if dispute_info.buyer_pubkey.is_none() || dispute_info.seller_pubkey.is_none() {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -88,7 +88,9 @@ pub async fn run_post_terminal_startup(
         .nsec_privkey
         .parse::<Keys>()
         .map_err(|e| anyhow::anyhow!("Invalid NSEC privkey: {}", e))?;
-    let client = Client::new(my_keys);
+    let client = Client::builder()
+        .authenticator(SignerAuthenticator::new(my_keys.clone()))
+        .build();
 
     for relay in &input.configured_relays {
         client.add_relay(relay).await?;

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -22,7 +22,7 @@ use crate::ui::orders::{
 };
 use crate::ui::user_state::UserMode;
 use crate::util::{transport_from_instance, MostroInstanceInfo};
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 
 #[derive(Debug)]
 pub enum UiMode {

--- a/src/ui/helpers/attachments.rs
+++ b/src/ui/helpers/attachments.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use nostr_sdk::serde_json::{from_str as json_from_str, to_string as json_to_string, Value};
+use serde_json::{from_str as json_from_str, to_string as json_to_string, Value};
 
 use crate::ui::{AppState, ChatAttachment, ChatAttachmentType};
 

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -19,7 +19,7 @@ use crate::util::{
     OrderDmSubscriptionCmd, StartupDmHydration,
 };
 use mostro_core::prelude::{Dispute, SmallOrder, Transport};
-use nostr_sdk::prelude::{Client, Keys, PublicKey};
+use nostr_sdk::prelude::{Client, Keys, PublicKey, SignerAuthenticator};
 use sqlx::SqlitePool;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -253,7 +253,9 @@ pub async fn apply_pending_key_reload(
     match load_settings_from_disk() {
         Ok(latest_settings) => match latest_settings.nsec_privkey.parse::<Keys>() {
             Ok(new_identity_keys) => {
-                let new_client = Client::new(new_identity_keys);
+                let new_client = Client::builder()
+                    .authenticator(SignerAuthenticator::new(new_identity_keys.clone()))
+                    .build();
                 let mut reload_error: Option<String> = None;
                 for relay in &latest_settings.relays {
                     let relay = relay.trim();
@@ -444,7 +446,9 @@ pub async fn apply_pending_fetch_scheduler_reload(
     message_listener_handle.abort();
     order_fetch_task.abort();
     dispute_fetch_task.abort();
-    client.unsubscribe_all().await;
+    if let Err(e) = client.unsubscribe_all().await {
+        log::debug!("unsubscribe failed: {e}");
+    }
 
     connect_client_safely(client)
         .await
@@ -619,7 +623,9 @@ pub async fn reload_runtime_session_after_reconnect(
     ctx.message_listener_handle.abort();
     ctx.order_fetch_task.abort();
     ctx.dispute_fetch_task.abort();
-    ctx.client.unsubscribe_all().await;
+    if let Err(e) = ctx.client.unsubscribe_all().await {
+        log::debug!("unsubscribe failed: {e}");
+    }
 
     connect_client_safely(ctx.client)
         .await

--- a/src/ui/key_handler/async_tasks.rs
+++ b/src/ui/key_handler/async_tasks.rs
@@ -446,8 +446,24 @@ pub async fn apply_pending_fetch_scheduler_reload(
     message_listener_handle.abort();
     order_fetch_task.abort();
     dispute_fetch_task.abort();
-    if let Err(e) = client.unsubscribe_all().await {
-        log::debug!("unsubscribe failed: {e}");
+    match client.unsubscribe_all().await {
+        Ok(output) if !output.failed.is_empty() => {
+            let failed: Vec<String> = output
+                .failed
+                .iter()
+                .map(|(url, err)| format!("{url}: {err}"))
+                .collect();
+            return Err(format!(
+                "Fetch scheduler reload: unsubscribe_all failed on relays: {}",
+                failed.join("; ")
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return Err(format!(
+                "Fetch scheduler reload: unsubscribe_all failed: {e}"
+            ));
+        }
     }
 
     connect_client_safely(client)
@@ -623,8 +639,22 @@ pub async fn reload_runtime_session_after_reconnect(
     ctx.message_listener_handle.abort();
     ctx.order_fetch_task.abort();
     ctx.dispute_fetch_task.abort();
-    if let Err(e) = ctx.client.unsubscribe_all().await {
-        log::debug!("unsubscribe failed: {e}");
+    match ctx.client.unsubscribe_all().await {
+        Ok(output) if !output.failed.is_empty() => {
+            let failed: Vec<String> = output
+                .failed
+                .iter()
+                .map(|(url, err)| format!("{url}: {err}"))
+                .collect();
+            return Err(format!(
+                "Reconnect: unsubscribe_all failed on relays: {}",
+                failed.join("; ")
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return Err(format!("Reconnect: unsubscribe_all failed: {e}"));
+        }
     }
 
     connect_client_safely(ctx.client)

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -33,9 +33,9 @@ use crate::ui::key_handler::user_handlers::{
 };
 use bip39::Mnemonic;
 use mostro_core::prelude::*;
-use nostr_sdk::nips::nip06::FromMnemonic;
+use nostr_sdk::prelude::FromMnemonic;
+use nostr_sdk::prelude::ToBech32;
 use nostr_sdk::prelude::{Keys, PublicKey, SecretKey};
-use nostr_sdk::ToBech32;
 use std::collections::HashSet;
 use std::str::FromStr;
 

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -440,7 +440,7 @@ pub fn handle_key_event(
     seed_words_tx: &UnboundedSender<Result<Zeroizing<String>, String>>,
     mostro_info_tx: &UnboundedSender<MostroInfoFetchResult>,
     validate_range_amount: &dyn Fn(&mut TakeOrderState),
-    admin_chat_keys: Option<&nostr_sdk::Keys>,
+    admin_chat_keys: Option<&Keys>,
     save_attachment_tx: Option<&UnboundedSender<(String, ChatAttachment)>>,
     send_order_attachment_tx: Option<&UnboundedSender<SendOrderAttachmentJob>>,
     dm_subscription_tx: &UnboundedSender<OrderDmSubscriptionCmd>,

--- a/src/ui/key_handler/user_handlers.rs
+++ b/src/ui/key_handler/user_handlers.rs
@@ -1,6 +1,7 @@
 use crate::ui::key_handler::async_tasks::spawn_take_order_task;
 use crate::ui::{AppState, FormState, Tab, TakeOrderState, UiMode, UserMode, UserRole, UserTab};
-use nostr_sdk::Client;
+use nostr_sdk::prelude::Client;
+use nostr_sdk::prelude::PublicKey;
 use sqlx::SqlitePool;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -56,7 +57,7 @@ pub(crate) fn execute_take_order_action(
     take_state: TakeOrderState,
     pool: &SqlitePool,
     client: &Client,
-    mostro_pubkey: nostr_sdk::PublicKey,
+    mostro_pubkey: PublicKey,
     order_result_tx: &UnboundedSender<crate::ui::OperationResult>,
     dm_subscription_tx: &UnboundedSender<crate::util::OrderDmSubscriptionCmd>,
     mostro_info: Option<crate::util::MostroInstanceInfo>,

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -1537,7 +1537,7 @@ mod message_emoji_and_badge_tests {
         is_mine: Option<bool>,
         order_status: Option<Status>,
     ) -> OrderMessage {
-        let keys = nostr_sdk::Keys::generate();
+        let keys = Keys::generate();
         OrderMessage {
             message: Message::new_order(None, None, None, action, None),
             timestamp: 0,
@@ -1692,7 +1692,7 @@ mod message_emoji_and_badge_tests {
 #[cfg(test)]
 mod order_success_placeholder_tests {
     use super::*;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
 
     fn sample_order_success(
         is_mine: bool,
@@ -1768,7 +1768,7 @@ mod order_success_placeholder_tests {
 #[cfg(test)]
 mod timeline_step_tests {
     use super::*;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
 
     fn sample_order_message(
         action: Action,
@@ -2077,7 +2077,7 @@ mod placeholder_action_tests {
 
     #[test]
     fn placeholder_action_maker_waiting_maker_bond() {
-        let keys = nostr_sdk::Keys::generate();
+        let keys = Keys::generate();
         let order_id = uuid::Uuid::new_v4();
         let os = OrderSuccess {
             order_id: Some(order_id),
@@ -2118,7 +2118,7 @@ mod invoice_popup_role_tests {
         is_mine: Option<bool>,
         order_status: Option<Status>,
     ) -> OrderMessage {
-        let keys = nostr_sdk::Keys::generate();
+        let keys = Keys::generate();
         OrderMessage {
             message: Message::new_order(None, None, None, action, None),
             timestamp: 0,

--- a/src/ui/tabs/message_flow_tab.rs
+++ b/src/ui/tabs/message_flow_tab.rs
@@ -796,7 +796,7 @@ fn center_in(text: &str, width: usize) -> String {
 mod sidebar_tests {
     use super::*;
     use mostro_core::prelude::{Action, Message};
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
 
     fn sample_message(read: bool) -> OrderMessage {
         let keys = Keys::generate();
@@ -944,7 +944,7 @@ mod trade_snapshot_tests {
 
     fn message_with(action: mostro_core::prelude::Action, status: Option<Status>) -> OrderMessage {
         use mostro_core::prelude::Message;
-        use nostr_sdk::Keys;
+        use nostr_sdk::prelude::Keys;
         OrderMessage {
             message: Message::new_order(None, None, None, action, None),
             timestamp: 0,
@@ -965,7 +965,7 @@ mod trade_snapshot_tests {
     #[test]
     fn trade_order_snapshot_prefers_stable_field_over_empty_payload() {
         use mostro_core::prelude::{Action, Message, Payload};
-        use nostr_sdk::Keys;
+        use nostr_sdk::prelude::Keys;
         let snap = order(100, None, None);
         let msg = OrderMessage {
             message: Message::new_order(None, None, None, Action::FiatSent, None),
@@ -1042,7 +1042,7 @@ mod trade_snapshot_tests {
 mod layout_and_render_tests {
     use super::*;
     use mostro_core::prelude::{Action, Message, SmallOrder, Status};
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 

--- a/src/util/blossom.rs
+++ b/src/util/blossom.rs
@@ -5,8 +5,8 @@
 use anyhow::{anyhow, Result};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
-use chacha20poly1305::ChaCha20Poly1305;
+use chacha20poly1305::aead::{Aead, Generate, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use mostro_core::prelude::SharedKey;
 use nostr_sdk::prelude::{EventBuilder, FinalizeEvent, Keys, Kind, PublicKey, Tag, Timestamp};
 use reqwest::{header::CONTENT_LENGTH, Client};
@@ -138,7 +138,9 @@ pub fn decrypt_blob(key: &[u8], blob: &[u8]) -> Result<Vec<u8>> {
     }
     let (nonce_slice, ciphertext_and_tag) = blob.split_at(12);
     let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|e| anyhow!("key init: {}", e))?;
-    let nonce = chacha20poly1305::Nonce::from_slice(nonce_slice);
+    let nonce: &Nonce = nonce_slice
+        .try_into()
+        .map_err(|_| anyhow!("invalid nonce length"))?;
     let plaintext = cipher
         .decrypt(nonce, ciphertext_and_tag)
         .map_err(|e| anyhow!("decrypt failed: {}", e))?;
@@ -151,11 +153,11 @@ pub fn encrypt_blob(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
         return Err(anyhow!("encrypt key must be 32 bytes, got {}", key.len()));
     }
     let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|e| anyhow!("key init: {}", e))?;
-    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let nonce = Nonce::generate();
     let ciphertext = cipher
         .encrypt(&nonce, plaintext.as_ref())
         .map_err(|e| anyhow!("encrypt failed: {}", e))?;
-    let mut blob = nonce.to_vec();
+    let mut blob = nonce.as_slice().to_vec();
     blob.extend_from_slice(&ciphertext);
     Ok(blob)
 }

--- a/src/util/blossom.rs
+++ b/src/util/blossom.rs
@@ -7,7 +7,8 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
 use chacha20poly1305::ChaCha20Poly1305;
-use nostr_sdk::prelude::{EventBuilder, JsonUtil, Keys, Kind, PublicKey, Tag, Timestamp};
+use mostro_core::prelude::SharedKey;
+use nostr_sdk::prelude::{EventBuilder, FinalizeEvent, Keys, Kind, PublicKey, Tag, Timestamp};
 use reqwest::{header::CONTENT_LENGTH, Client};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
@@ -38,17 +39,10 @@ const BLOSSOM_UPLOAD_TIMEOUT_SECS: u64 = 300;
 /// Derives the 32-byte shared decryption key from our (admin) private key and the sender's public key.
 /// Mirror of mostro-cli's derive_shared_key: they use (trade_sk, admin_pubkey); we use (admin_sk, sender_pubkey).
 pub fn derive_shared_key(admin_keys: &Keys, sender_pubkey: &PublicKey) -> Result<[u8; 32]> {
-    use nostr_sdk::secp256k1::ecdh::shared_secret_point;
-    use nostr_sdk::secp256k1::{Parity, PublicKey as SecpPublicKey};
-
-    let sk = admin_keys.secret_key();
-    let xonly = sender_pubkey
-        .xonly()
-        .map_err(|_| anyhow!("failed to get x-only public key for sender"))?;
-    let secp_pk = SecpPublicKey::from_x_only_public_key(xonly, Parity::Even);
-    let point = shared_secret_point(&secp_pk, sk);
+    let shared = SharedKey::derive(admin_keys.secret_key(), sender_pubkey)
+        .map_err(|e| anyhow!("shared key derivation failed: {e}"))?;
     let mut key = [0u8; 32];
-    key.copy_from_slice(&point[..32]);
+    key.copy_from_slice(shared.secret_key().as_secret_bytes());
     Ok(key)
 }
 
@@ -187,9 +181,7 @@ pub(crate) fn blossom_upload_auth_header(blob_hash_hex: &str, keys: &Keys) -> Re
         Tag::parse(["expiration", expiration.as_str()])
             .map_err(|e| anyhow!("auth tag expiration: {}", e))?,
     ];
-    let signed = EventBuilder::new(BLOSSOM_AUTH_KIND, "")
-        .tags(tags)
-        .sign_with_keys(keys)
+    let signed = FinalizeEvent::finalize(EventBuilder::new(BLOSSOM_AUTH_KIND, "").tags(tags), keys)
         .map_err(|e| anyhow!("sign Blossom auth event: {}", e))?;
     let json = signed.as_json();
     Ok(format!("Nostr {}", BASE64.encode(json.as_bytes())))

--- a/src/util/chat_listener.rs
+++ b/src/util/chat_listener.rs
@@ -38,6 +38,7 @@ use crate::util::chat_utils::{
     chat_keys_from_ecdh, clamp_chat_since_cursor_now, derive_shared_key_hex,
     fetch_chat_messages_for_shared_key, keys_from_shared_hex, unwrap_giftwrap_with_shared_key,
 };
+use futures::StreamExt;
 
 /// Identifies which chat a shared key belongs to.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -86,10 +87,14 @@ struct LiveSubs {
 impl LiveSubs {
     async fn clear(&mut self, client: &Client) {
         if let Some(id) = self.giftwrap.take() {
-            client.unsubscribe(&id).await;
+            if let Err(e) = client.unsubscribe(&id).await {
+                log::debug!("unsubscribe failed: {e}");
+            }
         }
         if let Some(id) = self.kind14.take() {
-            client.unsubscribe(&id).await;
+            if let Err(e) = client.unsubscribe(&id).await {
+                log::debug!("unsubscribe failed: {e}");
+            }
         }
     }
 }
@@ -274,9 +279,9 @@ async fn resubscribe(
     let mut new_kind14: Option<SubscriptionId> = None;
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match client.subscribe(giftwrap_filter.clone(), None).await {
+        match client.subscribe(giftwrap_filter.clone()).await {
             Ok(output) => {
-                new_giftwrap = Some(output.val);
+                new_giftwrap = Some(output.value);
                 break;
             }
             Err(e) => {
@@ -296,9 +301,9 @@ async fn resubscribe(
     }
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match client.subscribe(kind14_filter.clone(), None).await {
+        match client.subscribe(kind14_filter.clone()).await {
             Ok(output) => {
-                new_kind14 = Some(output.val);
+                new_kind14 = Some(output.value);
                 break;
             }
             Err(e) => {
@@ -307,7 +312,9 @@ async fn resubscribe(
                         "[chat_live] failed to subscribe kind-14 chats after {MAX_ATTEMPTS} attempts: {e}; rolling back new GiftWrap sub"
                     );
                     if let Some(id) = new_giftwrap.take() {
-                        client.unsubscribe(&id).await;
+                        if let Err(e) = client.unsubscribe(&id).await {
+                            log::debug!("unsubscribe failed: {e}");
+                        }
                     }
                     return;
                 }
@@ -331,10 +338,14 @@ async fn resubscribe(
         .giftwrap
         .replace(new_giftwrap.expect("subscribed"))
     {
-        client.unsubscribe(&old_id).await;
+        if let Err(e) = client.unsubscribe(&old_id).await {
+            log::debug!("unsubscribe failed: {e}");
+        }
     }
     if let Some(old_id) = current_subs.kind14.replace(new_kind14.expect("subscribed")) {
-        client.unsubscribe(&old_id).await;
+        if let Err(e) = client.unsubscribe(&old_id).await {
+            log::debug!("unsubscribe failed: {e}");
+        }
     }
 }
 
@@ -554,16 +565,15 @@ pub async fn listen_for_chat_messages(
                     .await;
                 }
             }
-            notification = notifications.recv() => {
-                let event = match notification {
-                    Ok(RelayPoolNotification::Event { event, .. }) => *event,
-                    Ok(_) => continue,
-                    // Lagged/closed broadcast: log and keep going (not fatal), like the order/dispute loops.
-                    Err(e) => {
-                        log::debug!("[chat_live] notification channel: {e}");
-                        continue;
-                    }
+            notification = notifications.next() => {
+                let Some(notification) = notification else {
+                    log::debug!("[chat_live] notification stream ended");
+                    break;
                 };
+                let ClientNotification::Event { event, .. } = notification else {
+                    continue;
+                };
+                let event = *event;
                 let Some(target) = resolve_chat_target(&targets, &event) else {
                     continue;
                 };
@@ -608,7 +618,7 @@ fn resolve_chat_target<'a>(
 ) -> Option<&'a ChatTarget> {
     match event.kind {
         Kind::GiftWrap => {
-            let target_pubkey = event.tags.public_keys().next().copied()?;
+            let target_pubkey = event.tags.public_keys().next()?;
             targets.get(&target_pubkey)
         }
         Kind::PrivateDirectMessage => targets.values().find(|t| t.sign_pubkey == event.pubkey),
@@ -763,7 +773,7 @@ mod tests {
         // Outer kind-14 authored by K_sign
         let event = EventBuilder::new(Kind::PrivateDirectMessage, "ciphertext")
             .tag(Tag::public_key(Keys::generate().public_key()))
-            .sign_with_keys(&sign)
+            .finalize(&sign)
             .expect("sign");
 
         let resolved = resolve_chat_target(&targets, &event).expect("route kind14");
@@ -790,7 +800,7 @@ mod tests {
         let junk = Keys::generate();
         let event = EventBuilder::new(Kind::PrivateDirectMessage, "ciphertext")
             .tag(Tag::public_key(target_pubkey))
-            .sign_with_keys(&junk)
+            .finalize(&junk)
             .expect("sign");
 
         assert!(resolve_chat_target(&targets, &event).is_none());

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -7,7 +7,7 @@ use mostro_core::chat::{
 };
 use mostro_core::prelude::DisputeStatus;
 use mostro_core::prelude::SmallOrder;
-use nostr_sdk::nips::nip44;
+use nostr_sdk::prelude::nip44;
 use nostr_sdk::prelude::*;
 
 use crate::models::{AdminDispute, Order};
@@ -268,10 +268,12 @@ pub async fn fetch_chat_messages_for_shared_key(
     // Run both fetches independently so a transient failure of either query does
     // not hide history still available on the other envelope during migration.
     let kind14_result = client
-        .fetch_events(kind14_filter, FETCH_EVENTS_TIMEOUT)
+        .fetch_events(kind14_filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
         .await;
     let legacy_result = client
-        .fetch_events(giftwrap_filter, FETCH_EVENTS_TIMEOUT)
+        .fetch_events(giftwrap_filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
         .await;
 
     let events = merge_dual_read_events(kind14_result, legacy_result)?;
@@ -588,8 +590,8 @@ mod tests {
     }
 
     fn sample_text_event(keys: &Keys, content: &str) -> Event {
-        EventBuilder::text_note(content)
-            .sign_with_keys(keys)
+        EventBuilder::new(Kind::TextNote, content)
+            .finalize(keys)
             .expect("sign event")
     }
 

--- a/src/util/dm_utils/dm_helpers.rs
+++ b/src/util/dm_utils/dm_helpers.rs
@@ -66,9 +66,9 @@ pub(crate) async fn ensure_order_dm_subscription(
         DmSubscriptionMode::LiveOnly => base.limit(0),
     };
 
-    match client.subscribe(filter, None).await {
+    match client.subscribe(filter).await {
         Ok(output) => {
-            let sub_id = output.val;
+            let sub_id = output.value;
             if let Some(label) = options.info_label {
                 log::info!(
                     "{} subscription_id={}, order_id={}, trade_index={}",

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -40,6 +40,8 @@ use crate::util::order_utils::{
     inferred_status_from_trade_action, map_action_to_status, should_apply_status_transition,
     should_strictly_advance_status,
 };
+use futures::StreamExt;
+use std::collections::BTreeSet;
 
 pub const FETCH_EVENTS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const PENDING_WAITER_GC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
@@ -66,7 +68,7 @@ fn is_own_signed_v2_outbound(
     trade_keys: &Keys,
     unwrapped: &UnwrappedMessage,
 ) -> bool {
-    event.kind == nostr_sdk::Kind::PrivateDirectMessage
+    event.kind == nostr_sdk::prelude::Kind::PrivateDirectMessage
         && event.pubkey == trade_keys.public_key()
         && unwrapped.signature.is_some()
 }
@@ -117,7 +119,9 @@ pub async fn unsubscribe_dm_listener_subscriptions(client: &Client) {
         .map(|mut guard| std::mem::take(&mut *guard))
         .unwrap_or_default();
     for id in ids {
-        client.unsubscribe(&id).await;
+        if let Err(e) = client.unsubscribe(&id).await {
+            log::debug!("unsubscribe failed: {e}");
+        }
     }
 }
 
@@ -269,64 +273,6 @@ fn trade_message_is_terminal(message: &Message) -> bool {
     message_has_terminal_order_status(message)
 }
 
-/// NIP-44 protocol wrap that keeps a self `#p` tag when author == receiver.
-///
-/// nostr-sdk [`EventBuilder`] strips `p` tags matching the author unless
-/// [`EventBuilder::allow_self_tagging`] is set. Mostro subscribes on `#p`, so
-/// admin DMs that reuse the Mostro key would otherwise never be delivered.
-fn wrap_message_nip44_allow_self_p(
-    message: &Message,
-    identity_keys: &Keys,
-    trade_keys: &Keys,
-    receiver: PublicKey,
-    opts: WrapOptions,
-) -> Result<Event> {
-    let message_json = message
-        .as_json()
-        .map_err(|e| anyhow::anyhow!("Failed to serialize message for nip44 wrap: {e:?}"))?;
-
-    let trade_sig = opts
-        .signed
-        .then(|| Message::sign(message_json.clone(), trade_keys).to_string());
-
-    let identity_proof = (identity_keys.public_key() != trade_keys.public_key()).then(|| {
-        let payload = format!(
-            "mostro-transport-v2-identity:{}:{}",
-            trade_keys.public_key().to_hex(),
-            message_json
-        );
-        (
-            identity_keys.public_key().to_hex(),
-            Message::sign(payload, identity_keys).to_string(),
-        )
-    });
-
-    let tuple: (&Message, Option<String>, Option<(String, String)>) =
-        (message, trade_sig, identity_proof);
-    let content = serde_json::to_string(&tuple)
-        .map_err(|e| anyhow::anyhow!("Failed to serialize nip44 tuple: {e}"))?;
-
-    let encrypted = nip44::encrypt(
-        trade_keys.secret_key(),
-        &receiver,
-        content,
-        nip44::Version::default(),
-    )
-    .map_err(|e| anyhow::anyhow!("Failed to nip44-encrypt protocol message: {e}"))?;
-
-    let mut tags: Vec<Tag> = vec![Tag::public_key(receiver)];
-    if let Some(exp) = opts.expiration {
-        tags.push(Tag::expiration(exp));
-    }
-
-    EventBuilder::new(nostr_sdk::Kind::PrivateDirectMessage, encrypted)
-        .tags(tags)
-        .allow_self_tagging()
-        .pow(opts.pow)
-        .sign_with_keys(trade_keys)
-        .map_err(|e| anyhow::anyhow!("Failed to sign nip44 protocol event: {e}"))
-}
-
 /// Send a direct message to a receiver
 pub async fn send_dm(
     client: &Client,
@@ -352,29 +298,18 @@ pub async fn send_dm(
         expiration,
         signed: true,
     };
-    // Self-addressed v2 DMs must keep `#p` (Mostro filters on it). nostr-sdk strips
-    // self `p` tags unless allow_self_tagging is set — mostro-core's wrap does not.
-    let event =
-        if transport == Transport::Nip44Direct && trade_keys.public_key() == *receiver_pubkey {
-            wrap_message_nip44_allow_self_p(
-                &message,
-                identity_keys,
-                trade_keys,
-                *receiver_pubkey,
-                wrap_opts,
-            )?
-        } else {
-            wrap_message_with(
-                transport,
-                &message,
-                identity_keys,
-                trade_keys,
-                *receiver_pubkey,
-                wrap_opts,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to wrap protocol message: {e}"))?
-        };
+    // nostr 0.45 no longer strips self `#p` tags from EventBuilder, so the
+    // core `wrap_message_nip44` path is correct for admin self-addressed DMs.
+    let event = wrap_message_with(
+        transport,
+        &message,
+        identity_keys,
+        trade_keys,
+        *receiver_pubkey,
+        wrap_opts,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to wrap protocol message: {e}"))?;
 
     client.send_event(&event).await?;
     Ok(())
@@ -386,7 +321,7 @@ pub async fn wait_for_dm<F>(
     trade_keys: &Keys,
     timeout: std::time::Duration,
     sent_message: F,
-) -> Result<Events>
+) -> Result<BTreeSet<Event>>
 where
     F: std::future::Future<Output = Result<()>> + Send,
 {
@@ -419,14 +354,14 @@ where
         .map_err(|_| anyhow::anyhow!("Timeout waiting for DM or gift wrap event"))?
         .map_err(|_| anyhow::anyhow!("DM waiter canceled before receiving an event"))?;
 
-    let mut events = Events::default();
+    let mut events = BTreeSet::new();
     events.insert(event);
     Ok(events)
 }
 
 /// Parse DM events to extract Messages (v1 GiftWrap and v2 kind 14 via [`unwrap_incoming`]).
 pub async fn parse_dm_events(
-    events: Events,
+    events: BTreeSet<Event>,
     pubkey: &Keys,
     since: Option<&i64>,
 ) -> Vec<(Message, i64, PublicKey)> {
@@ -476,7 +411,7 @@ async fn parse_dm_events_single(
     if let Some(u) = pre_unwrapped {
         return vec![(u.message, u.created_at.as_secs() as i64, u.sender)];
     }
-    let mut batch = Events::default();
+    let mut batch = BTreeSet::new();
     batch.insert(event.clone());
     parse_dm_events(batch, trade_keys, None).await
 }
@@ -1278,7 +1213,9 @@ async fn dispatch_giftwrap_batch(
                     }
                     subscription_to_order.remove(subscription_id);
                     unregister_dm_listener_subscription(subscription_id);
-                    client.unsubscribe(subscription_id).await;
+                    if let Err(e) = client.unsubscribe(subscription_id).await {
+                        log::debug!("unsubscribe failed: {e}");
+                    }
                     break;
                 }
                 GiftWrapTerminalPolicy::UntrackedFallback => {
@@ -1393,7 +1330,11 @@ async fn fetch_and_replay_startup_trade_dms(
             .since(Timestamp::from(since_ts))
             .limit(STARTUP_TRADE_DM_FETCH_LIMIT);
 
-        let events = match client.fetch_events(filter, FETCH_EVENTS_TIMEOUT).await {
+        let events = match client
+            .fetch_events(filter)
+            .timeout(FETCH_EVENTS_TIMEOUT)
+            .await
+        {
             Ok(e) => e,
             Err(e) => {
                 log::warn!(
@@ -1817,13 +1758,13 @@ pub async fn listen_for_order_messages(
                                 waiter_pubkey,
                             )
                             .limit(0);
-                            match client.subscribe(filter, None).await {
+                            match client.subscribe(filter).await {
                                 Ok(output) => {
                                     // Remember the subscription id so a later TrackOrder can
                                     // rebind this pubkey to a concrete order_id without requiring
                                     // a second relay subscription.
-                                    register_dm_listener_subscription(output.val.clone());
-                                    pubkey_to_subscription.insert(waiter_pubkey, output.val);
+                                    register_dm_listener_subscription(output.value.clone());
+                                    pubkey_to_subscription.insert(waiter_pubkey, output.value);
                                 }
                                 Err(e) => {
                                     subscribed_pubkeys.remove(&waiter_pubkey);
@@ -1851,16 +1792,13 @@ pub async fn listen_for_order_messages(
                     }
                 }
             }
-            notification = notifications.recv() => {
-                let notification = match notification {
-                    Ok(n) => n,
-                    Err(e) => {
-                        log::warn!("Error receiving relay notification: {:?}", e);
-                        continue;
-                    }
+            notification = notifications.next() => {
+                let Some(notification) = notification else {
+                    log::warn!("DM notification stream ended");
+                    break;
                 };
 
-                if let RelayPoolNotification::Event {
+                if let ClientNotification::Event {
                     subscription_id,
                     event,
                     ..
@@ -2053,15 +1991,14 @@ mod tests {
     };
     use crate::models::Order;
     use mostro_core::prelude::{Action, Message, Payload, SmallOrder, Status, UnwrappedMessage};
-    use nostr_sdk::prelude::{EventBuilder, Keys, Tag, Timestamp};
+    use nostr_sdk::prelude::{EventBuilder, FinalizeEvent, Keys, Tag, Timestamp};
 
     #[test]
     fn own_signed_v2_outbound_is_skipped_by_waiter_guard() {
         let keys = Keys::generate();
-        let event = EventBuilder::new(nostr_sdk::Kind::PrivateDirectMessage, "ciphertext")
+        let event = EventBuilder::new(nostr_sdk::prelude::Kind::PrivateDirectMessage, "ciphertext")
             .tags([Tag::public_key(keys.public_key())])
-            .allow_self_tagging()
-            .sign_with_keys(&keys)
+            .finalize(&keys)
             .expect("sign kind-14");
         let message = Message::new_dispute(None, None, None, Action::AdminTakeDispute, None);
         let sig = Message::sign(message.as_json().expect("json"), &keys);

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -8,7 +8,9 @@ use crate::util::types::ListKind;
 /// GiftWrap events (NIP-59) addressed to `pubkey` as recipient (`p` tag target).
 /// Chain `.since()`, `.limit()`, etc. for subscriptions or `fetch_events`.
 pub fn filter_giftwrap_to_recipient(pubkey: PublicKey) -> Filter {
-    Filter::new().pubkey(pubkey).kind(nostr_sdk::Kind::GiftWrap)
+    Filter::new()
+        .pubkey(pubkey)
+        .kind(nostr_sdk::prelude::Kind::GiftWrap)
 }
 
 /// Protocol DM filter for inbound Mostro → client traffic on the active wire transport.
@@ -16,9 +18,9 @@ pub fn filter_giftwrap_to_recipient(pubkey: PublicKey) -> Filter {
 /// v1: GiftWrap addressed to the trade key (`p` tag).
 /// v2: signed kind-14 from Mostro with trade key in `#p`.
 ///
-/// When `mostro_pubkey == trade_pubkey` on v2 (admin using the Mostro nsec), nostr-sdk's
-/// [`EventBuilder`] strips self `#p` tags unless `allow_self_tagging` is set. Mostro replies
-/// may therefore have **no** `#p`, so this path subscribes by author+kind only.
+/// When `mostro_pubkey == trade_pubkey` on v2 (admin using the Mostro nsec), the
+/// daemon may omit `#p` on self-addressed replies, so this path subscribes by
+/// author+kind only.
 ///
 /// That broader filter can also match the client's own outbound request. `wait_for_dm`
 /// waiters ignore signed self-authored kind-14 events (`is_own_signed_v2_outbound`) so the
@@ -33,15 +35,15 @@ pub fn filter_protocol_dm_from_mostro(
         Transport::GiftWrap => filter_giftwrap_to_recipient(trade_pubkey),
         Transport::Nip44Direct if mostro_pubkey == trade_pubkey => Filter::new()
             .author(mostro_pubkey)
-            .kind(nostr_sdk::Kind::PrivateDirectMessage),
+            .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage),
         Transport::Nip44Direct => Filter::new()
             .author(mostro_pubkey)
             .pubkey(trade_pubkey)
-            .kind(nostr_sdk::Kind::PrivateDirectMessage),
+            .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage),
     }
 }
 
-/// Relay fetch cap for Mostro-published [`Kind::Custom`] order/dispute list snapshots.
+/// Relay fetch cap for Mostro-published [`nostr_sdk::prelude::Kind::Custom`] order/dispute list snapshots.
 pub const MOSTRO_LIST_FETCH_EVENT_LIMIT: usize = 500;
 
 /// Build a fetch filter for Mostro list snapshots: events authored by `pubkey`, a given custom
@@ -52,7 +54,7 @@ pub fn create_mostro_list_fetch_filter(kind: u16, pubkey: PublicKey) -> Result<F
     Ok(Filter::new()
         .author(pubkey)
         .limit(MOSTRO_LIST_FETCH_EVENT_LIMIT)
-        .kind(nostr_sdk::Kind::Custom(kind)))
+        .kind(nostr_sdk::prelude::Kind::Custom(kind)))
 }
 
 /// Create a filter based on list kind

--- a/src/util/mostro_info.rs
+++ b/src/util/mostro_info.rs
@@ -280,12 +280,13 @@ pub async fn fetch_mostro_instance_info(
 ) -> Result<Option<MostroInstanceInfo>> {
     let filter = Filter::new()
         .author(mostro_pubkey)
-        .kind(nostr_sdk::Kind::Custom(MOSTRO_INSTANCE_INFO_KIND))
+        .kind(nostr_sdk::prelude::Kind::Custom(MOSTRO_INSTANCE_INFO_KIND))
         .identifier(mostro_pubkey.to_string())
         .limit(1);
 
     let events = client
-        .fetch_events(filter, FETCH_EVENTS_TIMEOUT)
+        .fetch_events(filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to fetch Mostro instance info from relays: {}", e))?;
 

--- a/src/util/network.rs
+++ b/src/util/network.rs
@@ -56,9 +56,11 @@ pub async fn any_relay_reachable(relays: &[String]) -> bool {
 /// Some `nostr-sdk` connect paths have historically panicked in "no network" environments.
 /// This wrapper turns that into an error so the UI can keep running (offline overlay / retry).
 pub async fn connect_client_safely(client: &Client) -> Result<(), String> {
-    let result = std::panic::AssertUnwindSafe(client.connect())
-        .catch_unwind()
-        .await;
+    let result = std::panic::AssertUnwindSafe(async {
+        client.connect().await;
+    })
+    .catch_unwind()
+    .await;
     match result {
         Ok(()) => Ok(()),
         Err(_) => Err("nostr client connect panicked".to_string()),

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 
+use futures::StreamExt;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use tokio::task::JoinHandle;
@@ -183,13 +185,13 @@ pub fn spawn_fetch_scheduler_loops(
             };
             let order_filter = Filter::new()
                 .author(mostro_pubkey_for_order_subscribe)
-                .kind(nostr_sdk::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
+                .kind(nostr_sdk::prelude::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
                 .since(Timestamp::now());
-            match client_for_orders.subscribe(order_filter, None).await {
+            match client_for_orders.subscribe(order_filter).await {
                 Ok(output) => {
                     log::debug!(
                         "[orders_live] subscribed to order updates subscription_id={}",
-                        output.val
+                        output.value
                     );
                 }
                 Err(e) => {
@@ -280,15 +282,15 @@ pub fn spawn_fetch_scheduler_loops(
                             );
                         }
                     }
-                    notification = notifications.recv() => {
-                        let Ok(RelayPoolNotification::Event { event, .. }) = notification else {
+                    notification = notifications.next() => {
+                        let Some(ClientNotification::Event { event, .. }) = notification else {
                             continue;
                         };
                         let event = *event;
-                        if event.kind != nostr_sdk::Kind::Custom(NOSTR_ORDER_EVENT_KIND) {
+                        if event.kind != nostr_sdk::prelude::Kind::Custom(NOSTR_ORDER_EVENT_KIND) {
                             continue;
                         }
-                        let mut one = Events::default();
+                        let mut one = BTreeSet::new();
                         one.insert(event);
                         let latest_live = aggregate_latest_orders_by_id(&one);
                         for relay_order in latest_live.values() {
@@ -330,13 +332,13 @@ pub fn spawn_fetch_scheduler_loops(
                 };
             let dispute_filter = Filter::new()
                 .author(mostro_pubkey_for_dispute_subscribe)
-                .kind(nostr_sdk::Kind::Custom(NOSTR_DISPUTE_EVENT_KIND))
+                .kind(nostr_sdk::prelude::Kind::Custom(NOSTR_DISPUTE_EVENT_KIND))
                 .since(Timestamp::now());
-            match client_for_disputes.subscribe(dispute_filter, None).await {
+            match client_for_disputes.subscribe(dispute_filter).await {
                 Ok(output) => {
                     log::debug!(
                         "[disputes_live] subscribed to dispute updates subscription_id={}",
-                        output.val
+                        output.value
                     );
                 }
                 Err(e) => {
@@ -382,15 +384,15 @@ pub fn spawn_fetch_scheduler_loops(
                             );
                         }
                     }
-                    notification = notifications.recv() => {
-                        let Ok(RelayPoolNotification::Event { event, .. }) = notification else {
+                    notification = notifications.next() => {
+                        let Some(ClientNotification::Event { event, .. }) = notification else {
                             continue;
                         };
                         let event = *event;
-                        if event.kind != nostr_sdk::Kind::Custom(NOSTR_DISPUTE_EVENT_KIND) {
+                        if event.kind != nostr_sdk::prelude::Kind::Custom(NOSTR_DISPUTE_EVENT_KIND) {
                             continue;
                         }
-                        let mut one = Events::default();
+                        let mut one = BTreeSet::new();
                         one.insert(event);
                         let mut parsed = super::parse_disputes_events(one);
                         log::debug!(

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -283,7 +283,11 @@ pub fn spawn_fetch_scheduler_loops(
                         }
                     }
                     notification = notifications.next() => {
-                        let Some(ClientNotification::Event { event, .. }) = notification else {
+                        let Some(notification) = notification else {
+                            log::warn!("[orders_live] notification stream ended");
+                            break;
+                        };
+                        let ClientNotification::Event { event, .. } = notification else {
                             continue;
                         };
                         let event = *event;
@@ -385,7 +389,11 @@ pub fn spawn_fetch_scheduler_loops(
                         }
                     }
                     notification = notifications.next() => {
-                        let Some(ClientNotification::Event { event, .. }) = notification else {
+                        let Some(notification) = notification else {
+                            log::warn!("[disputes_live] notification stream ended");
+                            break;
+                        };
+                        let ClientNotification::Event { event, .. } = notification else {
                             continue;
                         };
                         let event = *event;

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -13,7 +13,11 @@ use crate::util::filters::create_filter;
 use crate::util::types::{get_cant_do_description, Event, ListKind};
 use crate::util::OrderDmSubscriptionCmd;
 use sqlx::SqlitePool;
+use std::collections::BTreeSet;
 use tokio::sync::mpsc::UnboundedSender;
+
+/// Nostr events from relays (distinct from [`Event`] in `util::types`).
+type NostrEvents = BTreeSet<nostr_sdk::prelude::Event>;
 
 /// Parse order from nostr tags
 pub fn order_from_tags(tags: Tags) -> Result<SmallOrder> {
@@ -269,7 +273,7 @@ pub fn dispute_from_tags(tags: Tags) -> Result<Dispute> {
 ///
 /// Uses a HashMap keyed by dispute id to keep only the latest dispute per id,
 /// mirroring the strategy used in `parse_orders_events` for orders.
-pub fn parse_disputes_events(events: Events) -> Vec<Dispute> {
+pub fn parse_disputes_events(events: NostrEvents) -> Vec<Dispute> {
     let mut latest_by_id: HashMap<Uuid, Dispute> = HashMap::new();
 
     // Scan events to extract all disputes
@@ -304,7 +308,7 @@ pub fn parse_disputes_events(events: Events) -> Vec<Dispute> {
 /// Latest [`SmallOrder`] per order id from Mostro nostr order events (newest event wins).
 ///
 /// Does not apply currency, status, or kind filters — use [`parse_orders_events`] for that.
-pub fn aggregate_latest_orders_by_id(events: &Events) -> HashMap<Uuid, SmallOrder> {
+pub fn aggregate_latest_orders_by_id(events: &NostrEvents) -> HashMap<Uuid, SmallOrder> {
     let mut latest_by_id: HashMap<Uuid, SmallOrder> = HashMap::new();
 
     for event in events.iter() {
@@ -344,7 +348,7 @@ pub fn aggregate_latest_orders_by_id(events: &Events) -> HashMap<Uuid, SmallOrde
 
 /// Parse orders from events
 pub fn parse_orders_events(
-    events: Events,
+    events: NostrEvents,
     currencies: Option<Vec<String>>,
     status: Option<Status>,
     kind: Option<mostro_core::order::Kind>,
@@ -380,9 +384,12 @@ pub fn parse_orders_events(
 pub async fn fetch_mostro_order_events(
     client: &Client,
     mostro_pubkey: PublicKey,
-) -> Result<Events> {
+) -> Result<NostrEvents> {
     let filters = create_filter(ListKind::Orders, mostro_pubkey, None)?;
-    Ok(client.fetch_events(filters, FETCH_EVENTS_TIMEOUT).await?)
+    Ok(client
+        .fetch_events(filters)
+        .timeout(FETCH_EVENTS_TIMEOUT)
+        .await?)
 }
 
 /// Pending listings for the public order book from an aggregated relay snapshot.
@@ -426,7 +433,10 @@ pub async fn fetch_events_list(
         }
         ListKind::Disputes => {
             let filters = create_filter(list_kind, mostro_pubkey, None)?;
-            let fetched_events = client.fetch_events(filters, FETCH_EVENTS_TIMEOUT).await?;
+            let fetched_events = client
+                .fetch_events(filters)
+                .timeout(FETCH_EVENTS_TIMEOUT)
+                .await?;
             let disputes = parse_disputes_events(fetched_events);
             Ok(disputes.into_iter().map(Event::Dispute).collect())
         }
@@ -490,11 +500,12 @@ pub async fn fetch_small_order_by_id_from_relay(
 ) -> Result<Option<SmallOrder>> {
     let filter = Filter::new()
         .author(mostro_pubkey)
-        .kind(nostr_sdk::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
+        .kind(nostr_sdk::prelude::Kind::Custom(NOSTR_ORDER_EVENT_KIND))
         .identifier(order_id.to_string())
         .limit(10);
     let events = client
-        .fetch_events(filter, FETCH_EVENTS_TIMEOUT)
+        .fetch_events(filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to fetch order from relay by id: {}", e))?;
     let Some(best) = events.iter().max_by_key(|e| e.created_at) else {


### PR DESCRIPTION
## Summary

- Bump **mostro-core** to `0.14.3` and **nostr-sdk** to `0.45.1`, adding a direct `nostr` dependency for NIP-06/44/59 features.
- Adapt Mostrix to nostr 0.45 breaking changes: client no longer owns a signer (`Client::builder().authenticator(...)`), event signing via `finalize`, builder-style `subscribe` / `fetch_events(...).timeout(...)`, `ClientNotification` streams, and `Output.value`.
- Replace removed `nostr-database::Events` with `BTreeSet<Event>` for relay snapshots and DM batching; delegate NIP-44 self-addressed wraps to `mostro-core::wrap_message_with`.

## Breaking changes (internal)

This PR only updates the Mostrix client; no user-facing protocol changes. The migration touches relay/DM plumbing:

- `Client::new(keys)` → `Client::builder().authenticator(SignerAuthenticator::new(keys)).build()`
- `EventBuilder::sign_with_keys` → `FinalizeEvent::finalize`
- `RelayPoolNotification` + `recv()` → `ClientNotification` + stream `.next()`
- `fetch_events(filter, timeout)` → `fetch_events(filter).timeout(timeout)`

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (325 tests passed)
- [ ] Manual smoke: startup relay connect, order book fetch, take order DM round-trip, chat listener on active trade


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated Nostr connectivity and messaging for improved compatibility with current client services.
  - Improved authentication and key reload handling.
  - Made event subscriptions, notification processing, and cleanup more reliable.
  - Added timeouts when retrieving orders, disputes, and instance information.
  - Improved reporting for connection, subscription, and encryption-related errors.
  - Enhanced encrypted message and authorization processing while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->