### PR TITLE
feat(chat): Step 6 — Observer K_conv disclosure UX

### DIFF
--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -100,7 +100,7 @@ See [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) for detailed finalization workf
 
 **Status**: ✅ **Implemented – Relay-based chat inspection**
 
-The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses **`K_conv` only** (My Trades **Shift+K**) — never `K_sign`. `K_conv` decrypts the conversation but cannot sign, so Observer access is read-only by construction.
+The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses **`K_conv` only** (My Trades **Shift+K**) — never `K_sign`. `K_conv` decrypts the conversation but cannot author a valid kind-14 envelope as `pub(K_sign)`, so Observer access is read-only by construction.
 
 #### Observer Workflow
 

--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -100,23 +100,22 @@ See [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) for detailed finalization workf
 
 **Status**: ✅ **Implemented – Relay-based chat inspection**
 
-The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 (and, during the dual-read window, legacy NIP-59 GiftWrap) events from Nostr relays. A party involved in a dispute provides the admin with their shared key (64-char hex) out-of-band so the admin can view the full conversation and decide who is right.
+The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses **`K_conv` only** (My Trades **Shift+K**) — never `K_sign`. `K_conv` decrypts the conversation but cannot sign, so Observer access is read-only by construction.
 
 #### Observer Workflow
 
-1. **Acquire the shared key**:
-   - During a dispute, one of the parties provides the admin with their **shared key** as a 64-character hex string (32-byte ECDH secret derived between the two trade pubkeys).
+1. **Acquire `K_conv`**:
+   - During a dispute, one of the parties discloses **`K_conv`** (64-character hex). In Mostrix this is **Shift+K** on My Trades. They may also share **`pub(K_sign)`** as an optional locator for an `authors` filter. Never accept or ask for the `K_sign` secret.
 2. **Open Observer tab**:
    - Switch to Admin mode and navigate to the **Observer** tab.
-3. **Paste shared key**:
-   - In the "Shared key (64-char hex)" input, paste the key provided by the user. The input supports bracketed paste mode for seamless pasting.
+3. **Paste keys**:
+   - In the **K_conv** field, paste the 64-char hex grant. Optionally paste **`pub(K_sign)`** (hex or npub) in the second field. **Tab** switches focus. Paste supports bracketed paste into the focused field.
 4. **Fetch and view chat**:
    - Press **Enter** to:
-     - Validate the shared key (non-empty, valid hex).
-     - Derive `Keys` from the shared key hex (via `keys_from_shared_hex` in `chat_utils.rs`).
-     - Fetch chat events for the shared key from the last 7 days (`fetch_gift_wraps_for_shared_key`), unwrapping only inner signers in the known-role map (admin key plus buyer/seller trade pubkeys from taken disputes).
-     - Decrypt each event using the shared key (kind 14, plus legacy GiftWrap while `CHAT_ACCEPT_LEGACY_GIFTWRAP` is true).
-     - Map sender public keys from that known-role map only; unknown inner signers are dropped (no arrival-order Buyer/Seller/Admin fallback).
+     - Validate `K_conv` (non-empty, valid hex secret).
+     - Parse optional `pub(K_sign)`; invalid locators fail closed.
+     - Fetch kind-14 events for the last 7 days: `authors = [pub(K_sign)]` when the locator is present, otherwise `#p = pub(K_conv)` (junk may arrive; decrypt fails).
+     - Unwrap with `K_conv` against the known-role map (admin key plus buyer/seller trade pubkeys from taken disputes). Unknown inner signers are dropped.
      - Fetch fails if the known-role map is empty (no admin keys and no taken-dispute party pubkeys).
      - Parse attachments (Mostro Mobile Encrypted File Messaging format: `image_encrypted` / `file_encrypted`).
    - The chat is displayed using the same rich formatting as the dispute chat: color-coded sender labels (Cyan=Admin, Green=Buyer, Magenta=Seller), timestamps, and attachment indicators.
@@ -125,8 +124,9 @@ The Observer tab is a read-only tool that lets admins inspect encrypted user-to-
 
 #### Observer Keyboard Shortcuts
 
-- **Enter**: Fetch chat from relays using the current shared key.
-- **Ctrl+C**: Clear shared key input, messages, error state, and loading indicator. Sensitive data is securely cleared with `zeroize`.
+- **Enter**: Fetch chat from relays using `K_conv` (and optional `pub(K_sign)`).
+- **Tab / Shift+Tab**: Switch focus between `K_conv` and `pub(K_sign)`.
+- **Ctrl+C**: Clear inputs, messages, error state, and loading indicator. Sensitive data is securely cleared with `zeroize`.
 - **Ctrl+S**: Open save-attachment popup (when attachments are present in the fetched chat).
 - **Ctrl+H**: Open help popup with Observer shortcuts (Esc/Enter/Ctrl+H to close).
 
@@ -134,7 +134,9 @@ When validation or fetching fails (empty key, invalid hex, no messages found, de
 
 #### Observer State (AppState)
 
-- `observer_shared_key_input: String` -- current shared key input.
+- `observer_shared_key_input: String` -- disclosed `K_conv` hex.
+- `observer_sign_pubkey_input: String` -- optional `pub(K_sign)` locator.
+- `observer_input_focus` -- which field receives typing/paste.
 - `observer_messages: Vec<DisputeChatMessage>` -- fetched and decrypted chat messages.
 - `observer_loading: bool` -- indicates an async fetch is in progress.
 - `observer_error: Option<String>` -- inline error message.
@@ -144,7 +146,7 @@ The fetch is performed asynchronously via `tokio::spawn` calling `chat_utils::fe
 
 When closing the **operation result** popup from the **Disputes in Progress** tab (e.g. after saving an attachment or after a finalization result), the app stays on Disputes in Progress and returns to **ManagingDispute** mode instead of switching to the first tab.
 
-> **Note**: Observer fetches messages from Nostr relays using the shared key and authenticates inner signers against taken-dispute party pubkeys plus the admin key (`fetch_observer_chat` / `observer_known_signer_roles`). Sensitive data (shared key, message contents) is securely cleared from memory via `zeroize` when the admin clears the observer state with Ctrl+C.
+> **Note**: Observer fetches kind-14 messages using disclosed `K_conv` and authenticates inner signers against taken-dispute party pubkeys plus the admin key (`fetch_observer_chat` / `observer_known_signer_roles`). GiftWrap cannot be unwrapped from `K_conv` alone. Sensitive data is securely cleared from memory via `zeroize` when the admin clears the observer state with Ctrl+C.
 
 **Source**: `src/ui/tabs/observer_tab.rs` (rendering), `src/ui/key_handler/enter_handlers.rs` (Enter handler), `src/util/chat_utils.rs` (`fetch_observer_chat`), `src/ui/key_handler/mod.rs` (Ctrl+S and observer save-attachment popup handling), `src/ui/save_attachment_popup.rs` (`render_observer_save_attachment_popup`)
 

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -97,13 +97,13 @@ Focused on dispute resolution and protocol management.
   - **Scrollable sidebar list** (`List` + `ListState`): ↑↓ keeps the selected dispute in view when many disputes overflow the sidebar; scrollbar when the list is taller than the panel
   - Finalization popup for resolution actions
   - **Empty state**: When no disputes are available, displays helpful key hints footer (filter + `↑↓: Select Dispute | Ctrl+H: Help`); footer is width-aware (narrow terminals show only Ctrl+H).
-- **Observer**: Read-only workspace for inspecting user-to-user encrypted chats via a shared key:
-  - Single shared-key input (64-char hex secret, paste-friendly)
-  - Fetches kind-14 chat events from relays for the last 7 days (`authors = [pub(K_sign)]`); also reads legacy GiftWrap while `CHAT_ACCEPT_LEGACY_GIFTWRAP` is true
+- **Observer**: Read-only workspace for inspecting user-to-user encrypted chats via disclosed **`K_conv`**:
+  - `K_conv` input (64-char hex secret, paste-friendly) plus optional `pub(K_sign)` locator
+  - Fetches kind-14 chat events from relays for the last 7 days (`authors` when locator present, else `#p = pub(K_conv)`)
   - Decrypts messages and maps sender pubkeys to Buyer/Seller/Admin roles automatically
   - Displays chat using the same formatting as the dispute chat (color-coded, right-aligned Buyer/Seller, left-aligned Admin)
   - Supports file/image attachments with `Ctrl+S` to save (same popup as dispute chat)
-  - Keyboard hints: `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
+  - Keyboard hints: `Tab` switches `K_conv` / `pub(K_sign)`, `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
 - **Settings**: Role-specific configuration including:
   - Add Dispute Solver
   - Generate New Keys (rotates the Admin keypair)
@@ -148,7 +148,7 @@ The primary shared popup is the **operation result** modal, used for:
 - Order creation / take-order flows
 - Settings validation errors (invalid pubkey, relay, currency, Lightning address format, LNURL verification failure, etc.)
 - Admin actions (add solver, finalize disputes)
-- Blossom attachment downloads and Observer-mode shared-key errors
+- Blossom attachment downloads and Observer-mode `K_conv` errors
 
 When the popup is closed (**Esc** or **Enter**) from the **Disputes in Progress** tab, the app stays on that tab and returns to **ManagingDispute** mode (it does not switch to the first tab).
 
@@ -186,7 +186,7 @@ if let UiMode::OperationResult(result) = &app.mode {
 **Help popup (Ctrl+H)**:
 
 - **Open**: Press **Ctrl+H** in normal or managing-dispute mode to show a context-aware shortcuts overlay for the current tab (Disputes in Progress, Observer, Settings, Orders, etc.).
-- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed).
+- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Shift+K** (reveal `K_conv` for solvers), **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed). On **Observer**, Tab switches `K_conv` / `pub(K_sign)` (Left/Right still change tabs).
 - **Close**: **Esc**, **Enter**, or **Ctrl+H** close the popup; other keys are absorbed while it is open.
 - **Source**: `src/ui/help_popup.rs` (rendering), `src/ui/key_handler/mod.rs` (Ctrl+H and close handling).
 
