### PR TITLE
fix: accept npub or hex for Mostro pubkey

### DIFF
--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -44,8 +44,10 @@ pub enum UiMode {
     UserSaveAttachmentPopup(String, usize),
     /// User order chat send attachment file picker: pinned order id (Ctrl+O on My Trades tab).
     UserSendAttachmentPicker(String),
+    /// Settings: enter Mostro pubkey (`npub` or hex).
     AddMostroPubkey(KeyInputState),
-    ConfirmMostroPubkey(String, bool), // (key_string, selected_button: true=Yes, false=No)
+    /// Settings: confirm Mostro pubkey (hex string, Yes/No).
+    ConfirmMostroPubkey(String, bool),
     AddRelay(KeyInputState),
     ConfirmRelay(String, bool), // (relay_string, selected_button: true=Yes, false=No)
     /// User-mode Settings: buyer Lightning address (`user@domain.com`).

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -236,8 +236,8 @@ pub fn ui_draw(
         key_input_popup::render_key_input_popup(
             f,
             "🌐 Add Mostro Pubkey",
-            "Enter Mostro public key (64 hex chars):",
-            "0123... (64 hex chars)",
+            "Enter Mostro public key (npub... or hex):",
+            "npub... / hex...",
             key_state,
             false,
         );

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -218,7 +218,7 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
         ),
         (
             "Change Mostro Pubkey",
-            "Set the Mostro daemon hex pubkey used for subscriptions and orders.",
+            "Set the Mostro daemon pubkey (npub or hex) used for subscriptions and orders.",
         ),
         (
             "Add Nostr Relay",
@@ -257,7 +257,7 @@ fn settings_instruction_lines(user_role: UserRole) -> (String, Vec<Line<'static>
         ),
         (
             "Change Mostro Pubkey",
-            "Set the Mostro daemon hex pubkey used for subscriptions and orders.",
+            "Set the Mostro daemon pubkey (npub or hex) used for subscriptions and orders.",
         ),
         (
             "Add Nostr Relay",

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -56,7 +56,7 @@ use crate::ui::key_handler::settings::{
     validate_ln_address_format,
 };
 use crate::ui::key_handler::validation::{
-    validate_currency, validate_mostro_pubkey, validate_relay,
+    normalize_mostro_pubkey, validate_currency, validate_relay,
 };
 use crate::ui::tabs::settings_tab::{settings_action_for_index, SettingsMenuAction};
 use crate::util::dm_utils::{apply_saved_ln_address_invoice_choice, present_add_invoice_popup};
@@ -761,13 +761,12 @@ fn handle_enter_settings_mode(
 ) -> bool {
     match mode {
         UiMode::AddMostroPubkey(key_state) => {
-            // Validate Mostro pubkey (hex format) before proceeding to confirmation
-            match validate_mostro_pubkey(&key_state.key_input) {
-                Ok(_) => {
-                    app.mode =
-                        handle_input_to_confirmation(&key_state.key_input, default_mode, |input| {
-                            UiMode::ConfirmMostroPubkey(input, true)
-                        });
+            // Accept npub or hex; normalize to hex before confirmation (settings store hex).
+            match normalize_mostro_pubkey(&key_state.key_input) {
+                Ok(normalized) => {
+                    app.mode = handle_input_to_confirmation(&normalized, default_mode, |input| {
+                        UiMode::ConfirmMostroPubkey(input, true)
+                    });
                 }
                 Err(e) => {
                     // Show error popup

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -752,7 +752,10 @@ pub fn handle_enter_key(app: &mut AppState, ctx: &super::EnterKeyContext<'_>) ->
     }
 }
 
-/// Handle Enter key for settings-related modes (Mostro pubkey, relay, currency, etc.)
+/// Handle Enter key for settings-related modes (Mostro pubkey, relay, currency, etc.).
+///
+/// Mostro pubkey input accepts npub or hex; [`normalize_mostro_pubkey`] converts to hex
+/// before the confirmation dialog so settings persistence stays hex-encoded.
 fn handle_enter_settings_mode(
     app: &mut AppState,
     mode: UiMode,

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -129,8 +129,8 @@ pub use input_helpers::{handle_invoice_input, handle_key_input};
 pub use navigation::{handle_navigation, handle_tab_navigation};
 pub use settings::handle_mode_switch;
 pub use validation::{
-    hex_pubkey_to_npub, hex_seckey_to_nsec, validate_currency, validate_mostro_pubkey,
-    validate_npub, validate_relay,
+    hex_pubkey_to_npub, hex_seckey_to_nsec, normalize_mostro_pubkey, validate_currency,
+    validate_mostro_pubkey, validate_npub, validate_relay,
 };
 
 /// Check if we're in admin chat input mode and handle character input

--- a/src/ui/key_handler/settings.rs
+++ b/src/ui/key_handler/settings.rs
@@ -35,7 +35,9 @@ pub fn try_save_admin_key_to_settings(key_string: &str) -> Result<(), String> {
     }
 }
 
-/// Save Mostro pubkey to settings file
+/// Save Mostro pubkey to settings file.
+///
+/// `key_string` should already be lowercase hex from [`super::validation::normalize_mostro_pubkey`].
 pub fn save_mostro_pubkey_to_settings(key_string: &str) {
     save_settings_with(
         |s| s.mostro_pubkey = key_string.to_string(),

--- a/src/ui/key_handler/validation.rs
+++ b/src/ui/key_handler/validation.rs
@@ -80,20 +80,28 @@ pub fn normalize_to_nsec(input: &str) -> Result<String, String> {
     })
 }
 
-/// Validate if a string is a valid hex-encoded Mostro pubkey
-/// Example: 627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84ae
+/// Validate if a string is a valid Mostro pubkey (npub or hex).
+/// Prefer [`normalize_mostro_pubkey`] when saving so settings stay hex-encoded.
 pub fn validate_mostro_pubkey(pubkey_str: &str) -> Result<(), String> {
-    let key = pubkey_str.trim();
+    normalize_mostro_pubkey(pubkey_str).map(|_| ())
+}
+
+/// Normalize a Mostro pubkey to 64-char hex for settings persistence.
+/// Accepts `npub1...` (bech32) or hex. Always returns lowercase hex on success.
+pub fn normalize_mostro_pubkey(input: &str) -> Result<String, String> {
+    let key = input.trim();
     if key.is_empty() {
         return Err("Mostro pubkey cannot be empty".to_string());
     }
 
-    // Use nostr-sdk parsing to ensure it's a valid public key
-    PublicKey::from_hex(key).map_err(|_| {
-        "Invalid Mostro pubkey format, expected 64-character hex string".to_string()
-    })?;
+    if let Ok(pk) = PublicKey::from_bech32(key) {
+        return Ok(pk.to_hex());
+    }
+    if let Ok(pk) = PublicKey::from_hex(key) {
+        return Ok(pk.to_hex());
+    }
 
-    Ok(())
+    Err("Invalid Mostro pubkey: expected npub1... (bech32) or 64-char hex string".to_string())
 }
 
 /// Validate if a relay URL has a valid format (must start with wss://)
@@ -226,5 +234,31 @@ mod tests {
         let nsec = normalize_to_nsec(hex).expect("must convert");
         let sk = SecretKey::from_bech32(&nsec).expect("must decode");
         assert_eq!(sk.to_secret_hex(), hex);
+    }
+
+    #[test]
+    fn normalize_mostro_pubkey_accepts_npub_and_returns_hex() {
+        let hex = "627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84ae";
+        let npub = PublicKey::from_hex(hex)
+            .expect("hex must parse")
+            .to_bech32()
+            .expect("bech32");
+        let out = normalize_mostro_pubkey(&npub).expect("npub must succeed");
+        assert_eq!(out, hex);
+        assert!(validate_mostro_pubkey(&npub).is_ok());
+    }
+
+    #[test]
+    fn normalize_mostro_pubkey_accepts_hex() {
+        let hex = "627788f4ea6c308b98e5928a632e8220108fcbb7fbcc1270e67582d98eac84ae";
+        let out = normalize_mostro_pubkey(hex).expect("hex must succeed");
+        assert_eq!(out, hex);
+    }
+
+    #[test]
+    fn normalize_mostro_pubkey_rejects_invalid() {
+        assert!(normalize_mostro_pubkey("").is_err());
+        assert!(normalize_mostro_pubkey("not-a-key").is_err());
+        assert!(normalize_mostro_pubkey("npub1invalid").is_err());
     }
 }

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -47,14 +47,13 @@ fn test_validate_mostro_pubkey_empty() {
 }
 
 #[test]
-fn test_validate_mostro_pubkey_invalid() {
-    // npub should NOT be valid for Mostro pubkey
+fn test_validate_mostro_pubkey_accepts_npub_and_rejects_invalid() {
     let keys = Keys::generate();
     let npub = keys.public_key().to_bech32().unwrap();
 
+    assert!(validate_mostro_pubkey(&npub).is_ok());
     assert!(validate_mostro_pubkey("not_hex").is_err());
     assert!(validate_mostro_pubkey("1234").is_err());
-    assert!(validate_mostro_pubkey(&npub).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Settings **Change Mostro Pubkey** now accepts `npub1…` or hex, matching add-solver / admin-key style input.
- Input is normalized to hex before confirmation and saved as hex in `settings.toml`.
- Prompt/help copy and validation tests updated accordingly.

## Test plan
- [ ] Settings → Change Mostro Pubkey: paste a valid `npub`; confirm shows hex and saves
- [ ] Same flow with 64-char hex still works
- [ ] Invalid keys show a clear error
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`

Made with [Cursor](https://cursor.com)