### PR TITLE
feat(release): build macOS binaries for Apple Silicon and Intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+# CI only reads the repo; no job needs write access to anything.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -70,8 +74,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+      # Pinned to the rust-toolchain.toml channel on purpose: that file overrides
+      # `rustup default`, so a target installed into `stable` would be invisible to
+      # the toolchain cargo actually resolves (E0463: can't find crate for `core`).
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.97.0
           targets: x86_64-apple-darwin
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,24 @@ jobs:
       - name: cargo test
         run: cargo test --all-features
 
+  macos:
+    name: build & test (macos)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with: { cache-on-failure: true }
+      - name: cargo build (host, aarch64-apple-darwin)
+        run: cargo build --all-features
+      - name: cargo test
+        run: cargo test --all-features
+      - name: cargo build (x86_64-apple-darwin)
+        run: cargo build --all-features --target x86_64-apple-darwin
+
   msrv:
     name: MSRV build (1.97.0)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Windows MSVC must build on windows-latest (native); other targets use cross on Ubuntu.
+          # Windows MSVC must build on windows-latest (native); Apple targets must build on
+          # macos-latest (the Apple SDK cannot be redistributed in a cross image, and it ships
+          # both arm64 and x86_64 slices, so one runner covers both Darwin triples).
+          # Everything else uses cross on Ubuntu.
           # windows-gnu via cross is avoided: MinGW ld in the cross image rejects LLVM
           # -exclude-symbols .drectve directives from modern Rust (link failure).
           targets=$(
@@ -76,6 +79,9 @@ jobs:
                   echo "Unsupported Windows target in archs (use x86_64-pc-windows-msvc): $t" >&2
                   exit 1
                   ;;
+                *-apple-darwin)
+                  jq -nc --arg t "$t" '{target:$t,os:"macos-latest",use_cross:false}'
+                  ;;
                 *)
                   jq -nc --arg t "$t" '{target:$t,os:"ubuntu-latest",use_cross:true}'
                   ;;
@@ -84,7 +90,7 @@ jobs:
           )
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
 
-  # Build binaries for all targets (cross on Linux, native cargo on Windows MSVC)
+  # Build binaries for all targets (cross on Linux, native cargo on Windows MSVC and macOS)
   build:
     needs: matrix
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags: ['v*.*.*']          # run only when a tag like v1.2.3 is pushed
   workflow_dispatch:
 
+# Default to read-only; the `release` job opts into `contents: write` to publish.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,6 +2,8 @@
 # https://github.com/cross-rs/cross/wiki/Configuration
 #
 # No custom image overrides: mostrix uses rustls (sqlx + reqwest), so we do not
-# need OpenSSL. The default cross base images are sufficient for the non-Windows
-# targets in archs (Linux musl, FreeBSD). Windows releases use
-# x86_64-pc-windows-msvc on windows-latest (see .github/workflows/release.yml).
+# need OpenSSL. The default cross base images are sufficient for the cross-built
+# targets in archs (Linux musl, FreeBSD). Windows and macOS releases are built
+# natively instead: x86_64-pc-windows-msvc on windows-latest, and
+# {aarch64,x86_64}-apple-darwin on macos-latest, because the Apple SDK cannot be
+# redistributed in a cross image (see .github/workflows/release.yml).

--- a/archs
+++ b/archs
@@ -3,3 +3,5 @@ aarch64-unknown-linux-musl
 armv7-unknown-linux-gnueabi
 x86_64-pc-windows-msvc
 x86_64-unknown-freebsd
+aarch64-apple-darwin
+x86_64-apple-darwin


### PR DESCRIPTION
## Summary

Mostrix releases currently ship binaries for Linux (musl x86_64/aarch64, armv7 gnueabi), Windows MSVC and FreeBSD — but nothing for macOS, so Mac users have to build from source. This adds macOS to the release matrix.

Two triples are added rather than one, because they cover disjoint sets of Macs and both build on the same runner at no extra configuration cost:

- `aarch64-apple-darwin` — Apple Silicon (M1 and later)
- `x86_64-apple-darwin` — Intel Macs

## Changes

- **`archs`**: added `aarch64-apple-darwin` and `x86_64-apple-darwin`.
- **`.github/workflows/release.yml`**: the `matrix` job now routes `*-apple-darwin` to `macos-latest` with `use_cross: false`. macOS cannot be built through `cross` from the Ubuntu runner — the Apple SDK is not redistributable in a cross image. The `macos-latest` SDK ships both arm64 and x86_64 slices, so one runner builds both triples natively via `cargo build --target`.
- **`.github/workflows/ci.yml`**: new `macos` job (mirrors the existing `windows` job) that builds and tests on the host arm64 target and also builds `x86_64-apple-darwin`. This surfaces a Darwin compile break on PRs instead of at tag time, when the release job would fail.
- **`Cross.toml`**: updated the comment describing which targets are cross-built vs. built natively.

No change was needed to artifact naming, checksums or the release step: Darwin targets fall into the generic non-Windows branch, producing `mostrix-aarch64-apple-darwin` and `mostrix-x86_64-apple-darwin`, which the existing `artifact-*/mostrix*` glob and `manifest.txt` generation already pick up.

## Notes

The binaries are unsigned and un-notarized, so first launch on macOS requires the usual Gatekeeper override (right-click → Open, or `xattr -d com.apple.quarantine ./mostrix`). Signing/notarization needs an Apple Developer certificate in repo secrets and is deliberately out of scope here.

## Test plan

- [x] Reproduced the `matrix` job's target→runner routing locally against the updated `archs`; all 7 targets resolve as expected (5 cross on ubuntu-latest, 1 native on windows-latest, 2 native on macos-latest).
- [x] Both workflow files parse as valid YAML.
- [ ] CI `build & test (macos)` job passes on this PR — this is the real verification that the code compiles and tests pass on Darwin (the crate already has `target_os = "macos"` branches in `src/ui/constants.rs`, but it has never been built in CI).
- [ ] After merge, confirm the next tagged release publishes `mostrix-aarch64-apple-darwin` and `mostrix-x86_64-apple-darwin` with entries in `manifest.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building releases for Apple macOS on both Intel and Apple Silicon architectures.

* **CI/CD**
  * Added macOS build and test coverage.
  * Updated release builds to use native macOS runners for Apple targets.
  * Expanded documented release architecture coverage for macOS, Windows, Linux, and FreeBSD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->