@@ -388,6 +388,7 @@ The My Trades workspace (`src/ui/tabs/order_in_progress_tab.rs`) now shows riche
   - **Shift+F** mark fiat sent (YES/NO popup).
   - **Shift+R** release sats (YES/NO popup).
   - **Shift+V** rate counterparty (opens 1–5 star rating picker).
+  - **Shift+K** reveal `K_conv` (read-only grant for solvers; never the `K_sign` secret).
   - **PgUp/PgDn** scroll chat history; **End** jump to bottom.
   - **Ctrl+S** save attachment (when the selected order has attachments).
   - **Ctrl+O** send attachment (file picker); **Ctrl+Shift+O** retry DM when a prepared send is pending.

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ async fn drain_order_result_queue(
     }
 }
 
-use crate::ui::{AdminMode, AdminTab, AppState, ChatAttachment, Tab, UiMode, UserRole};
+use crate::ui::{AdminMode, AppState, ChatAttachment, UiMode, UserRole};
 use sqlx::SqlitePool;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
@@ -210,7 +210,7 @@ fn apply_pasted_text_to_active_input(app: &mut AppState, pasted_text: &str) {
     }
 
     // Handle paste for the focused Observer field (`K_conv` or `pub(K_sign)`)
-    if matches!(app.active_tab, Tab::Admin(AdminTab::Observer)) {
+    if app.observer_inputs_editable() {
         let filtered_text: String = pasted_text.chars().filter(|c| !c.is_control()).collect();
         app.observer_active_input_mut().push_str(&filtered_text);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,10 +209,10 @@ fn apply_pasted_text_to_active_input(app: &mut AppState, pasted_text: &str) {
         }
     }
 
-    // Handle paste for observer shared key input
+    // Handle paste for the focused Observer field (`K_conv` or `pub(K_sign)`)
     if matches!(app.active_tab, Tab::Admin(AdminTab::Observer)) {
         let filtered_text: String = pasted_text.chars().filter(|c| !c.is_control()).collect();
-        app.observer_shared_key_input.push_str(&filtered_text);
+        app.observer_active_input_mut().push_str(&filtered_text);
     }
 }
 

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -15,7 +15,7 @@ use crate::ui::chat::{
     UserOrderChatMessage,
 };
 use crate::ui::helpers::OrderChatListItem;
