### PR TITLE
fix(clipboard): clipboard lost after thread exits on X11

### DIFF
--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -232,6 +232,11 @@ fn handle_clipboard_copy(invoice: String) -> bool {
         // Some clipboard backends can emit warnings to stderr; silence stderr during the call
         // to avoid corrupting the TUI.
         std::thread::spawn(move || {
+            // Needed for `SetExtLinux::wait`. It keeps this thread alive serving the selection
+            // until another app takes the clipboard ownership; otherwhise the copied text is lost
+            // as soon as the thread exists. See the documentation of `SetExtLinux::wait` for
+            // details.
+            use arboard::SetExtLinux;
             let copy_result = {
                 #[cfg(unix)]
                 {
@@ -247,7 +252,7 @@ fn handle_clipboard_copy(invoice: String) -> bool {
                     }
 
                     let r = match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set_text(invoice),
+                        Ok(mut clipboard) => clipboard.set().wait().text(invoice),
                         Err(e) => Err(e),
                     };
 
@@ -262,7 +267,7 @@ fn handle_clipboard_copy(invoice: String) -> bool {
                 #[cfg(not(unix))]
                 {
                     match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set_text(invoice),
+                        Ok(mut clipboard) => clipboard.set().wait().text(invoice),
                         Err(e) => Err(e),
                     }
                 }


### PR DESCRIPTION
https://github.com/MostroP2P/mostrix/issues/70 was still an issue for me. This fixes it for me on X11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying on Linux and other supported platforms.
  * Clipboard content now remains available reliably until another application replaces it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->