### PR TITLE
fix(security): prevent cross-order DM upsert clobber and trade-key swap

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -388,7 +388,6 @@ impl Order {
         existing: Option<&Order>,
         message_request_id: Option<i64>,
     ) -> Order {
-        let trade_keys_hex = trade_keys.secret_key().to_secret_hex();
         let (counterparty_pubkey, order_chat_shared_key_hex) =
             match crate::util::chat_utils::order_chat_counterparty_and_shared_hex(
                 trade_keys,
@@ -412,7 +411,9 @@ impl Order {
             fiat_amount: small_order.fiat_amount,
             payment_method: small_order.payment_method.clone(),
             premium: small_order.premium,
-            trade_keys: Some(trade_keys_hex),
+            // Security invariant: trade_keys ownership is bound to the persisted order row.
+            // DM hydration must never rotate/swap it from the decrypting trade context.
+            trade_keys: existing.and_then(|e| e.trade_keys.clone()),
             counterparty_pubkey,
             order_chat_shared_key_hex,
             dispute_id: existing.and_then(|e| e.dispute_id.clone()),
@@ -445,7 +446,16 @@ impl Order {
         trade_keys: &nostr_sdk::prelude::Keys,
         message_request_id: Option<i64>,
     ) -> Result<Self> {
-        let resolved_id = small_order.id.unwrap_or(order_id_fallback);
+        if let Some(payload_id) = small_order.id {
+            if payload_id != order_id_fallback {
+                anyhow::bail!(
+                    "Rejected DM order upsert: payload id {} does not match routed order id {}",
+                    payload_id,
+                    order_id_fallback
+                );
+            }
+        }
+        let resolved_id = order_id_fallback;
         small_order.id = Some(resolved_id);
         let id_str = resolved_id.to_string();
 
@@ -1107,6 +1117,131 @@ mod terminal_dm_status_tests {
         assert_eq!(
             expected, actual,
             "TERMINAL_DM_STATUSES must match mostro_core::order::Status::to_string()"
+        );
+    }
+}
+
+#[cfg(test)]
+mod upsert_from_small_order_dm_tests {
+    use super::Order;
+    use mostro_core::prelude::{Kind, SmallOrder, Status};
+    use nostr_sdk::prelude::Keys;
+    use uuid::Uuid;
+
+    async fn create_test_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory database");
+        sqlx::query(
+            r#"
+            CREATE TABLE orders (
+                id TEXT PRIMARY KEY, kind TEXT, status TEXT, amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL, min_amount INTEGER, max_amount INTEGER,
+                fiat_amount INTEGER NOT NULL, payment_method TEXT NOT NULL,
+                premium INTEGER NOT NULL, trade_keys TEXT, counterparty_pubkey TEXT,
+                order_chat_shared_key_hex TEXT, dispute_id TEXT, solver_pubkey TEXT,
+                dispute_chat_shared_key_hex TEXT, is_mine INTEGER NOT NULL,
+                buyer_invoice TEXT, request_id INTEGER, trade_index INTEGER,
+                created_at INTEGER, expires_at INTEGER, last_seen_dm_ts INTEGER
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("orders table");
+        pool
+    }
+
+    fn sample_small_order(id: Uuid, amount: i64) -> SmallOrder {
+        SmallOrder {
+            id: Some(id),
+            kind: Some(Kind::Buy),
+            status: Some(Status::Active),
+            amount,
+            fiat_code: "USD".to_string(),
+            min_amount: None,
+            max_amount: None,
+            fiat_amount: 100,
+            payment_method: "bank".to_string(),
+            premium: 0,
+            buyer_trade_pubkey: None,
+            seller_trade_pubkey: None,
+            buyer_invoice: None,
+            created_at: None,
+            expires_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_payload_id_mismatch_against_routed_order_id() {
+        let pool = create_test_pool().await;
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let keys_b = Keys::generate();
+        sqlx::query(
+            "INSERT INTO orders (id, kind, status, amount, fiat_code, fiat_amount, payment_method, premium, trade_keys, is_mine, trade_index) VALUES (?, 'buy', 'active', 1000, 'USD', 10, 'bank', 0, ?, 1, 7)",
+        )
+        .bind(id_b.to_string())
+        .bind(keys_b.secret_key().to_secret_hex())
+        .execute(&pool)
+        .await
+        .expect("seed order b");
+
+        let err = Order::upsert_from_small_order_dm(
+            &pool,
+            id_a,
+            sample_small_order(id_b, 1),
+            &Keys::generate(),
+            Some(1),
+        )
+        .await
+        .expect_err("mismatched id must fail");
+        assert!(err
+            .to_string()
+            .contains("payload id"));
+
+        let untouched = Order::get_by_id(&pool, &id_b.to_string())
+            .await
+            .expect("order b still present");
+        assert_eq!(untouched.amount, 1000);
+        assert_eq!(
+            untouched.trade_keys.as_deref(),
+            Some(keys_b.secret_key().to_secret_hex().as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_existing_trade_keys_on_dm_upsert() {
+        let pool = create_test_pool().await;
+        let id = Uuid::new_v4();
+        let stored_keys = Keys::generate();
+        let decrypting_keys = Keys::generate();
+        sqlx::query(
+            "INSERT INTO orders (id, kind, status, amount, fiat_code, fiat_amount, payment_method, premium, trade_keys, is_mine, trade_index) VALUES (?, 'buy', 'active', 1000, 'USD', 10, 'bank', 0, ?, 1, 3)",
+        )
+        .bind(id.to_string())
+        .bind(stored_keys.secret_key().to_secret_hex())
+        .execute(&pool)
+        .await
+        .expect("seed order");
+
+        Order::upsert_from_small_order_dm(
+            &pool,
+            id,
+            sample_small_order(id, 777),
+            &decrypting_keys,
+            Some(2),
+        )
+        .await
+        .expect("upsert succeeds");
+
+        let updated = Order::get_by_id(&pool, &id.to_string())
+            .await
+            .expect("updated order");
+        assert_eq!(updated.amount, 777);
+        assert_eq!(
+            updated.trade_keys.as_deref(),
+            Some(stored_keys.secret_key().to_secret_hex().as_str())
         );
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1196,9 +1196,7 @@ mod upsert_from_small_order_dm_tests {
         )
         .await
         .expect_err("mismatched id must fail");
-        assert!(err
-            .to_string()
-            .contains("payload id"));
+        assert!(err.to_string().contains("payload id"));
 
         let untouched = Order::get_by_id(&pool, &id_b.to_string())
             .await

--- a/src/util/dm_utils/mod.rs
+++ b/src/util/dm_utils/mod.rs
@@ -1027,10 +1027,7 @@ async fn handle_trade_dm_for_order(
     };
 
     if let Some(candidate) = status_candidate {
-        let oid = small_order_ref_from_payload(&inner_kind.payload)
-            .and_then(|o| o.id)
-            .or(inner_kind.id)
-            .unwrap_or(order_id);
+        let oid = order_id;
         if should_accept_candidate {
             if baseline_status != Some(candidate) {
                 if let Err(e) = update_order_status(pool, &oid.to_string(), candidate).await {
@@ -2132,6 +2129,87 @@ mod tests {
         );
         assert_eq!(*pending_notifications.lock().expect("pending lock"), 1);
         assert!(notification_rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn payload_id_mismatch_cannot_redirect_status_update() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory database");
+        sqlx::query(
+            r#"
+            CREATE TABLE orders (
+                id TEXT PRIMARY KEY, kind TEXT, status TEXT, amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL, min_amount INTEGER, max_amount INTEGER,
+                fiat_amount INTEGER NOT NULL, payment_method TEXT NOT NULL,
+                premium INTEGER NOT NULL, trade_keys TEXT, counterparty_pubkey TEXT,
+                order_chat_shared_key_hex TEXT, dispute_id TEXT, solver_pubkey TEXT,
+                dispute_chat_shared_key_hex TEXT, is_mine INTEGER NOT NULL,
+                buyer_invoice TEXT, request_id INTEGER, trade_index INTEGER,
+                created_at INTEGER, expires_at INTEGER, last_seen_dm_ts INTEGER
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("orders table");
+
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO orders (id, kind, status, amount, fiat_code, fiat_amount, payment_method, premium, is_mine) VALUES (?, 'buy', 'active', 1000, 'USD', 10, 'bank', 0, 1)",
+        )
+        .bind(id_a.to_string())
+        .execute(&pool)
+        .await
+        .expect("order a");
+        sqlx::query(
+            "INSERT INTO orders (id, kind, status, amount, fiat_code, fiat_amount, payment_method, premium, is_mine) VALUES (?, 'buy', 'active', 1000, 'USD', 10, 'bank', 0, 1)",
+        )
+        .bind(id_b.to_string())
+        .execute(&pool)
+        .await
+        .expect("order b");
+
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let pending_notifications = Arc::new(Mutex::new(0));
+        let (notification_tx, _notification_rx) = tokio::sync::mpsc::unbounded_channel();
+        let trade_keys = Keys::generate();
+        let message = Message::new_order(
+            Some(id_a),
+            None,
+            Some(8),
+            Action::Released,
+            Some(Payload::Order(SmallOrder {
+                id: Some(id_b),
+                status: Some(Status::Success),
+                ..Default::default()
+            })),
+        );
+
+        handle_trade_dm_for_order(
+            &messages,
+            &pending_notifications,
+            &notification_tx,
+            id_a,
+            8,
+            message,
+            100,
+            Keys::generate().public_key(),
+            &pool,
+            &trade_keys,
+            true,
+        )
+        .await;
+
+        let row_a = Order::get_by_id(&pool, &id_a.to_string())
+            .await
+            .expect("order a present");
+        let row_b = Order::get_by_id(&pool, &id_b.to_string())
+            .await
+            .expect("order b present");
+        assert_eq!(row_a.status.as_deref(), Some("success"));
+        assert_eq!(row_b.status.as_deref(), Some("active"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bind trade DM persistence to the subscription-routed order id: reject `upsert_from_small_order_dm` when payload `SmallOrder.id` differs from the routed order.
- Preserve stored `trade_keys` on DM hydration instead of rewriting them from the decrypting trade context.
- Apply DM-driven status updates only to the routed order row (not payload-derived ids).

Fixes cross-order row clobber / trade-key swap reported as MOSTRO-038: a forged DM on trade A could overwrite order B's SQLite row, including swapping B's trade secret for A's key material.

## Security impact

- **Before:** attacker with DM delivery to one trade channel could clobber unrelated existing order rows (public orderbook UUIDs), corrupt key material, and mis-target terminal status writes.
- **After:** mismatched payload ids are rejected; trade keys are not rotated by DM upsert; status writes stay on the routed order.

## Breaking changes

None for legitimate Mostro flows. Payload id missing still falls back to routed id; create/take paths still set keys via `save_order`.

## Test plan

- [x] `cargo test --all-features upsert_from_small_order_dm_tests`
- [x] `cargo test --all-features payload_id_mismatch_cannot_redirect_status_update`
- [ ] `cargo test --all-features` (full suite)
- [ ] Manual: take order → add invoice → pay invoice progression
- [ ] Manual: range child listing (`NewOrder` on trade DM listener)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented direct-message order updates from affecting a different order when payload and routed IDs don’t match.
  * Order updates now consistently target the routed order.
  * Rebuilding an order preserves its existing trade keys.
  * Added safeguards and regression coverage for mismatched IDs and trade-key preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->