-use crate::ui::navigation::{Tab, UserRole};
+use crate::ui::navigation::{AdminTab, Tab, UserRole};
 use crate::ui::orders::{
     BuyerInvoicePreference, FormState, InvoiceInputState, KeyInputState, MessageNotification,
     MessageViewState, OperationResult, OrderChatStaticHeader, OrderMessage, RatingOrderState,
@@ -259,6 +259,11 @@ pub struct AppState {
     pub observer_loading: bool,
     /// Observer mode: last error message (if any).
     pub observer_error: Option<String>,
+    /// Bumped on each Observer fetch and on [`Self::clear_observer_secrets`].
+    /// Async `ObserverChatLoaded` / `ObserverChatError` results with an older
+    /// generation are ignored so a slow relay reply cannot overwrite a newer
+    /// transcript or restored-empty state.
+    pub observer_fetch_generation: u64,
     /// Parsed `admin_privkey` from settings (dispute chat, classification). Updated on save / reload.
     pub admin_keys: Option<Keys>,
     /// After switching to admin mode (Settings → Switch Mode) or saving admin key: reload disputes from DB in main.
@@ -346,6 +351,7 @@ impl AppState {
             observer_scroll_tracker: None,
             observer_loading: false,
             observer_error: None,
+            observer_fetch_generation: 0,
             admin_keys: None,
             pending_admin_disputes_reload: false,
             currencies_filter: Vec::new(),
@@ -374,10 +380,39 @@ impl AppState {
         }
     }
 
+    /// True when Observer `K_conv` / `pub(K_sign)` fields should accept typing and paste.
+    ///
+    /// False while a modal (`HelpPopup`, `OperationResult`, save-attachment, …) owns input.
+    pub fn observer_inputs_editable(&self) -> bool {
+        matches!(self.active_tab, Tab::Admin(AdminTab::Observer))
+            && matches!(
+                self.mode,
+                UiMode::Normal | UiMode::AdminMode(AdminMode::Normal)
+            )
+    }
+
+    fn bump_observer_fetch_generation(&mut self) -> u64 {
+        self.observer_fetch_generation = self.observer_fetch_generation.saturating_add(1);
+        self.observer_fetch_generation
+    }
+
+    /// Invalidate in-flight Observer fetches, then mark a new fetch as current.
+    pub fn begin_observer_fetch(&mut self) -> u64 {
+        let generation = self.bump_observer_fetch_generation();
+        for msg in &mut self.observer_messages {
+            msg.content.zeroize();
+        }
+        self.observer_messages.clear();
+        self.observer_error = None;
+        self.observer_loading = true;
+        generation
+    }
+
     /// Securely wipe all observer inputs and fetched content.
     /// Uses `zeroize` to overwrite strings before clearing them, then
     /// resets error state to safe defaults.
     pub fn clear_observer_secrets(&mut self) {
+        self.bump_observer_fetch_generation();
         self.observer_shared_key_input.zeroize();
         self.observer_shared_key_input.clear();
         self.observer_sign_pubkey_input.zeroize();
@@ -413,5 +448,52 @@ impl AppState {
         // admin_disputes_in_progress, admin_chat_scrollview_state, admin_chat_selected_message_idx,
         // admin_chat_line_starts, admin_chat_scroll_tracker, and dispute_filter across role switches
         // so that admin context is not lost when temporarily viewing user mode.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::chat::{ChatSender, DisputeChatMessage};
+
+    fn dummy_observer_message(content: &str) -> DisputeChatMessage {
+        DisputeChatMessage {
+            sender: ChatSender::Buyer,
+            content: content.to_string(),
+            timestamp: 1,
+            target_party: None,
+            attachment: None,
+        }
+    }
+
+    #[test]
+    fn observer_inputs_editable_only_in_plain_observer_mode() {
+        let mut app = AppState::new(UserRole::Admin);
+        app.active_tab = Tab::Admin(AdminTab::Observer);
+        app.mode = UiMode::AdminMode(AdminMode::Normal);
+        assert!(app.observer_inputs_editable());
+
+        app.mode = UiMode::HelpPopup(
+            app.active_tab,
+            Box::new(UiMode::AdminMode(AdminMode::Normal)),
+        );
+        assert!(!app.observer_inputs_editable());
+
+        app.mode = UiMode::operation_result(crate::ui::OperationResult::Error("x".into()));
+        assert!(!app.observer_inputs_editable());
+
+        app.mode = UiMode::ObserverSaveAttachmentPopup(0);
+        assert!(!app.observer_inputs_editable());
+    }
+
+    #[test]
+    fn clear_observer_secrets_invalidates_in_flight_fetch_generation() {
+        let mut app = AppState::new(UserRole::Admin);
+        let gen = app.begin_observer_fetch();
+        app.observer_messages.push(dummy_observer_message("from-a"));
+        app.clear_observer_secrets();
+        assert_ne!(app.observer_fetch_generation, gen);
+        assert!(app.observer_messages.is_empty());
+        assert!(!app.observer_loading);
     }
 }

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -24,6 +24,23 @@ use crate::ui::user_state::UserMode;
 use crate::util::{transport_from_instance, MostroInstanceInfo};
 use nostr_sdk::prelude::Keys;
 
+/// Which Observer input has keyboard / paste focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ObserverInputField {
+    #[default]
+    ConvKey,
+    SignAuthor,
+}
+
+impl ObserverInputField {
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::ConvKey => Self::SignAuthor,
+            Self::SignAuthor => Self::ConvKey,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum UiMode {
     // Shared modes (available to both user and admin)
@@ -226,9 +243,13 @@ pub struct AppState {
     pub user_send_attachment_explorer: Option<ratatui_explorer::FileExplorer>,
     /// Order id with an outbound attachment send in progress (blocks duplicate Ctrl+O).
     pub sending_attachment_order_id: Option<String>,
-    /// Observer mode: shared key as 64-char hex string (32 bytes).
+    /// Observer mode: disclosed `K_conv` as 64-char hex (read-only grant).
     pub observer_shared_key_input: String,
-    /// Observer mode: chat messages fetched from relays for the pasted shared key.
+    /// Observer mode: optional `pub(K_sign)` locator (hex or npub) for `authors` filter.
+    pub observer_sign_pubkey_input: String,
+    /// Observer mode: which input receives typing and paste.
+    pub observer_input_focus: ObserverInputField,
+    /// Observer mode: chat messages fetched from relays for the pasted `K_conv`.
     pub observer_messages: Vec<DisputeChatMessage>,
     /// Observer mode: scroll state for chat messages.
     pub observer_scrollview_state: tui_scrollview::ScrollViewState,
@@ -318,6 +339,8 @@ impl AppState {
             user_send_attachment_explorer: None,
             sending_attachment_order_id: None,
             observer_shared_key_input: String::new(),
+            observer_sign_pubkey_input: String::new(),
+            observer_input_focus: ObserverInputField::ConvKey,
             observer_messages: Vec::new(),
             observer_scrollview_state: tui_scrollview::ScrollViewState::default(),
             observer_scroll_tracker: None,
@@ -344,12 +367,22 @@ impl AppState {
         self.mostro_info = info;
     }
 
+    pub fn observer_active_input_mut(&mut self) -> &mut String {
+        match self.observer_input_focus {
+            ObserverInputField::ConvKey => &mut self.observer_shared_key_input,
+            ObserverInputField::SignAuthor => &mut self.observer_sign_pubkey_input,
+        }
+    }
+
     /// Securely wipe all observer inputs and fetched content.
     /// Uses `zeroize` to overwrite strings before clearing them, then
     /// resets error state to safe defaults.
     pub fn clear_observer_secrets(&mut self) {
         self.observer_shared_key_input.zeroize();
         self.observer_shared_key_input.clear();
+        self.observer_sign_pubkey_input.zeroize();
+        self.observer_sign_pubkey_input.clear();
+        self.observer_input_focus = ObserverInputField::ConvKey;
 
         for msg in &mut self.observer_messages {
             msg.content.zeroize();

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -39,18 +39,18 @@ pub const HELP_DP_ENTER_TAKE: &str = "Enter: Take selected dispute";
 pub const HELP_DP_SELECT_DISPUTE: &str = "↑↓: Select dispute";
 
 // Help popup lines (Observer)
-pub const HELP_OBS_ENTER_LOAD: &str = "Enter: Load chat for shared key";
+pub const HELP_OBS_ENTER_LOAD: &str = "Enter: Load chat for K_conv";
 #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd"
 ))]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+Shift+V: Paste shared key";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+Shift+V: Paste into focused field";
 #[cfg(target_os = "windows")]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste shared key";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into focused field";
 #[cfg(target_os = "macos")]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste shared key";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste into focused field";
 #[cfg(not(any(
     target_os = "linux",
     target_os = "freebsd",
@@ -59,12 +59,13 @@ pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste shared key";
     target_os = "windows",
     target_os = "macos"
 )))]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste shared key";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into focused field";
 pub const HELP_OBS_SCROLL_LINE: &str = "↑↓: Scroll messages";
 pub const HELP_OBS_SCROLL_PAGE: &str = "PgUp/PgDn: Scroll page";
 pub const HELP_OBS_ESC_CLEAR_ERR: &str = "Esc: Clear error";
 pub const HELP_OBS_CTRL_C_CLEAR: &str = "Ctrl+C: Clear all";
 pub const HELP_OBS_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment";
+pub const HELP_OBS_TAB_FOCUS: &str = "Tab: Switch K_conv / pub(K_sign) fields";
 
 // Help popup lines (Settings)
 pub const HELP_SETTINGS_SWITCH_FROM_MENU: &str =
@@ -97,6 +98,8 @@ pub const HELP_MY_TRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats (Release
 pub const HELP_MY_TRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty (open rating popup)";
 pub const HELP_MY_TRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Open a dispute (Dispute message)";
 pub const HELP_MY_TRADES_SHIFT_H_HELP: &str = "Shift+H: Show shortcuts help";
+pub const HELP_MY_TRADES_SHIFT_K_KCONV: &str =
+    "Shift+K: Reveal K_conv (read-only grant for solvers; never K_sign)";
 pub const HELP_MY_TRADES_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment (choose from list)";
 pub const HELP_MY_TRADES_CTRL_O_SEND: &str = "Ctrl+O: Send attachment (file picker)";
 pub const HELP_MY_TRADES_CTRL_SHIFT_O_RETRY: &str =
@@ -182,6 +185,7 @@ pub const FOOTER_MYTRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Dispute";
 pub const FOOTER_MYTRADES_SHIFT_F_FIAT_SENT: &str = "Shift+F: Mark fiat sent";
 pub const FOOTER_MYTRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats";
 pub const FOOTER_MYTRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty";
+pub const FOOTER_MYTRADES_SHIFT_K_KCONV: &str = "Shift+K: Reveal K_conv";
 pub const FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT: &str = "PgUp/PgDn: Scroll chat";
 pub const FOOTER_MYTRADES_END_BOTTOM: &str = "End: Bottom";
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -336,6 +336,7 @@ fn help_content(app: &AppState, tab: Tab) -> (String, Vec<String>) {
             HELP_TITLE_OBSERVER.to_string(),
             vec![
                 HELP_OBS_ENTER_LOAD.to_string(),
+                HELP_OBS_TAB_FOCUS.to_string(),
                 HELP_OBS_PASTE_SHARED_KEY.to_string(),
                 HELP_OBS_SCROLL_LINE.to_string(),
                 HELP_OBS_SCROLL_PAGE.to_string(),
@@ -375,6 +376,7 @@ fn help_content(app: &AppState, tab: Tab) -> (String, Vec<String>) {
                 HELP_MY_TRADES_SHIFT_R_RELEASE.to_string(),
                 HELP_MY_TRADES_SHIFT_V_RATE.to_string(),
                 HELP_MY_TRADES_SHIFT_D_DISPUTE.to_string(),
+                HELP_MY_TRADES_SHIFT_K_KCONV.to_string(),
                 HELP_MY_TRADES_CTRL_S_ATTACH.to_string(),
                 HELP_MY_TRADES_CTRL_O_SEND.to_string(),
                 HELP_MY_TRADES_CTRL_SHIFT_O_RETRY.to_string(),
@@ -424,6 +426,24 @@ mod help_content_tests {
         assert!(
             lines.iter().any(|l| l == HELP_MY_TRADES_SHIFT_D_DISPUTE),
             "Shift+D missing from My Trades help: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l == HELP_MY_TRADES_SHIFT_K_KCONV),
+            "Shift+K missing from My Trades help: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn observer_help_lists_k_conv_load_and_tab_focus() {
+        let app = AppState::new(UserRole::Admin);
+        let (_, lines) = help_content(&app, Tab::Admin(AdminTab::Observer));
+        assert!(
+            lines.iter().any(|l| l == HELP_OBS_ENTER_LOAD),
+            "K_conv load missing from Observer help: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l == HELP_OBS_TAB_FOCUS),
+            "Tab focus missing from Observer help: {lines:?}"
         );
     }
 }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1164,22 +1164,34 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             }
         }
     } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-        // Validate shared key, then fetch observer chat authenticated against
+        // Validate K_conv, then fetch observer chat authenticated against
         // known admin/party inner signers from taken disputes.
         let key_str = app.observer_shared_key_input.trim().to_string();
         if key_str.is_empty() {
-            let msg = "Shared key is required".to_string();
+            let msg = "K_conv is required".to_string();
             app.observer_error = Some(msg.clone());
             app.mode = UiMode::operation_result(OperationResult::Error(msg));
             return;
         }
 
         if crate::util::chat_utils::keys_from_shared_hex(&key_str).is_none() {
-            let msg = "Shared key must be a valid 64-char hex secret (32 bytes)".to_string();
+            let msg = "K_conv must be a valid 64-char hex secret (32 bytes)".to_string();
             app.observer_error = Some(msg.clone());
             app.mode = UiMode::operation_result(OperationResult::Error(msg));
             return;
         }
+
+        let sign_pubkey = match crate::util::chat_utils::parse_optional_sign_pubkey(
+            &app.observer_sign_pubkey_input,
+        ) {
+            Ok(pk) => pk,
+            Err(e) => {
+                let msg = e.to_string();
+                app.observer_error = Some(msg.clone());
+                app.mode = UiMode::operation_result(OperationResult::Error(msg));
+                return;
+            }
+        };
 
         // Clear previous results and set loading state
         for msg in &mut app.observer_messages {
@@ -1197,7 +1209,7 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
         let tx = ctx.order_result_tx.clone();
 
         tokio::spawn(async move {
-            match fetch_observer_chat(&client, &key_str, &known_roles).await {
+            match fetch_observer_chat(&client, &key_str, sign_pubkey, &known_roles).await {
                 Ok(messages) => {
                     let _ = tx.send(OperationResult::ObserverChatLoaded(messages));
                 }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1193,15 +1193,8 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             }
         };
 
-        // Clear previous results and set loading state
-        for msg in &mut app.observer_messages {
-            zeroize::Zeroize::zeroize(&mut msg.content);
-        }
-        app.observer_messages.clear();
-        app.observer_error = None;
-        app.observer_loading = true;
-
         // Spawn async fetch via the order_result channel
+        let generation = app.begin_observer_fetch();
         let client = ctx.client.clone();
         let admin_pubkey = ctx.admin_chat_keys.map(|k| k.public_key());
         let known_roles =
@@ -1211,10 +1204,16 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
         tokio::spawn(async move {
             match fetch_observer_chat(&client, &key_str, sign_pubkey, &known_roles).await {
                 Ok(messages) => {
-                    let _ = tx.send(OperationResult::ObserverChatLoaded(messages));
+                    let _ = tx.send(OperationResult::ObserverChatLoaded {
+                        generation,
+                        messages,
+                    });
                 }
                 Err(e) => {
-                    let _ = tx.send(OperationResult::ObserverChatError(e.to_string()));
+                    let _ = tx.send(OperationResult::ObserverChatError {
+                        generation,
+                        message: e.to_string(),
+                    });
                 }
             }
         });

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -531,7 +531,7 @@ pub fn handle_key_event(
             if let Some(text) = read_clipboard_text_best_effort() {
                 let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
                 if !filtered.is_empty() {
-                    app.observer_shared_key_input.push_str(&filtered);
+                    app.observer_active_input_mut().push_str(&filtered);
                     return Some(true);
                 }
             }
@@ -766,10 +766,8 @@ pub fn handle_key_event(
                             app.observer_shared_key_input.chars().take(8).collect();
                         let id = format!("observer_{}", key_prefix);
 
-                        // For Observer mode (pure P2P chats), attachment JSON often omits a `key`
-                        // and expects decryption using the same shared key used for messages.
-                        // If no explicit decryption_key was provided, derive it from the pasted
-                        // shared key hex so the saved file is decrypted instead of left encrypted.
+                        // Observer holds K_conv only; use it as the ChaCha key when the
+                        // attachment JSON omitted an inline key.
                         let mut att_clone = (*att).clone();
                         if att_clone.decryption_key.is_none() {
                             if let Some(keys) = crate::util::chat_utils::keys_from_shared_hex(
@@ -1112,6 +1110,53 @@ pub fn handle_key_event(
                         return Some(true);
                     }
                 }
+                KeyCode::Char('k') | KeyCode::Char('K') => {
+                    if !app.mode.user_my_trades_interactive() {
+                        return Some(true);
+                    }
+                    let Some((order_id, _)) = resolve_selected_mytrades_order_status(app) else {
+                        app.mode = UiMode::operation_result(OperationResult::Info(
+                            "Select an order to reveal K_conv.".to_string(),
+                        ));
+                        return Some(true);
+                    };
+                    let pool = pool.clone();
+                    let tx = order_result_tx.clone();
+                    tokio::spawn(async move {
+                        let result = match crate::models::Order::get_by_id(
+                            &pool,
+                            &order_id.to_string(),
+                        )
+                        .await
+                        {
+                            Ok(order) => {
+                                let trade_keys = order
+                                    .trade_keys
+                                    .as_deref()
+                                    .and_then(|h| Keys::parse(h).ok());
+                                match crate::util::chat_utils::conversation_disclosure_from_order(
+                                    order.order_chat_shared_key_hex.as_deref(),
+                                    trade_keys.as_ref(),
+                                    order.counterparty_pubkey.as_deref(),
+                                ) {
+                                    Some((conv, sign_pk)) => OperationResult::Info(format!(
+                                        "K_conv (read-only grant for solvers):\n{conv}\n\n\
+pub(K_sign) optional locator:\n{sign_pk}\n\n\
+Disclose K_conv only. Never share the K_sign secret."
+                                    )),
+                                    None => OperationResult::Error(
+                                        "No conversation key for this order yet.".to_string(),
+                                    ),
+                                }
+                            }
+                            Err(e) => OperationResult::Error(format!(
+                                "Could not load order for K_conv: {e}"
+                            )),
+                        };
+                        let _ = tx.send(result);
+                    });
+                    return Some(true);
+                }
                 _ => {}
             }
         }
@@ -1127,7 +1172,7 @@ pub fn handle_key_event(
         return Some(result);
     }
 
-    // Observer tab: handle all character and backspace input early so y/n/m/c etc. go to the shared key input.
+    // Observer tab: handle all character and backspace input early so y/n/m/c etc. go to the focused field.
     // Skip when a modal result popup is active so we don't edit inputs behind the overlay.
     if let Tab::Admin(AdminTab::Observer) = app.active_tab {
         if !matches!(app.mode, UiMode::OperationResult(_)) {
@@ -1137,11 +1182,11 @@ pub fn handle_key_event(
             if !is_ctrl {
                 match code {
                     KeyCode::Char(c) => {
-                        app.observer_shared_key_input.push(c);
+                        app.observer_active_input_mut().push(c);
                         return Some(true);
                     }
                     KeyCode::Backspace => {
-                        app.observer_shared_key_input.pop();
+                        app.observer_active_input_mut().pop();
                         return Some(true);
                     }
                     _ => {}
@@ -1426,7 +1471,9 @@ pub fn handle_key_event(
 #[cfg(test)]
 mod key_handler_tests {
     use super::*;
-    use crate::ui::{InvoiceInputState, InvoiceNotificationActionSelection};
+    use crate::ui::{
+        InvoiceInputState, InvoiceNotificationActionSelection, ObserverInputField, UserRole,
+    };
     use crossterm::event::KeyModifiers;
 
     #[test]
@@ -1499,6 +1546,17 @@ mod key_handler_tests {
 
         let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
         assert!(is_paste_shortcut(&ctrl_v));
+    }
+
+    #[test]
+    fn observer_tab_toggles_k_conv_and_sign_locator_focus() {
+        let mut app = AppState::new(UserRole::Admin);
+        app.active_tab = Tab::Admin(AdminTab::Observer);
+        assert_eq!(app.observer_input_focus, ObserverInputField::ConvKey);
+        handle_tab_navigation(KeyCode::Tab, &mut app);
+        assert_eq!(app.observer_input_focus, ObserverInputField::SignAuthor);
+        handle_tab_navigation(KeyCode::BackTab, &mut app);
+        assert_eq!(app.observer_input_focus, ObserverInputField::ConvKey);
     }
 
     #[test]

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -526,14 +526,12 @@ pub fn handle_key_event(
     }
 
     // Observer tab paste fallback for terminals without bracketed paste (notably cmd.exe).
-    if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-        if is_paste_shortcut(&key_event) {
-            if let Some(text) = read_clipboard_text_best_effort() {
-                let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
-                if !filtered.is_empty() {
-                    app.observer_active_input_mut().push_str(&filtered);
-                    return Some(true);
-                }
+    if app.observer_inputs_editable() && is_paste_shortcut(&key_event) {
+        if let Some(text) = read_clipboard_text_best_effort() {
+            let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
+            if !filtered.is_empty() {
+                app.observer_active_input_mut().push_str(&filtered);
+                return Some(true);
             }
         }
     }
@@ -1173,24 +1171,22 @@ Disclose K_conv only. Never share the K_sign secret."
     }
 
     // Observer tab: handle all character and backspace input early so y/n/m/c etc. go to the focused field.
-    // Skip when a modal result popup is active so we don't edit inputs behind the overlay.
-    if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-        if !matches!(app.mode, UiMode::OperationResult(_)) {
-            let is_ctrl = key_event
-                .modifiers
-                .contains(crossterm::event::KeyModifiers::CONTROL);
-            if !is_ctrl {
-                match code {
-                    KeyCode::Char(c) => {
-                        app.observer_active_input_mut().push(c);
-                        return Some(true);
-                    }
-                    KeyCode::Backspace => {
-                        app.observer_active_input_mut().pop();
-                        return Some(true);
-                    }
-                    _ => {}
+    // Skip when a modal owns input so we don't edit K_conv / pub(K_sign) behind an overlay.
+    if app.observer_inputs_editable() {
+        let is_ctrl = key_event
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL);
+        if !is_ctrl {
+            match code {
+                KeyCode::Char(c) => {
+                    app.observer_active_input_mut().push(c);
+                    return Some(true);
                 }
+                KeyCode::Backspace => {
+                    app.observer_active_input_mut().pop();
+                    return Some(true);
+                }
+                _ => {}
             }
         }
     }

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -569,6 +569,8 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                 // Reset scroll/selection when switching parties (will be set in render)
                 app.admin_chat_selected_message_idx = None;
                 app.admin_chat_scroll_tracker = None;
+            } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
+                app.observer_input_focus = app.observer_input_focus.toggle();
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.next(form.use_range);
             }
@@ -582,6 +584,8 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                 // Reset scroll/selection when switching parties (will be set in render)
                 app.admin_chat_selected_message_idx = None;
                 app.admin_chat_scroll_tracker = None;
+            } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
+                app.observer_input_focus = app.observer_input_focus.toggle();
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.prev(form.use_range);
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -45,9 +45,9 @@ pub use state::{
     AppState, BuyerInvoicePreference, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
     DecodedChatMessage, DisputeChatMessage, DisputeFilter, FormState, InvoiceInputState,
     InvoiceNotificationActionSelection, KeyInputState, LnAddressVerifyResult, MessageNotification,
-    MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen,
-    OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,
-    ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
+    MessageViewState, MostroInfoFetchResult, ObserverInputField, OperationResult,
+    OrderChatLastSeen, OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab,
+    TakeOrderState, ThreeState, UiMode, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
     ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -50,8 +50,8 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
     let popup_height = match result {
         OperationResult::Success(_) => 18,
         OperationResult::PaymentRequestRequired { .. }
-        | OperationResult::ObserverChatLoaded(_)
-        | OperationResult::ObserverChatError(_) => 8,
+        | OperationResult::ObserverChatLoaded { .. }
+        | OperationResult::ObserverChatError { .. } => 8,
         OperationResult::Info(message) => info_popup_height(message, popup_width),
         OperationResult::Error(_)
         | OperationResult::InvoiceSubmitted { .. }
@@ -225,7 +225,7 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
         }
-        OperationResult::ObserverChatLoaded(_) | OperationResult::ObserverChatError(_) => {
+        OperationResult::ObserverChatLoaded { .. } | OperationResult::ObserverChatError { .. } => {
             // Handled directly in handle_operation_result, should not reach render
         }
         OperationResult::PaymentRequestRequired { .. } => {

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -154,9 +154,15 @@ pub enum OperationResult {
     },
     Error(String),
     /// Observer chat loaded successfully from relays.
-    ObserverChatLoaded(Vec<crate::ui::chat::DisputeChatMessage>),
+    ObserverChatLoaded {
+        generation: u64,
+        messages: Vec<crate::ui::chat::DisputeChatMessage>,
+    },
     /// Observer chat fetch failed.
-    ObserverChatError(String),
+    ObserverChatError {
+        generation: u64,
+        message: String,
+    },
     /// Trade ended (e.g. cooperative cancel confirmed); remove order from Messages and show `message`.
     TradeClosed {
         order_id: uuid::Uuid,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,6 +1,6 @@
 pub use crate::shared::permissions::SolverPermission;
 pub use crate::ui::admin_state::AddSolverState;
-pub use crate::ui::app_state::{AppState, UiMode};
+pub use crate::ui::app_state::{AppState, ObserverInputField, UiMode};
 pub use crate::ui::chat::{
     AdminChatLastSeen, AdminChatUpdate, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
     DecodedChatMessage, DisputeChatMessage, DisputeFilter, OrderChatLastSeen, OrderChatUpdate,

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -10,64 +10,68 @@ use crate::ui::{AppState, ObserverInputField, BACKGROUND_COLOR, PRIMARY_COLOR};
 pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppState) {
     let compact = area.height < 16;
     let input_height = if compact { 5 } else { 8 };
+    // Borders consume 2 rows. Compact: 1 inner row (status/error). Full: 2 inner rows.
+    let header_height = if compact { 3 } else { 4 };
     let chunks = Layout::new(
         Direction::Vertical,
         [
-            Constraint::Length(3), // Header / status
-            Constraint::Min(0),    // Chat messages
+            Constraint::Length(header_height),
+            Constraint::Min(0), // Chat messages
             Constraint::Length(input_height),
         ],
     )
     .split(area);
 
-    // Header / status
-    let status_lines = {
-        let mut lines = Vec::new();
-        lines.push(Line::from(vec![
+    // Header / status — keep the dynamic row visible (do not clip it behind the title).
+    let status_line = if let Some(err) = &app.observer_error {
+        Line::from(vec![
             Span::styled(
-                "Observer Mode",
-                Style::default()
-                    .fg(PRIMARY_COLOR)
-                    .add_modifier(Modifier::BOLD),
+                "Error: ",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             ),
-            Span::raw("  –  paste K_conv (read-only). Never paste K_sign."),
-        ]));
+            Span::styled(err.as_str(), Style::default().fg(Color::Red)),
+        ])
+    } else if !app.observer_messages.is_empty() {
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::Gray)),
+            Span::styled(
+                format!("Loaded {} message(s)", app.observer_messages.len()),
+                Style::default().fg(Color::Green),
+            ),
+        ])
+    } else if app.observer_loading {
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::Gray)),
+            Span::styled(
+                "Fetching messages from relays...",
+                Style::default().fg(Color::Yellow),
+            ),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::Gray)),
+            Span::styled(
+                "Paste K_conv and press Enter to load chat",
+                Style::default().fg(Color::Gray),
+            ),
+        ])
+    };
 
-        if let Some(err) = &app.observer_error {
-            lines.push(Line::from(vec![
+    let status_lines = if compact {
+        vec![status_line]
+    } else {
+        vec![
+            Line::from(vec![
                 Span::styled(
-                    "Error: ",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    "Observer Mode",
+                    Style::default()
+                        .fg(PRIMARY_COLOR)
+                        .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(err.as_str(), Style::default().fg(Color::Red)),
-            ]));
-        } else if !app.observer_messages.is_empty() {
-            lines.push(Line::from(vec![
-                Span::styled("Status: ", Style::default().fg(Color::Gray)),
-                Span::styled(
-                    format!("Loaded {} message(s)", app.observer_messages.len()),
-                    Style::default().fg(Color::Green),
-                ),
-            ]));
-        } else if app.observer_loading {
-            lines.push(Line::from(vec![
-                Span::styled("Status: ", Style::default().fg(Color::Gray)),
-                Span::styled(
-                    "Fetching messages from relays...",
-                    Style::default().fg(Color::Yellow),
-                ),
-            ]));
-        } else {
-            lines.push(Line::from(vec![
-                Span::styled("Status: ", Style::default().fg(Color::Gray)),
-                Span::styled(
-                    "Paste K_conv and press Enter to load chat",
-                    Style::default().fg(Color::Gray),
-                ),
-            ]));
-        }
-
-        lines
+                Span::raw("  –  paste K_conv (read-only). Never paste K_sign."),
+            ]),
+            status_line,
+        ]
     };
 
     let header = Paragraph::new(status_lines).block(
@@ -262,6 +266,44 @@ mod tests {
         assert!(
             buffer_contains(buf, "read-only"),
             "missing read-only grant copy"
+        );
+    }
+
+    fn render_observer(app: &mut AppState, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| render_observer_tab(f, f.area(), app))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn observer_header_shows_loading_and_error_at_standard_and_compact_heights() {
+        let mut app = AppState::new(UserRole::Admin);
+        app.observer_loading = true;
+        let buf = render_observer(&mut app, 80, 24);
+        assert!(
+            buffer_contains(&buf, "Fetching messages"),
+            "standard height clipped loading status"
+        );
+        let buf = render_observer(&mut app, 80, 12);
+        assert!(
+            buffer_contains(&buf, "Fetching messages"),
+            "compact height clipped loading status"
+        );
+
+        app.observer_loading = false;
+        app.observer_error = Some("invalid-k-conv".to_string());
+        let buf = render_observer(&mut app, 80, 24);
+        assert!(
+            buffer_contains(&buf, "invalid-k-conv"),
+            "standard height clipped K_conv error"
+        );
+        let buf = render_observer(&mut app, 80, 12);
+        assert!(
+            buffer_contains(&buf, "invalid-k-conv"),
+            "compact height clipped K_conv error"
         );
     }
 

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -5,15 +5,17 @@ use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::helpers::build_observer_scrollview_content;
-use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
+use crate::ui::{AppState, ObserverInputField, BACKGROUND_COLOR, PRIMARY_COLOR};
 
 pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppState) {
+    let compact = area.height < 16;
+    let input_height = if compact { 5 } else { 8 };
     let chunks = Layout::new(
         Direction::Vertical,
         [
             Constraint::Length(3), // Header / status
             Constraint::Min(0),    // Chat messages
-            Constraint::Length(6), // Input + footer
+            Constraint::Length(input_height),
         ],
     )
     .split(area);
@@ -28,7 +30,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
                     .fg(PRIMARY_COLOR)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::raw("  –  paste a shared key to fetch and view chat messages"),
+            Span::raw("  –  paste K_conv (read-only). Never paste K_sign."),
         ]));
 
         if let Some(err) = &app.observer_error {
@@ -59,7 +61,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
             lines.push(Line::from(vec![
                 Span::styled("Status: ", Style::default().fg(Color::Gray)),
                 Span::styled(
-                    "Paste shared key and press Enter to load chat",
+                    "Paste K_conv and press Enter to load chat",
                     Style::default().fg(Color::Gray),
                 ),
             ]));
@@ -98,7 +100,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         let hint = if app.observer_loading {
             "Fetching messages..."
         } else {
-            "No messages yet. Paste a shared key and press Enter to load."
+            "No messages yet. Paste K_conv and press Enter to load."
         };
         let paragraph = Paragraph::new(Line::from(Span::styled(
             hint,
@@ -146,29 +148,72 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         f.render_stateful_widget(scroll_view, inner_area, &mut app.observer_scrollview_state);
     }
 
-    // Shared key input + footer
-    let input_chunks = Layout::new(
-        Direction::Vertical,
-        [Constraint::Length(4), Constraint::Length(2)],
-    )
-    .split(chunks[2]);
+    // K_conv / optional pub(K_sign) inputs + footer
+    let show_both_fields = !compact;
+    let input_chunks = if show_both_fields {
+        Layout::new(
+            Direction::Vertical,
+            [
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Length(2),
+            ],
+        )
+        .split(chunks[2])
+    } else {
+        Layout::new(
+            Direction::Vertical,
+            [Constraint::Length(3), Constraint::Length(2)],
+        )
+        .split(chunks[2])
+    };
 
-    let key_border = Style::default()
+    let focused_border = Style::default()
         .fg(PRIMARY_COLOR)
         .add_modifier(Modifier::BOLD);
-    let key_title_style = Style::default()
+    let idle_border = Style::default().fg(Color::Gray);
+    let title_style = Style::default()
         .fg(PRIMARY_COLOR)
         .add_modifier(Modifier::BOLD);
 
-    let key_title = Span::styled("Shared key (64-char hex)", key_title_style);
-    let key_input = Paragraph::new(app.observer_shared_key_input.as_str()).block(
+    let conv_focused = app.observer_input_focus == ObserverInputField::ConvKey;
+    let conv_input = Paragraph::new(app.observer_shared_key_input.as_str()).block(
         Block::default()
-            .title(key_title)
+            .title(Span::styled(
+                "K_conv (64-char hex, read-only grant)",
+                title_style,
+            ))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(key_border),
+            .border_style(if conv_focused {
+                focused_border
+            } else {
+                idle_border
+            }),
     );
-    f.render_widget(key_input, input_chunks[0]);
+    let sign_input = Paragraph::new(app.observer_sign_pubkey_input.as_str()).block(
+        Block::default()
+            .title(Span::styled(
+                "pub(K_sign) optional locator (hex/npub)",
+                title_style,
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if !conv_focused {
+                focused_border
+            } else {
+                idle_border
+            }),
+    );
+
+    if show_both_fields {
+        f.render_widget(conv_input, input_chunks[0]);
+        f.render_widget(sign_input, input_chunks[1]);
+    } else if conv_focused {
+        f.render_widget(conv_input, input_chunks[0]);
+    } else {
+        f.render_widget(sign_input, input_chunks[0]);
+    }
 
     let paste_hint = if cfg!(windows) {
         "Shift+Insert / Ctrl+V / Ctrl+Shift+V / right-click"
@@ -176,8 +221,62 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         "Ctrl+V / Ctrl+Shift+V / middle-click"
     };
     let footer = Paragraph::new(format!(
-        "Ctrl+H: Help | Tab/Shift+Tab: Switch focus | Paste shared key ({paste_hint})\n\
+        "Ctrl+H: Help | Tab: Switch K_conv / pub(K_sign) | Paste ({paste_hint})\n\
 Enter: Load chat | Esc: Clear error | Ctrl+C: Clear all | Ctrl+S: Save attachment | ↑↓/PgUp/PgDn: Scroll"
     ));
-    f.render_widget(footer, input_chunks[1]);
+    let footer_idx = if show_both_fields { 2 } else { 1 };
+    f.render_widget(footer, input_chunks[footer_idx]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_observer_tab;
+    use crate::ui::{AppState, UserRole};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        let mut hay = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                hay.push_str(buf[(x, y)].symbol());
+            }
+        }
+        hay.contains(needle)
+    }
+
+    #[test]
+    fn observer_tab_prompts_for_k_conv_not_ecdh() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = AppState::new(UserRole::Admin);
+        terminal
+            .draw(|f| render_observer_tab(f, f.area(), &mut app))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        assert!(buffer_contains(buf, "K_conv"), "missing K_conv field");
+        assert!(
+            buffer_contains(buf, "Never paste K_sign") || buffer_contains(buf, "K_sign"),
+            "missing K_sign warning"
+        );
+        assert!(
+            buffer_contains(buf, "read-only"),
+            "missing read-only grant copy"
+        );
+    }
+
+    #[test]
+    fn observer_tab_compact_height_keeps_k_conv_field() {
+        let backend = TestBackend::new(80, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = AppState::new(UserRole::Admin);
+        terminal
+            .draw(|f| render_observer_tab(f, f.area(), &mut app))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        assert!(
+            buffer_contains(buf, "K_conv"),
+            "compact layout dropped K_conv"
+        );
+    }
 }

--- a/src/ui/tabs/order_in_progress_tab.rs
+++ b/src/ui/tabs/order_in_progress_tab.rs
@@ -13,8 +13,8 @@ use crate::ui::constants::{
     FOOTER_MYTRADES_END_BOTTOM, FOOTER_MYTRADES_ENTER_SEND, FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
     FOOTER_MYTRADES_SELECT_ORDER, FOOTER_MYTRADES_SHIFT_C_CANCEL, FOOTER_MYTRADES_SHIFT_D_DISPUTE,
     FOOTER_MYTRADES_SHIFT_F_FIAT_SENT, FOOTER_MYTRADES_SHIFT_I_DISABLE,
-    FOOTER_MYTRADES_SHIFT_I_ENABLE, FOOTER_MYTRADES_SHIFT_R_RELEASE, FOOTER_MYTRADES_SHIFT_V_RATE,
-    FOOTER_SENDING_ATTACHMENT, HELP_KEY,
+    FOOTER_MYTRADES_SHIFT_I_ENABLE, FOOTER_MYTRADES_SHIFT_K_KCONV, FOOTER_MYTRADES_SHIFT_R_RELEASE,
+    FOOTER_MYTRADES_SHIFT_V_RATE, FOOTER_SENDING_ATTACHMENT, HELP_KEY,
 };
 use crate::ui::helpers::{
     active_order_chat_list_snapshot, count_order_attachments, format_local_timestamp,
@@ -564,10 +564,11 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}{}",
+                    "{} | {} | {} | {}{}",
                     FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
                     FOOTER_MYTRADES_END_BOTTOM,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_SHIFT_K_KCONV,
                     attach_hints,
                 )),
             ])
@@ -585,10 +586,11 @@ pub fn render_order_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut Ap
                     FOOTER_MYTRADES_SHIFT_R_RELEASE,
                 )),
                 Line::from(format!(
-                    "{} | {} | {}{}",
+                    "{} | {} | {} | {}{}",
                     FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT,
                     FOOTER_MYTRADES_END_BOTTOM,
                     FOOTER_MYTRADES_SHIFT_V_RATE,
+                    FOOTER_MYTRADES_SHIFT_K_KCONV,
                     attach_hints,
                 )),
             ])

--- a/src/util/chat_utils.rs
+++ b/src/util/chat_utils.rs
@@ -80,11 +80,65 @@ pub fn derive_shared_key_hex(
         .map(|shared| shared.to_hex())
 }
 
-/// Rebuild ECDH `Keys` from a stored shared-key hex string.
+/// Rebuild `Keys` from a 32-byte secret hex (ECDH IKM **or** disclosed `K_conv`).
 pub fn keys_from_shared_hex(hex: &str) -> Option<Keys> {
     SharedKey::from_hex(hex)
         .ok()
         .map(|shared| shared.keys().clone())
+}
+
+/// Parse optional Observer `pub(K_sign)` locator (hex or bech32). Empty → `None`.
+pub fn parse_optional_sign_pubkey(s: &str) -> Result<Option<PublicKey>, anyhow::Error> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Ok(None);
+    }
+    parse_chat_pubkey(s)
+        .map(Some)
+        .ok_or_else(|| anyhow::anyhow!("pub(K_sign) must be a valid hex or npub pubkey"))
+}
+
+/// Kind-14 Observer fetch filter: `authors = [pub(K_sign)]` when known, else `#p = pub(K_conv)`.
+pub(crate) fn observer_kind14_filter(
+    conv_pubkey: PublicKey,
+    sign_pubkey: Option<PublicKey>,
+    since: Timestamp,
+) -> Filter {
+    match sign_pubkey {
+        Some(author) => chat_filter(author).since(since).limit(100),
+        None => Filter::new()
+            .kind(Kind::PrivateDirectMessage)
+            .pubkey(conv_pubkey)
+            .since(since)
+            .limit(100),
+    }
+}
+
+/// Read-only disclosure for a solver: `K_conv` secret hex and `pub(K_sign)`.
+///
+/// Never returns the `K_sign` secret. `K_conv` decrypts; it cannot author kind 14.
+pub fn conversation_disclosure_from_ecdh(ecdh_keys: &Keys) -> Option<(String, String)> {
+    let (conv, sign) = chat_keys_from_ecdh(ecdh_keys)?;
+    Some((
+        conv.secret_key().to_secret_hex(),
+        sign.public_key().to_hex(),
+    ))
+}
+
+/// Observer disclosure from a stored order (ECDH hex or trade-key ECDH).
+pub fn conversation_disclosure_from_order(
+    order_chat_shared_key_hex: Option<&str>,
+    trade_keys: Option<&Keys>,
+    counterparty_pubkey: Option<&str>,
+) -> Option<(String, String)> {
+    let ecdh = order_chat_shared_key_hex
+        .and_then(keys_from_shared_hex)
+        .or_else(|| {
+            let trade = trade_keys?;
+            let pk = parse_chat_pubkey(counterparty_pubkey?)?;
+            derive_shared_keys(Some(trade), Some(&pk))
+        })?;
+    conversation_disclosure_from_ecdh(&ecdh)
 }
 
 /// Derive `(K_conv, K_sign)` from ECDH keys rebuilt via [`keys_from_shared_hex`].
@@ -562,17 +616,49 @@ pub async fn fetch_admin_chat_updates(
     Ok(updates)
 }
 
-/// Fetch chat messages for the Observer tab using a pasted ECDH shared key hex.
+/// Unwrap a kind-14 Observer event using disclosed `K_conv`.
 ///
-/// Derives `K_conv` / `K_sign` for fetch/decrypt. Observer UX that accepts
-/// `K_conv`-only disclosure is Step 6; this path still expects the ECDH secret
-/// Mostrix stores today (which can derive both keys).
+/// When `sign_pubkey` is `Some`, the outer author must match `pub(K_sign)`.
+/// When `None`, junk authors are accepted at the filter (`#p`) and dropped when
+/// decrypt fails — same as mostro-chat `-k` without `-a`.
+pub(crate) fn unwrap_observer_chat_event(
+    conv: &Keys,
+    sign_pubkey: Option<&PublicKey>,
+    event: &Event,
+    allowed_signers: &[PublicKey],
+) -> Result<DecodedChatMessage> {
+    if allowed_signers.is_empty() {
+        return Err(anyhow::anyhow!(
+            "chat unwrap requires a non-empty inner-signer allow-list"
+        ));
+    }
+    if event.kind == Kind::GiftWrap {
+        return Err(anyhow::anyhow!(
+            "Observer K_conv cannot unwrap legacy GiftWrap (disclose K_conv from a kind-14 chat)"
+        ));
+    }
+    let expected = sign_pubkey.copied().unwrap_or(event.pubkey);
+    let msg = unwrap_chat_message(conv, &expected, allowed_signers, event, Timestamp::now())
+        .map_err(|e| anyhow::anyhow!("Failed to unwrap observer chat event: {e}"))?;
+    Ok(DecodedChatMessage {
+        content: msg.content,
+        timestamp: msg.created_at.as_secs() as i64,
+        sender: msg.sender,
+        inner_event_id: msg.inner_event_id,
+    })
+}
+
+/// Fetch chat messages for the Observer tab using disclosed `K_conv` hex.
 ///
-/// Inner signers not present in `known_roles` are rejected (no arrival-order or
-/// Admin fallback). `known_roles` must be non-empty.
+/// Optional `sign_pubkey` (`pub(K_sign)`) uses an `authors` filter; without it
+/// the query is `#p = pub(K_conv)` (junk arrives; decrypt fails).
+///
+/// Inner signers not present in `known_roles` are rejected. `known_roles` must
+/// be non-empty.
 pub async fn fetch_observer_chat(
     client: &Client,
-    shared_key_hex: &str,
+    conv_key_hex: &str,
+    sign_pubkey: Option<PublicKey>,
     known_roles: &HashMap<PublicKey, ChatSender>,
 ) -> Result<Vec<DisputeChatMessage>> {
     use crate::ui::helpers::try_parse_attachment_message;
@@ -583,33 +669,50 @@ pub async fn fetch_observer_chat(
         ));
     }
 
-    let shared_keys = keys_from_shared_hex(shared_key_hex)
-        .ok_or_else(|| anyhow::anyhow!("Invalid shared key hex"))?;
+    let conv =
+        keys_from_shared_hex(conv_key_hex).ok_or_else(|| anyhow::anyhow!("Invalid K_conv hex"))?;
     let allowed: Vec<PublicKey> = known_roles.keys().copied().collect();
 
-    let raw = fetch_gift_wraps_for_shared_key(client, &shared_keys, &allowed).await?;
+    let local_now = Timestamp::now().as_secs() as i64;
+    let seven_days_secs: i64 = 7 * 24 * 60 * 60;
+    let lookback_floor = local_now.saturating_sub(seven_days_secs);
+    let since = Timestamp::from(lookback_floor.max(0) as u64);
+    let filter = observer_kind14_filter(conv.public_key(), sign_pubkey, since);
 
-    let mut messages = Vec::with_capacity(raw.len());
-    for msg in raw {
-        let Some(sender) = known_roles.get(&msg.sender).copied() else {
-            log::warn!("observer: dropping chat message from unknown inner signer");
-            continue;
-        };
+    let events = client
+        .fetch_events(filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to fetch observer chat events: {e}"))?;
 
-        let (msg_content, attachment) = match try_parse_attachment_message(&msg.content) {
-            Some((att, display)) => (display, Some(att)),
-            None => (msg.content, None),
-        };
+    let mut messages = Vec::new();
+    for wrapped in events.iter() {
+        match unwrap_observer_chat_event(&conv, sign_pubkey.as_ref(), wrapped, &allowed) {
+            Ok(msg) => {
+                let Some(sender) = known_roles.get(&msg.sender).copied() else {
+                    log::warn!("observer: dropping chat message from unknown inner signer");
+                    continue;
+                };
 
-        messages.push(DisputeChatMessage {
-            sender,
-            content: msg_content,
-            timestamp: msg.timestamp,
-            target_party: None,
-            attachment,
-        });
+                let (msg_content, attachment) = match try_parse_attachment_message(&msg.content) {
+                    Some((att, display)) => (display, Some(att)),
+                    None => (msg.content, None),
+                };
+
+                messages.push(DisputeChatMessage {
+                    sender,
+                    content: msg_content,
+                    timestamp: msg.timestamp,
+                    target_party: None,
+                    attachment,
+                });
+            }
+            Err(e) => {
+                log::debug!("observer: skipped event {}: {e}", wrapped.id);
+            }
+        }
     }
-
+    messages.sort_by_key(|m| m.timestamp);
     Ok(messages)
 }
 
@@ -977,5 +1080,140 @@ mod tests {
         assert_eq!(merged.len(), 2);
         assert_eq!(merged[0].id, shared.id);
         assert_eq!(merged[1].id, other.id);
+    }
+
+    #[test]
+    fn parse_optional_sign_pubkey_empty_is_none() {
+        assert!(parse_optional_sign_pubkey("").unwrap().is_none());
+        assert!(parse_optional_sign_pubkey("  ").unwrap().is_none());
+        assert!(parse_optional_sign_pubkey("not-a-key").is_err());
+        let pk = Keys::generate().public_key();
+        assert_eq!(parse_optional_sign_pubkey(&pk.to_hex()).unwrap(), Some(pk));
+    }
+
+    #[test]
+    fn observer_kind14_filter_authors_when_locator_present() {
+        let conv = Keys::generate().public_key();
+        let sign = Keys::generate().public_key();
+        let since = Timestamp::from(1_700_000_000u64);
+        let with_author = observer_kind14_filter(conv, Some(sign), since);
+        let json = serde_json::to_value(&with_author).expect("filter json");
+        let authors = json.get("authors").expect("authors");
+        assert!(authors
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(&sign.to_hex())));
+        assert!(json.get("#p").is_none());
+
+        let p_only = observer_kind14_filter(conv, None, since);
+        let json = serde_json::to_value(&p_only).expect("filter json");
+        assert!(json.get("authors").is_none());
+        let p = json.get("#p").expect("#p");
+        assert!(p
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(&conv.to_hex())));
+    }
+
+    #[test]
+    fn conversation_disclosure_is_k_conv_not_k_sign_secret() {
+        let a = Keys::generate();
+        let b = Keys::generate();
+        let ecdh = derive_shared_keys(Some(&a), Some(&b.public_key())).expect("ecdh");
+        let (conv_hex, sign_pk_hex) = conversation_disclosure_from_ecdh(&ecdh).expect("disclosure");
+        let (conv, sign) = chat_keys_from_ecdh(&ecdh).expect("keys");
+        assert_eq!(conv_hex, conv.secret_key().to_secret_hex());
+        assert_eq!(sign_pk_hex, sign.public_key().to_hex());
+        assert_ne!(conv_hex, sign.secret_key().to_secret_hex());
+        let via_order = conversation_disclosure_from_order(
+            Some(
+                &derive_shared_key_hex(Some(&a), Some(b.public_key().to_string().as_str()))
+                    .unwrap(),
+            ),
+            None,
+            None,
+        )
+        .expect("from stored hex");
+        assert_eq!(via_order.0, conv_hex);
+        assert_eq!(via_order.1, sign_pk_hex);
+    }
+
+    #[tokio::test]
+    async fn observer_k_conv_only_unwraps_kind14() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let shared = SharedKey::derive(sender.secret_key(), &receiver.public_key())
+            .expect("shared key derives");
+        let (conv, sign) = shared.chat_keys().expect("chat keys");
+        let wrapped = wrap_chat_message(&sender, &conv, &sign, "evidence")
+            .await
+            .expect("wrap");
+        let observer_conv =
+            keys_from_shared_hex(&conv.secret_key().to_secret_hex()).expect("observer conv");
+        let allowed = [sender.public_key(), receiver.public_key()];
+        let msg = unwrap_observer_chat_event(&observer_conv, None, &wrapped, &allowed)
+            .expect("observer decrypt");
+        assert_eq!(msg.content, "evidence");
+        assert_eq!(msg.sender, sender.public_key());
+
+        let with_locator = unwrap_observer_chat_event(
+            &observer_conv,
+            Some(&sign.public_key()),
+            &wrapped,
+            &allowed,
+        )
+        .expect("locator unwrap");
+        assert_eq!(with_locator.content, "evidence");
+    }
+
+    #[tokio::test]
+    async fn observer_cannot_unwrap_legacy_giftwrap_with_k_conv() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let shared =
+            SharedKey::derive(sender.secret_key(), &receiver.public_key()).expect("shared");
+        let (conv, _sign) = shared.chat_keys().expect("chat keys");
+        let giftwrap = wrap_giftwrap_chat_message(&sender, &shared.public_key(), "legacy")
+            .await
+            .expect("wrap giftwrap");
+        let allowed = [sender.public_key(), receiver.public_key()];
+        let err = unwrap_observer_chat_event(&conv, None, &giftwrap, &allowed)
+            .expect_err("GiftWrap needs ECDH not K_conv");
+        assert!(err.to_string().contains("GiftWrap"));
+    }
+
+    #[tokio::test]
+    async fn observer_wrong_locator_is_rejected() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let shared =
+            SharedKey::derive(sender.secret_key(), &receiver.public_key()).expect("shared");
+        let (conv, sign) = shared.chat_keys().expect("chat keys");
+        let wrapped = wrap_chat_message(&sender, &conv, &sign, "evidence")
+            .await
+            .expect("wrap");
+        let allowed = [sender.public_key(), receiver.public_key()];
+        let wrong = Keys::generate().public_key();
+        unwrap_observer_chat_event(&conv, Some(&wrong), &wrapped, &allowed)
+            .expect_err("locator must match pub(K_sign)");
+    }
+
+    #[tokio::test]
+    async fn observer_k_conv_cannot_author_kind14() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let shared =
+            SharedKey::derive(sender.secret_key(), &receiver.public_key()).expect("shared");
+        let (conv, sign) = shared.chat_keys().expect("chat keys");
+        // Observer only holds K_conv; using it as K_sign authors pub(K_conv), not pub(K_sign).
+        let forged = wrap_chat_message(&sender, &conv, &conv, "inject")
+            .await
+            .expect("wrap with conv as sign");
+        assert_eq!(forged.pubkey, conv.public_key());
+        let allowed = [sender.public_key(), receiver.public_key()];
+        unwrap_observer_chat_event(&conv, Some(&sign.public_key()), &forged, &allowed)
+            .expect_err("K_conv cannot produce a valid K_sign author");
     }
 }

--- a/src/util/dm_utils/order_ch_mng.rs
+++ b/src/util/dm_utils/order_ch_mng.rs
@@ -309,13 +309,25 @@ pub fn handle_operation_result(mut result: OperationResult, app: &mut AppState) 
 
     // Handle observer chat results directly (don't show popup)
     match result {
-        OperationResult::ObserverChatLoaded(messages) => {
+        OperationResult::ObserverChatLoaded {
+            generation,
+            messages,
+        } => {
+            if generation != app.observer_fetch_generation {
+                return;
+            }
             app.observer_loading = false;
             app.observer_error = None;
             app.observer_messages = messages;
             return;
         }
-        OperationResult::ObserverChatError(msg) => {
+        OperationResult::ObserverChatError {
+            generation,
+            message: msg,
+        } => {
+            if generation != app.observer_fetch_generation {
+                return;
+            }
             app.observer_loading = false;
             app.observer_error = Some(msg.clone());
             app.mode = UiMode::operation_result(OperationResult::Error(msg));
@@ -558,5 +570,74 @@ mod tests {
             !matches!(app.mode, UiMode::OperationResult(_)),
             "take AddInvoice must not show the create-order success overlay"
         );
+    }
+
+    #[test]
+    fn stale_observer_chat_loaded_does_not_replace_newer_or_cleared_state() {
+        use crate::ui::chat::{ChatSender, DisputeChatMessage};
+
+        let dummy = |content: &str| DisputeChatMessage {
+            sender: ChatSender::Buyer,
+            content: content.to_string(),
+            timestamp: 1,
+            target_party: None,
+            attachment: None,
+        };
+
+        let mut app = AppState::new(UserRole::Admin);
+        let gen_a = app.begin_observer_fetch();
+        app.clear_observer_secrets();
+        handle_operation_result(
+            OperationResult::ObserverChatLoaded {
+                generation: gen_a,
+                messages: vec![dummy("from-a")],
+            },
+            &mut app,
+        );
+        assert!(
+            app.observer_messages.is_empty(),
+            "cleared Observer must ignore the late fetch for the previous K_conv"
+        );
+
+        let gen_b = app.begin_observer_fetch();
+        handle_operation_result(
+            OperationResult::ObserverChatLoaded {
+                generation: gen_a,
+                messages: vec![dummy("from-a")],
+            },
+            &mut app,
+        );
+        assert!(
+            app.observer_messages.is_empty(),
+            "in-flight B must not be overwritten by late A"
+        );
+        assert!(app.observer_loading);
+
+        handle_operation_result(
+            OperationResult::ObserverChatLoaded {
+                generation: gen_b,
+                messages: vec![dummy("from-b")],
+            },
+            &mut app,
+        );
+        assert_eq!(app.observer_messages.len(), 1);
+        assert_eq!(app.observer_messages[0].content, "from-b");
+        assert!(!app.observer_loading);
+    }
+
+    #[test]
+    fn stale_observer_chat_error_does_not_raise_popup() {
+        let mut app = AppState::new(UserRole::Admin);
+        let gen_a = app.begin_observer_fetch();
+        app.clear_observer_secrets();
+        handle_operation_result(
+            OperationResult::ObserverChatError {
+                generation: gen_a,
+                message: "relay timeout".into(),
+            },
+            &mut app,
+        );
+        assert!(app.observer_error.is_none());
+        assert!(!matches!(app.mode, UiMode::OperationResult(_)));
     }
 }


### PR DESCRIPTION
## Summary
- Observer paste is **`K_conv`** (read-only grant), with optional **`pub(K_sign)`** for an `authors` filter; without the locator the query is `#p = pub(K_conv)` (junk may arrive, decrypt fails) — same as mostro-chat `-k` / `-a`.
- My Trades **Shift+K** reveals `K_conv` plus the `pub(K_sign)` locator and never the `K_sign` secret.
- Observer fetch is kind 14 only (`K_conv` cannot unwrap GiftWrap). Tests cover K_conv-only unwrap, wrong locator, and that `K_conv` cannot author a valid kind-14 envelope.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [ ] Manual: Shift+K on an active trade → paste `K_conv` in Observer → load chat; without locator still decrypts; Observer has no send path

Does not close #102 yet (step 7 docs/tests sweep + step 8 E2E acceptance remain).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observer chat inspection now uses a conversation key with an optional signing-author filter.
  * Added two focused Observer input fields, with Tab/BackTab navigation and improved compact-layout support.
  * Added a My Trades shortcut to reveal the conversation key for a selected order.
  * Updated Observer chat retrieval and validation for safer, read-only message viewing.

* **Documentation**
  * Updated Observer, My Trades, shortcuts, help text, and security guidance to reflect the new workflow.

* **Tests**
  * Added coverage for input focus, help entries, filtering, validation, decryption, and compact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->