### PR TITLE
feat(ui): rename K_conv to Shared key in Observer/My Trades and add clipboard copy

### DIFF
--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -100,21 +100,20 @@ See [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) for detailed finalization workf
 
 **Status**: ✅ **Implemented – Relay-based chat inspection**
 
-The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses the **Shared key only** (protocol `K_conv`; My Trades **Shift+K**) — never `K_sign`. The Shared key decrypts the conversation but cannot author a valid kind-14 envelope as `pub(K_sign)`, so Observer access is read-only by construction.
+The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses the **Shared key only** (protocol `K_conv`; My Trades **Shift+K**) — never the signing key. The Shared key decrypts the conversation but cannot author a valid kind-14 envelope as `pub(K_sign)`, so Observer access is read-only by construction.
 
 #### Observer Workflow
 
 1. **Acquire the Shared key**:
-   - During a dispute, one of the parties discloses the **Shared key** (64-character hex). In Mostrix this is **Shift+K** on My Trades, which also offers a **C** shortcut to copy the Shared key to the clipboard so it can be sent to the admin. They may also share **`pub(K_sign)`** as an optional locator for an `authors` filter. Never accept or ask for the `K_sign` secret.
+   - During a dispute, one of the parties discloses the **Shared key** (64-character hex). In Mostrix this is **Shift+K** on My Trades, which also offers a **C** shortcut to copy the Shared key to the clipboard so it can be sent to the admin. Never accept or ask for the signing key.
 2. **Open Observer tab**:
    - Switch to Admin mode and navigate to the **Observer** tab.
-3. **Paste keys**:
-   - In the **Shared key** field, paste the 64-char hex grant. Optionally paste **`pub(K_sign)`** (hex or npub) in the second field. **Tab** switches focus. Paste supports bracketed paste into the focused field.
+3. **Paste key**:
+   - In the **Shared key** field, paste the 64-char hex grant. Paste supports bracketed paste into the field. There is currently no input field for the Signer pubkey locator.
 4. **Fetch and view chat**:
    - Press **Enter** to:
      - Validate the Shared key (non-empty, valid hex secret).
-     - Parse optional `pub(K_sign)`; invalid locators fail closed.
-     - Fetch kind-14 events for the last 7 days: `authors = [pub(K_sign)]` when the locator is present, otherwise `#p = pub(K_conv)` (junk may arrive; decrypt fails).
+     - Fetch kind-14 events for the last 7 days: `#p = pub(K_conv)` (junk may arrive; decrypt fails). `fetch_observer_chat` always passes `sign_pubkey: None` since there is no UI field for it, so the `authors` filter is not used.
      - Unwrap with the Shared key against the known-role map (admin key plus buyer/seller trade pubkeys from taken disputes). Unknown inner signers are dropped.
      - Fetch fails if the known-role map is empty (no admin keys and no taken-dispute party pubkeys).
      - Parse attachments (Mostro Mobile Encrypted File Messaging format: `image_encrypted` / `file_encrypted`).
@@ -124,8 +123,7 @@ The Observer tab is a read-only tool that lets admins inspect encrypted user-to-
 
 #### Observer Keyboard Shortcuts
 
-- **Enter**: Fetch chat from relays using the Shared key (and optional `pub(K_sign)`).
-- **Tab / Shift+Tab**: Switch focus between the Shared key and `pub(K_sign)` fields.
+- **Enter**: Fetch chat from relays using the Shared key.
 - **Ctrl+C**: Clear inputs, messages, error state, and loading indicator. Sensitive data is securely cleared with `zeroize`.
 - **Ctrl+S**: Open save-attachment popup (when attachments are present in the fetched chat).
 - **Ctrl+H**: Open help popup with Observer shortcuts (Esc/Enter/Ctrl+H to close).
@@ -135,8 +133,6 @@ When validation or fetching fails (empty key, invalid hex, no messages found, de
 #### Observer State (AppState)
 
 - `observer_shared_key_input: String` -- disclosed Shared key (`K_conv`) hex.
-- `observer_sign_pubkey_input: String` -- optional `pub(K_sign)` locator.
-- `observer_input_focus` -- which field receives typing/paste.
 - `observer_messages: Vec<DisputeChatMessage>` -- fetched and decrypted chat messages.
 - `observer_loading: bool` -- indicates an async fetch is in progress.
 - `observer_error: Option<String>` -- inline error message.
@@ -148,7 +144,7 @@ When closing the **operation result** popup from the **Disputes in Progress** ta
 
 > **Note**: Observer fetches kind-14 messages using the disclosed Shared key and authenticates inner signers against taken-dispute party pubkeys plus the admin key (`fetch_observer_chat` / `observer_known_signer_roles`). GiftWrap cannot be unwrapped from the Shared key alone. Sensitive data is securely cleared from memory via `zeroize` when the admin clears the observer state with Ctrl+C.
 >
-> **Sharing the Shared key**: on My Trades, **Shift+K** opens a popup with the Shared key and the optional `pub(K_sign)` locator. Press **C** to copy the Shared key hex to the clipboard for pasting into a message to the admin — `pub(K_sign)` and the `K_sign` secret are never copied.
+> **Sharing the Shared key**: on My Trades, **Shift+K** opens a popup with the Shared key. Press **C** to copy the Shared key hex to the clipboard for pasting into a message to the admin — the signing key is never displayed or copied.
 
 **Source**: `src/ui/tabs/observer_tab.rs` (rendering), `src/ui/key_handler/enter_handlers.rs` (Enter handler), `src/util/chat_utils.rs` (`fetch_observer_chat`), `src/ui/key_handler/mod.rs` (Ctrl+S and observer save-attachment popup handling), `src/ui/save_attachment_popup.rs` (`render_observer_save_attachment_popup`)
 

--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -100,22 +100,22 @@ See [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md) for detailed finalization workf
 
 **Status**: ✅ **Implemented – Relay-based chat inspection**
 
-The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses **`K_conv` only** (My Trades **Shift+K**) — never `K_sign`. `K_conv` decrypts the conversation but cannot author a valid kind-14 envelope as `pub(K_sign)`, so Observer access is read-only by construction.
+The Observer tab is a read-only tool that lets admins inspect encrypted user-to-user chats by fetching kind-14 events from Nostr relays. A party involved in a dispute discloses the **Shared key only** (protocol `K_conv`; My Trades **Shift+K**) — never `K_sign`. The Shared key decrypts the conversation but cannot author a valid kind-14 envelope as `pub(K_sign)`, so Observer access is read-only by construction.
 
 #### Observer Workflow
 
-1. **Acquire `K_conv`**:
-   - During a dispute, one of the parties discloses **`K_conv`** (64-character hex). In Mostrix this is **Shift+K** on My Trades. They may also share **`pub(K_sign)`** as an optional locator for an `authors` filter. Never accept or ask for the `K_sign` secret.
+1. **Acquire the Shared key**:
+   - During a dispute, one of the parties discloses the **Shared key** (64-character hex). In Mostrix this is **Shift+K** on My Trades, which also offers a **C** shortcut to copy the Shared key to the clipboard so it can be sent to the admin. They may also share **`pub(K_sign)`** as an optional locator for an `authors` filter. Never accept or ask for the `K_sign` secret.
 2. **Open Observer tab**:
    - Switch to Admin mode and navigate to the **Observer** tab.
 3. **Paste keys**:
-   - In the **K_conv** field, paste the 64-char hex grant. Optionally paste **`pub(K_sign)`** (hex or npub) in the second field. **Tab** switches focus. Paste supports bracketed paste into the focused field.
+   - In the **Shared key** field, paste the 64-char hex grant. Optionally paste **`pub(K_sign)`** (hex or npub) in the second field. **Tab** switches focus. Paste supports bracketed paste into the focused field.
 4. **Fetch and view chat**:
    - Press **Enter** to:
-     - Validate `K_conv` (non-empty, valid hex secret).
+     - Validate the Shared key (non-empty, valid hex secret).
      - Parse optional `pub(K_sign)`; invalid locators fail closed.
      - Fetch kind-14 events for the last 7 days: `authors = [pub(K_sign)]` when the locator is present, otherwise `#p = pub(K_conv)` (junk may arrive; decrypt fails).
-     - Unwrap with `K_conv` against the known-role map (admin key plus buyer/seller trade pubkeys from taken disputes). Unknown inner signers are dropped.
+     - Unwrap with the Shared key against the known-role map (admin key plus buyer/seller trade pubkeys from taken disputes). Unknown inner signers are dropped.
      - Fetch fails if the known-role map is empty (no admin keys and no taken-dispute party pubkeys).
      - Parse attachments (Mostro Mobile Encrypted File Messaging format: `image_encrypted` / `file_encrypted`).
    - The chat is displayed using the same rich formatting as the dispute chat: color-coded sender labels (Cyan=Admin, Green=Buyer, Magenta=Seller), timestamps, and attachment indicators.
@@ -124,8 +124,8 @@ The Observer tab is a read-only tool that lets admins inspect encrypted user-to-
 
 #### Observer Keyboard Shortcuts
 
-- **Enter**: Fetch chat from relays using `K_conv` (and optional `pub(K_sign)`).
-- **Tab / Shift+Tab**: Switch focus between `K_conv` and `pub(K_sign)`.
+- **Enter**: Fetch chat from relays using the Shared key (and optional `pub(K_sign)`).
+- **Tab / Shift+Tab**: Switch focus between the Shared key and `pub(K_sign)` fields.
 - **Ctrl+C**: Clear inputs, messages, error state, and loading indicator. Sensitive data is securely cleared with `zeroize`.
 - **Ctrl+S**: Open save-attachment popup (when attachments are present in the fetched chat).
 - **Ctrl+H**: Open help popup with Observer shortcuts (Esc/Enter/Ctrl+H to close).
@@ -134,7 +134,7 @@ When validation or fetching fails (empty key, invalid hex, no messages found, de
 
 #### Observer State (AppState)
 
-- `observer_shared_key_input: String` -- disclosed `K_conv` hex.
+- `observer_shared_key_input: String` -- disclosed Shared key (`K_conv`) hex.
 - `observer_sign_pubkey_input: String` -- optional `pub(K_sign)` locator.
 - `observer_input_focus` -- which field receives typing/paste.
 - `observer_messages: Vec<DisputeChatMessage>` -- fetched and decrypted chat messages.
@@ -146,7 +146,9 @@ The fetch is performed asynchronously via `tokio::spawn` calling `chat_utils::fe
 
 When closing the **operation result** popup from the **Disputes in Progress** tab (e.g. after saving an attachment or after a finalization result), the app stays on Disputes in Progress and returns to **ManagingDispute** mode instead of switching to the first tab.
 
-> **Note**: Observer fetches kind-14 messages using disclosed `K_conv` and authenticates inner signers against taken-dispute party pubkeys plus the admin key (`fetch_observer_chat` / `observer_known_signer_roles`). GiftWrap cannot be unwrapped from `K_conv` alone. Sensitive data is securely cleared from memory via `zeroize` when the admin clears the observer state with Ctrl+C.
+> **Note**: Observer fetches kind-14 messages using the disclosed Shared key and authenticates inner signers against taken-dispute party pubkeys plus the admin key (`fetch_observer_chat` / `observer_known_signer_roles`). GiftWrap cannot be unwrapped from the Shared key alone. Sensitive data is securely cleared from memory via `zeroize` when the admin clears the observer state with Ctrl+C.
+>
+> **Sharing the Shared key**: on My Trades, **Shift+K** opens a popup with the Shared key and the optional `pub(K_sign)` locator. Press **C** to copy the Shared key hex to the clipboard for pasting into a message to the admin — `pub(K_sign)` and the `K_sign` secret are never copied.
 
 **Source**: `src/ui/tabs/observer_tab.rs` (rendering), `src/ui/key_handler/enter_handlers.rs` (Enter handler), `src/util/chat_utils.rs` (`fetch_observer_chat`), `src/ui/key_handler/mod.rs` (Ctrl+S and observer save-attachment popup handling), `src/ui/save_attachment_popup.rs` (`render_observer_save_attachment_popup`)
 

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -103,12 +103,12 @@ Focused on dispute resolution and protocol management.
   - Finalization popup for resolution actions
   - **Empty state**: When no disputes are available, displays helpful key hints footer (filter + `↑↓: Select Dispute | Ctrl+H: Help`); footer is width-aware (narrow terminals show only Ctrl+H).
 - **Observer**: Read-only workspace for inspecting user-to-user encrypted chats via a disclosed **Shared key** (protocol `K_conv`):
-  - **Shared key** input (64-char hex secret, paste-friendly) plus optional `pub(K_sign)` locator
-  - Fetches kind-14 chat events from relays for the last 7 days (`authors` when locator present, else `#p = pub(K_conv)`)
+  - **Shared key** input (64-char hex secret, paste-friendly). There is currently no UI field for the optional Signer pubkey (`pub(K_sign)`) locator, so `fetch_observer_chat` is always called with `sign_pubkey: None`.
+  - Fetches kind-14 chat events from relays for the last 7 days (`#p = pub(K_conv)`)
   - Decrypts messages and maps sender pubkeys to Buyer/Seller/Admin roles automatically
   - Displays chat using the same formatting as the dispute chat (color-coded, right-aligned Buyer/Seller, left-aligned Admin)
   - Supports file/image attachments with `Ctrl+S` to save (same popup as dispute chat)
-  - Keyboard hints: `Tab` switches Shared key / `pub(K_sign)`, `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
+  - Keyboard hints: `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
 - **Settings**: Role-specific configuration including:
   - Add Dispute Solver
   - Change Admin Key (set `admin_privkey` to the Mostro daemon nsec)
@@ -179,7 +179,7 @@ When the popup is closed (**Esc** or **Enter**) from the **Disputes in Progress*
 | `OrderChatAttachmentSent` | Appends **You** chat row + JSON transcript save; clears `pending_order_attachment_sends` and `sending_attachment_order_id` when `order_id` matches; then normalized to `Info` (`Attachment sent: …`) |
 | `OrderChatAttachmentError` | Early send failure (validate / encrypt / upload before DM); clears `sending_attachment_order_id` when `order_id` matches; normalized to `Error` popup. Generic `OperationResult::Error` from other tasks does **not** clear the in-flight send guard. |
 | `OrderChatAttachmentSendFailed` | Stores `PreparedOrderChatAttachment` in `AppState.pending_order_attachment_sends`; clears `sending_attachment_order_id` when `order_id` matches; normalized to `Error` (Blossom URL + **Ctrl+Shift+O** retry hint) |
-| `ConversationDisclosure` | My Trades **Shift+K** result: shows the disclosed Shared key (`K_conv`) and optional `pub(K_sign)` locator. Not normalized to `Info` — rendered as its own popup so **C** can safely copy only the Shared key hex to the clipboard (never `pub(K_sign)` or the `K_sign` secret) |
+| `ConversationDisclosure` | My Trades **Shift+K** result: shows the disclosed Shared key (`K_conv`). Not normalized to `Info` — rendered as its own popup so **C** can safely copy only the Shared key hex to the clipboard (never the signing key) |
 
 **`OperationResult::Info` / `Error` text**: `render_operation_result` splits on newlines, wraps at word boundaries (avoids mid-word breaks on long UUIDs), and sizes the popup from line count. Admin dispute **finalization success** uses a structured multi-line body from `BondSlashChoice::finalize_success_message` (see [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md)).
 
@@ -193,7 +193,7 @@ if let UiMode::OperationResult(result) = &app.mode {
 **Help popup (Ctrl+H)**:
 
 - **Open**: Press **Ctrl+H** in normal or managing-dispute mode to show a context-aware shortcuts overlay for the current tab (Disputes in Progress, Observer, Settings, Orders, etc.).
-- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Shift+K** (reveal Shared key for solvers), **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed). On **Observer**, Tab switches Shared key / `pub(K_sign)` (Left/Right still change tabs).
+- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Shift+K** (reveal Shared key for solvers), **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed). On **Observer**, it lists Enter to load chat, paste, scroll, clear, and save-attachment shortcuts (Left/Right still change tabs).
 - **Close**: **Esc**, **Enter**, or **Ctrl+H** close the popup; other keys are absorbed while it is open.
 - **Source**: `src/ui/help_popup.rs` (rendering), `src/ui/key_handler/mod.rs` (Ctrl+H and close handling).
 
@@ -259,7 +259,7 @@ The `handle_key_event` function dispatches keys based on the current `UiMode`.
 - **Paste support**: The event loop now centralizes paste routing for active inputs and supports:
   - `Event::Paste(...)` (bracketed paste)
   - mouse right-click paste (`MouseEventKind::Down(MouseButton::Right)`) using clipboard read fallback
-  This applies to invoice input, admin key/solver inputs, and Observer Shared key / `pub(K_sign)` fields.
+  This applies to invoice input, admin key/solver inputs, and the Observer Shared key field.
 - **Admin Chat**: `handle_admin_chat_input` handles direct text input in the "Disputes in Progress" tab:
   - Takes priority over other input handling (except invoice and key input)
   - Supports direct character input and backspace
@@ -267,7 +267,7 @@ The `handle_key_event` function dispatches keys based on the current `UiMode`.
   - Text wrapping with word boundary detection
   - **Input toggle**: Press **Shift+I** to enable/disable chat input (prevents accidental typing)
   - **Visual feedback**: Input title shows enabled/disabled state
-- **Copy to Clipboard**: Pressing `C` in a `PayInvoice` or `PayBondInvoice` notification, or in the My Trades **Shift+K** Shared key disclosure popup, uses the `arboard` crate (`handle_clipboard_copy` in `src/ui/key_handler/mod.rs`) to copy the invoice or the Shared key hex respectively. Only the Shared key is copyable from the disclosure popup — `pub(K_sign)` and the `K_sign` secret are never copied. On Linux, it uses the `SetExtLinux::wait()` method to properly wait until the clipboard is overwritten, ensuring reliable clipboard handling without arbitrary delays.
+- **Copy to Clipboard**: Pressing `C` in a `PayInvoice` or `PayBondInvoice` notification, or in the My Trades **Shift+K** Shared key disclosure popup, uses the `arboard` crate (`handle_clipboard_copy` in `src/ui/key_handler/mod.rs`) to copy the invoice or the Shared key hex respectively. Only the Shared key is copyable from the disclosure popup — the signing key is never copied (and never displayed). The write runs synchronously and reports the real result: `copied_to_clipboard` (and the "✓ ... copied!" confirmation) is only set once `arboard::Clipboard::new()` and `set_text()` actually succeed; a failed write leaves the popup showing "Press C to copy" instead of a false success message. Persistence beyond that call is handled by the platform backend without blocking on it — the shared clipboard worker thread `arboard` starts on X11, or the background process `wl-clipboard-rs` detaches on Wayland.
 - **Exit Confirmation**: Pressing `Q` or selecting the Exit tab shows a confirmation popup before exiting the application. Use Left/Right to select Yes/No, Enter to confirm, or Esc to cancel.
 - **Help popup**: Press **Ctrl+H** (in normal or managing-dispute mode) to open a centered overlay with all keyboard shortcuts for the current tab. Press Esc, Enter, or Ctrl+H to close.
 
@@ -396,7 +396,7 @@ The My Trades workspace (`src/ui/tabs/order_in_progress_tab.rs`) now shows riche
   - **Shift+F** mark fiat sent (YES/NO popup).
   - **Shift+R** release sats (YES/NO popup).
   - **Shift+V** rate counterparty (opens 1–5 star rating picker).
-  - **Shift+K** reveal Shared key (read-only grant for solvers; never the `K_sign` secret). Opens a popup where **C** copies the Shared key to the clipboard.
+  - **Shift+K** reveal Shared key (read-only grant for solvers; never the signing key). Opens a popup where **C** copies the Shared key to the clipboard.
   - **PgUp/PgDn** scroll chat history; **End** jump to bottom.
   - **Ctrl+S** save attachment (when the selected order has attachments).
   - **Ctrl+O** send attachment (file picker); **Ctrl+Shift+O** retry DM when a prepared send is pending.

--- a/docs/TUI_INTERFACE.md
+++ b/docs/TUI_INTERFACE.md
@@ -102,13 +102,13 @@ Focused on dispute resolution and protocol management.
   - **Scrollable sidebar list** (`List` + `ListState`): ↑↓ keeps the selected dispute in view when many disputes overflow the sidebar; scrollbar when the list is taller than the panel
   - Finalization popup for resolution actions
   - **Empty state**: When no disputes are available, displays helpful key hints footer (filter + `↑↓: Select Dispute | Ctrl+H: Help`); footer is width-aware (narrow terminals show only Ctrl+H).
-- **Observer**: Read-only workspace for inspecting user-to-user encrypted chats via disclosed **`K_conv`**:
-  - `K_conv` input (64-char hex secret, paste-friendly) plus optional `pub(K_sign)` locator
+- **Observer**: Read-only workspace for inspecting user-to-user encrypted chats via a disclosed **Shared key** (protocol `K_conv`):
+  - **Shared key** input (64-char hex secret, paste-friendly) plus optional `pub(K_sign)` locator
   - Fetches kind-14 chat events from relays for the last 7 days (`authors` when locator present, else `#p = pub(K_conv)`)
   - Decrypts messages and maps sender pubkeys to Buyer/Seller/Admin roles automatically
   - Displays chat using the same formatting as the dispute chat (color-coded, right-aligned Buyer/Seller, left-aligned Admin)
   - Supports file/image attachments with `Ctrl+S` to save (same popup as dispute chat)
-  - Keyboard hints: `Tab` switches `K_conv` / `pub(K_sign)`, `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
+  - Keyboard hints: `Tab` switches Shared key / `pub(K_sign)`, `Enter` to fetch chat, `Ctrl+C` to clear all, `Ctrl+S` to save attachment, `Ctrl+H` for help
 - **Settings**: Role-specific configuration including:
   - Add Dispute Solver
   - Change Admin Key (set `admin_privkey` to the Mostro daemon nsec)
@@ -154,7 +154,7 @@ The primary shared popup is the **operation result** modal, used for:
 - Order creation / take-order flows
 - Settings validation errors (invalid pubkey, relay, currency, Lightning address format, LNURL verification failure, etc.)
 - Admin actions (add solver, finalize disputes)
-- Blossom attachment downloads and Observer-mode `K_conv` errors
+- Blossom attachment downloads and Observer-mode Shared key errors
 
 When the popup is closed (**Esc** or **Enter**) from the **Disputes in Progress** tab, the app stays on that tab and returns to **ManagingDispute** mode (it does not switch to the first tab).
 
@@ -179,6 +179,7 @@ When the popup is closed (**Esc** or **Enter**) from the **Disputes in Progress*
 | `OrderChatAttachmentSent` | Appends **You** chat row + JSON transcript save; clears `pending_order_attachment_sends` and `sending_attachment_order_id` when `order_id` matches; then normalized to `Info` (`Attachment sent: …`) |
 | `OrderChatAttachmentError` | Early send failure (validate / encrypt / upload before DM); clears `sending_attachment_order_id` when `order_id` matches; normalized to `Error` popup. Generic `OperationResult::Error` from other tasks does **not** clear the in-flight send guard. |
 | `OrderChatAttachmentSendFailed` | Stores `PreparedOrderChatAttachment` in `AppState.pending_order_attachment_sends`; clears `sending_attachment_order_id` when `order_id` matches; normalized to `Error` (Blossom URL + **Ctrl+Shift+O** retry hint) |
+| `ConversationDisclosure` | My Trades **Shift+K** result: shows the disclosed Shared key (`K_conv`) and optional `pub(K_sign)` locator. Not normalized to `Info` — rendered as its own popup so **C** can safely copy only the Shared key hex to the clipboard (never `pub(K_sign)` or the `K_sign` secret) |
 
 **`OperationResult::Info` / `Error` text**: `render_operation_result` splits on newlines, wraps at word boundaries (avoids mid-word breaks on long UUIDs), and sizes the popup from line count. Admin dispute **finalization success** uses a structured multi-line body from `BondSlashChoice::finalize_success_message` (see [FINALIZE_DISPUTES.md](FINALIZE_DISPUTES.md)).
 
@@ -192,7 +193,7 @@ if let UiMode::OperationResult(result) = &app.mode {
 **Help popup (Ctrl+H)**:
 
 - **Open**: Press **Ctrl+H** in normal or managing-dispute mode to show a context-aware shortcuts overlay for the current tab (Disputes in Progress, Observer, Settings, Orders, etc.).
-- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Shift+K** (reveal `K_conv` for solvers), **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed). On **Observer**, Tab switches `K_conv` / `pub(K_sign)` (Left/Right still change tabs).
+- **Content**: The popup lists all relevant key bindings for that tab; e.g. in Disputes in Progress it shows filter toggle, Tab/Enter/Shift+I/Shift+F, scroll keys, and Ctrl+S to open the save-attachment list when applicable. On **My Trades** it includes PgUp/PgDn/End chat scroll, **Shift+K** (reveal Shared key for solvers), **Ctrl+S** (save attachment list), **Ctrl+O** (send file picker), and **Ctrl+Shift+O** (retry DM after upload ok / send failed). On **Observer**, Tab switches Shared key / `pub(K_sign)` (Left/Right still change tabs).
 - **Close**: **Esc**, **Enter**, or **Ctrl+H** close the popup; other keys are absorbed while it is open.
 - **Source**: `src/ui/help_popup.rs` (rendering), `src/ui/key_handler/mod.rs` (Ctrl+H and close handling).
 
@@ -258,7 +259,7 @@ The `handle_key_event` function dispatches keys based on the current `UiMode`.
 - **Paste support**: The event loop now centralizes paste routing for active inputs and supports:
   - `Event::Paste(...)` (bracketed paste)
   - mouse right-click paste (`MouseEventKind::Down(MouseButton::Right)`) using clipboard read fallback
-  This applies to invoice input, admin key/solver inputs, and Observer `K_conv` / `pub(K_sign)` fields.
+  This applies to invoice input, admin key/solver inputs, and Observer Shared key / `pub(K_sign)` fields.
 - **Admin Chat**: `handle_admin_chat_input` handles direct text input in the "Disputes in Progress" tab:
   - Takes priority over other input handling (except invoice and key input)
   - Supports direct character input and backspace
@@ -266,7 +267,7 @@ The `handle_key_event` function dispatches keys based on the current `UiMode`.
   - Text wrapping with word boundary detection
   - **Input toggle**: Press **Shift+I** to enable/disable chat input (prevents accidental typing)
   - **Visual feedback**: Input title shows enabled/disabled state
-- **Copy to Clipboard**: Pressing `C` in a `PayInvoice` or `PayBondInvoice` notification uses the `arboard` crate to copy the invoice. On Linux, it uses the `SetExtLinux::wait()` method to properly wait until the clipboard is overwritten, ensuring reliable clipboard handling without arbitrary delays.
+- **Copy to Clipboard**: Pressing `C` in a `PayInvoice` or `PayBondInvoice` notification, or in the My Trades **Shift+K** Shared key disclosure popup, uses the `arboard` crate (`handle_clipboard_copy` in `src/ui/key_handler/mod.rs`) to copy the invoice or the Shared key hex respectively. Only the Shared key is copyable from the disclosure popup — `pub(K_sign)` and the `K_sign` secret are never copied. On Linux, it uses the `SetExtLinux::wait()` method to properly wait until the clipboard is overwritten, ensuring reliable clipboard handling without arbitrary delays.
 - **Exit Confirmation**: Pressing `Q` or selecting the Exit tab shows a confirmation popup before exiting the application. Use Left/Right to select Yes/No, Enter to confirm, or Esc to cancel.
 - **Help popup**: Press **Ctrl+H** (in normal or managing-dispute mode) to open a centered overlay with all keyboard shortcuts for the current tab. Press Esc, Enter, or Ctrl+H to close.
 
@@ -395,7 +396,7 @@ The My Trades workspace (`src/ui/tabs/order_in_progress_tab.rs`) now shows riche
   - **Shift+F** mark fiat sent (YES/NO popup).
   - **Shift+R** release sats (YES/NO popup).
   - **Shift+V** rate counterparty (opens 1–5 star rating picker).
-  - **Shift+K** reveal `K_conv` (read-only grant for solvers; never the `K_sign` secret).
+  - **Shift+K** reveal Shared key (read-only grant for solvers; never the `K_sign` secret). Opens a popup where **C** copies the Shared key to the clipboard.
   - **PgUp/PgDn** scroll chat history; **End** jump to bottom.
   - **Ctrl+S** save attachment (when the selected order has attachments).
   - **Ctrl+O** send attachment (file picker); **Ctrl+Shift+O** retry DM when a prepared send is pending.

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,10 +209,10 @@ fn apply_pasted_text_to_active_input(app: &mut AppState, pasted_text: &str) {
         }
     }
 
-    // Handle paste for the focused Observer field (`K_conv` or `pub(K_sign)`)
+    // Handle paste for the Observer Shared key field
     if app.observer_inputs_editable() {
         let filtered_text: String = pasted_text.chars().filter(|c| !c.is_control()).collect();
-        app.observer_active_input_mut().push_str(&filtered_text);
+        app.observer_shared_key_input.push_str(&filtered_text);
     }
 }
 

--- a/src/ui/app_state.rs
+++ b/src/ui/app_state.rs
@@ -24,23 +24,6 @@ use crate::ui::user_state::UserMode;
 use crate::util::{transport_from_instance, MostroInstanceInfo};
 use nostr_sdk::prelude::Keys;
 
-/// Which Observer input has keyboard / paste focus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ObserverInputField {
-    #[default]
-    ConvKey,
-    SignAuthor,
-}
-
-impl ObserverInputField {
-    pub fn toggle(self) -> Self {
-        match self {
-            Self::ConvKey => Self::SignAuthor,
-            Self::SignAuthor => Self::ConvKey,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum UiMode {
     // Shared modes (available to both user and admin)
@@ -254,10 +237,6 @@ pub struct AppState {
     pub sending_attachment_order_id: Option<String>,
     /// Observer mode: disclosed `K_conv` as 64-char hex (read-only grant).
     pub observer_shared_key_input: String,
-    /// Observer mode: optional `pub(K_sign)` locator (hex or npub) for `authors` filter.
-    pub observer_sign_pubkey_input: String,
-    /// Observer mode: which input receives typing and paste.
-    pub observer_input_focus: ObserverInputField,
     /// Observer mode: chat messages fetched from relays for the pasted `K_conv`.
     pub observer_messages: Vec<DisputeChatMessage>,
     /// Observer mode: scroll state for chat messages.
@@ -357,8 +336,6 @@ impl AppState {
             user_send_attachment_explorer: None,
             sending_attachment_order_id: None,
             observer_shared_key_input: String::new(),
-            observer_sign_pubkey_input: String::new(),
-            observer_input_focus: ObserverInputField::ConvKey,
             observer_messages: Vec::new(),
             observer_scrollview_state: tui_scrollview::ScrollViewState::default(),
             observer_scroll_tracker: None,
@@ -386,14 +363,7 @@ impl AppState {
         self.mostro_info = info;
     }
 
-    pub fn observer_active_input_mut(&mut self) -> &mut String {
-        match self.observer_input_focus {
-            ObserverInputField::ConvKey => &mut self.observer_shared_key_input,
-            ObserverInputField::SignAuthor => &mut self.observer_sign_pubkey_input,
-        }
-    }
-
-    /// True when Observer `K_conv` / `pub(K_sign)` fields should accept typing and paste.
+    /// True when the Observer Shared key field should accept typing and paste.
     ///
     /// False while a modal (`HelpPopup`, `OperationResult`, save-attachment, …) owns input.
     pub fn observer_inputs_editable(&self) -> bool {
@@ -428,9 +398,6 @@ impl AppState {
         self.bump_observer_fetch_generation();
         self.observer_shared_key_input.zeroize();
         self.observer_shared_key_input.clear();
-        self.observer_sign_pubkey_input.zeroize();
-        self.observer_sign_pubkey_input.clear();
-        self.observer_input_focus = ObserverInputField::ConvKey;
 
         for msg in &mut self.observer_messages {
             msg.content.zeroize();

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -39,7 +39,7 @@ pub const HELP_DP_ENTER_TAKE: &str = "Enter: Take selected dispute";
 pub const HELP_DP_SELECT_DISPUTE: &str = "↑↓: Select dispute";
 
 // Help popup lines (Observer)
-pub const HELP_OBS_ENTER_LOAD: &str = "Enter: Load chat for K_conv";
+pub const HELP_OBS_ENTER_LOAD: &str = "Enter: Load chat for Shared key";
 #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",
@@ -65,7 +65,7 @@ pub const HELP_OBS_SCROLL_PAGE: &str = "PgUp/PgDn: Scroll page";
 pub const HELP_OBS_ESC_CLEAR_ERR: &str = "Esc: Clear error";
 pub const HELP_OBS_CTRL_C_CLEAR: &str = "Ctrl+C: Clear all";
 pub const HELP_OBS_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment";
-pub const HELP_OBS_TAB_FOCUS: &str = "Tab: Switch K_conv / pub(K_sign) fields";
+pub const HELP_OBS_TAB_FOCUS: &str = "Tab: Switch Shared key / pub(K_sign) fields";
 
 // Help popup lines (Settings)
 pub const HELP_SETTINGS_SWITCH_FROM_MENU: &str =
@@ -100,7 +100,7 @@ pub const HELP_MY_TRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty (open 
 pub const HELP_MY_TRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Open a dispute (Dispute message)";
 pub const HELP_MY_TRADES_SHIFT_H_HELP: &str = "Shift+H: Show shortcuts help";
 pub const HELP_MY_TRADES_SHIFT_K_KCONV: &str =
-    "Shift+K: Reveal K_conv (read-only grant for solvers; never K_sign)";
+    "Shift+K: Reveal Shared key (read-only grant for solvers; never K_sign)";
 pub const HELP_MY_TRADES_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment (choose from list)";
 pub const HELP_MY_TRADES_CTRL_O_SEND: &str = "Ctrl+O: Send attachment (file picker)";
 pub const HELP_MY_TRADES_CTRL_SHIFT_O_RETRY: &str =
@@ -187,7 +187,7 @@ pub const FOOTER_MYTRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Dispute";
 pub const FOOTER_MYTRADES_SHIFT_F_FIAT_SENT: &str = "Shift+F: Mark fiat sent";
 pub const FOOTER_MYTRADES_SHIFT_R_RELEASE: &str = "Shift+R: Release sats";
 pub const FOOTER_MYTRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty";
-pub const FOOTER_MYTRADES_SHIFT_K_KCONV: &str = "Shift+K: Reveal K_conv";
+pub const FOOTER_MYTRADES_SHIFT_K_KCONV: &str = "Shift+K: Reveal Shared key";
 pub const FOOTER_MYTRADES_PGUP_PGDN_SCROLL_CHAT: &str = "PgUp/PgDn: Scroll chat";
 pub const FOOTER_MYTRADES_END_BOTTOM: &str = "End: Bottom";
 

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -46,11 +46,11 @@ pub const HELP_OBS_ENTER_LOAD: &str = "Enter: Load chat for Shared key";
     target_os = "openbsd",
     target_os = "netbsd"
 ))]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+Shift+V: Paste into focused field";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+Shift+V: Paste into Shared key field";
 #[cfg(target_os = "windows")]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into focused field";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into Shared key field";
 #[cfg(target_os = "macos")]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste into focused field";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste into Shared key field";
 #[cfg(not(any(
     target_os = "linux",
     target_os = "freebsd",
@@ -59,13 +59,12 @@ pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Cmd+V: Paste into focused field";
     target_os = "windows",
     target_os = "macos"
 )))]
-pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into focused field";
+pub const HELP_OBS_PASTE_SHARED_KEY: &str = "Ctrl+V: Paste into Shared key field";
 pub const HELP_OBS_SCROLL_LINE: &str = "↑↓: Scroll messages";
 pub const HELP_OBS_SCROLL_PAGE: &str = "PgUp/PgDn: Scroll page";
 pub const HELP_OBS_ESC_CLEAR_ERR: &str = "Esc: Clear error";
 pub const HELP_OBS_CTRL_C_CLEAR: &str = "Ctrl+C: Clear all";
 pub const HELP_OBS_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment";
-pub const HELP_OBS_TAB_FOCUS: &str = "Tab: Switch Shared key / pub(K_sign) fields";
 
 // Help popup lines (Settings)
 pub const HELP_SETTINGS_SWITCH_FROM_MENU: &str =
@@ -100,7 +99,7 @@ pub const HELP_MY_TRADES_SHIFT_V_RATE: &str = "Shift+V: Rate counterparty (open 
 pub const HELP_MY_TRADES_SHIFT_D_DISPUTE: &str = "Shift+D: Open a dispute (Dispute message)";
 pub const HELP_MY_TRADES_SHIFT_H_HELP: &str = "Shift+H: Show shortcuts help";
 pub const HELP_MY_TRADES_SHIFT_K_KCONV: &str =
-    "Shift+K: Reveal Shared key (read-only grant for solvers; never K_sign)";
+    "Shift+K: Reveal Shared key (read-only grant for solvers; never your signing key)";
 pub const HELP_MY_TRADES_CTRL_S_ATTACH: &str = "Ctrl+S: Save attachment (choose from list)";
 pub const HELP_MY_TRADES_CTRL_O_SEND: &str = "Ctrl+O: Send attachment (file picker)";
 pub const HELP_MY_TRADES_CTRL_SHIFT_O_RETRY: &str =

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -369,7 +369,6 @@ fn help_content(app: &AppState, tab: Tab) -> (String, Vec<String>) {
             HELP_TITLE_OBSERVER.to_string(),
             vec![
                 HELP_OBS_ENTER_LOAD.to_string(),
-                HELP_OBS_TAB_FOCUS.to_string(),
                 HELP_OBS_PASTE_SHARED_KEY.to_string(),
                 HELP_OBS_SCROLL_LINE.to_string(),
                 HELP_OBS_SCROLL_PAGE.to_string(),
@@ -481,7 +480,7 @@ mod help_content_tests {
     }
 
     #[test]
-    fn observer_help_lists_shared_key_load_and_tab_focus() {
+    fn observer_help_lists_shared_key_load() {
         let app = AppState::new(UserRole::Admin);
         let (_, lines) = help_content(&app, Tab::Admin(AdminTab::Observer));
         assert!(
@@ -489,8 +488,8 @@ mod help_content_tests {
             "Shared key load missing from Observer help: {lines:?}"
         );
         assert!(
-            lines.iter().any(|l| l == HELP_OBS_TAB_FOCUS),
-            "Tab focus missing from Observer help: {lines:?}"
+            !lines.iter().any(|l| l.contains("Tab: Switch")),
+            "Tab focus shortcut should be removed from Observer help now that only one field exists: {lines:?}"
         );
     }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -481,12 +481,12 @@ mod help_content_tests {
     }
 
     #[test]
-    fn observer_help_lists_k_conv_load_and_tab_focus() {
+    fn observer_help_lists_shared_key_load_and_tab_focus() {
         let app = AppState::new(UserRole::Admin);
         let (_, lines) = help_content(&app, Tab::Admin(AdminTab::Observer));
         assert!(
             lines.iter().any(|l| l == HELP_OBS_ENTER_LOAD),
-            "K_conv load missing from Observer help: {lines:?}"
+            "Shared key load missing from Observer help: {lines:?}"
         );
         assert!(
             lines.iter().any(|l| l == HELP_OBS_TAB_FOCUS),

--- a/src/ui/helpers/chat_render.rs
+++ b/src/ui/helpers/chat_render.rs
@@ -188,7 +188,7 @@ pub fn build_observer_scrollview_content(
 
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
-            "No messages yet. Paste K_conv and press Enter to load.",
+            "No messages yet. Paste Shared key and press Enter to load.",
             Style::default().fg(Color::Gray),
         )));
     }
@@ -206,8 +206,11 @@ pub fn build_observer_scrollview_content(
 mod tests {
     use super::build_observer_scrollview_content;
 
+    /// The UI label for the disclosed `K_conv` secret is "Shared key" (never
+    /// confused with the persisted ECDH `order_chat_shared_key_hex`, which is
+    /// not shown to users at all).
     #[test]
-    fn observer_empty_hint_asks_for_k_conv_not_ecdh_shared_key() {
+    fn observer_empty_hint_asks_for_shared_key() {
         let content = build_observer_scrollview_content(&[], 40, Some(20));
         let flat: String = content
             .lines
@@ -220,12 +223,8 @@ mod tests {
             })
             .collect();
         assert!(
-            flat.contains("K_conv"),
-            "empty Observer hint must mention K_conv: {flat}"
-        );
-        assert!(
-            !flat.to_lowercase().contains("shared key"),
-            "empty Observer hint must not say shared key: {flat}"
+            flat.contains("Shared key"),
+            "empty Observer hint must mention Shared key: {flat}"
         );
     }
 }

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1225,17 +1225,9 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             return;
         }
 
-        let sign_pubkey = match crate::util::chat_utils::parse_optional_sign_pubkey(
-            &app.observer_sign_pubkey_input,
-        ) {
-            Ok(pk) => pk,
-            Err(e) => {
-                let msg = e.to_string();
-                app.observer_error = Some(msg.clone());
-                app.mode = UiMode::operation_result(OperationResult::Error(msg));
-                return;
-            }
-        };
+        // No UI field feeds an optional Signer pubkey locator at the moment, so the
+        // `authors` filter in `fetch_observer_chat` stays unrestricted.
+        let sign_pubkey = None;
 
         // Spawn async fetch via the order_result channel
         let generation = app.begin_observer_fetch();

--- a/src/ui/key_handler/enter_handlers.rs
+++ b/src/ui/key_handler/enter_handlers.rs
@@ -1208,18 +1208,18 @@ fn handle_enter_normal_mode(app: &mut AppState, ctx: &super::EnterKeyContext<'_>
             }
         }
     } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-        // Validate K_conv, then fetch observer chat authenticated against
-        // known admin/party inner signers from taken disputes.
+        // Validate the Shared key (K_conv), then fetch observer chat authenticated
+        // against known admin/party inner signers from taken disputes.
         let key_str = app.observer_shared_key_input.trim().to_string();
         if key_str.is_empty() {
-            let msg = "K_conv is required".to_string();
+            let msg = "Shared key is required".to_string();
             app.observer_error = Some(msg.clone());
             app.mode = UiMode::operation_result(OperationResult::Error(msg));
             return;
         }
 
         if crate::util::chat_utils::keys_from_shared_hex(&key_str).is_none() {
-            let msg = "K_conv must be a valid 64-char hex secret (32 bytes)".to_string();
+            let msg = "Shared key must be a valid 64-char hex secret (32 bytes)".to_string();
             app.observer_error = Some(msg.clone());
             app.mode = UiMode::operation_result(OperationResult::Error(msg));
             return;

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -314,51 +314,115 @@ fn copy_disclosed_shared_key_if_open_with(
     false
 }
 
-/// Handle clipboard copy for text (invoice, Shared key, etc.)
-///
-/// Runs synchronously and returns whether the write actually succeeded —
-/// `copied_to_clipboard` at the call site should only be set to `true` when
-/// this returns `true`, not merely because a copy attempt was made.
-fn handle_clipboard_copy(text: String) -> bool {
-    // Some clipboard backends (e.g. on Linux) can emit warnings to stderr;
-    // silence stderr during the call to avoid corrupting the TUI.
-    #[cfg(unix)]
-    {
-        use std::os::unix::io::AsRawFd;
-        let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
-        let devnull = std::fs::File::open("/dev/null");
-        if saved_stderr >= 0 {
-            if let Ok(devnull) = devnull {
-                unsafe {
-                    let _ = libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO);
-                }
-            }
-        }
+/// Silence stderr while running a clipboard operation so backend warnings do
+/// not corrupt the TUI.
+#[cfg(unix)]
+fn with_stderr_silenced<T>(operation: impl FnOnce() -> T) -> T {
+    use std::os::unix::io::AsRawFd;
 
-        let result = arboard::Clipboard::new().and_then(|mut c| c.set_text(text));
-
-        if saved_stderr >= 0 {
+    let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+    if saved_stderr >= 0 {
+        if let Ok(devnull) = std::fs::File::open("/dev/null") {
             unsafe {
-                let _ = libc::dup2(saved_stderr, libc::STDERR_FILENO);
-                let _ = libc::close(saved_stderr);
-            }
-        }
-
-        match result {
-            Ok(_) => {
-                log::info!("Copied to clipboard");
-                true
-            }
-            Err(e) => {
-                log::warn!("Failed to copy to clipboard: {}", e);
-                false
+                let _ = libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO);
             }
         }
     }
 
-    #[cfg(not(unix))]
+    let result = operation();
+
+    if saved_stderr >= 0 {
+        unsafe {
+            let _ = libc::dup2(saved_stderr, libc::STDERR_FILENO);
+            let _ = libc::close(saved_stderr);
+        }
+    }
+
+    result
+}
+
+/// Linux/X11/Wayland clipboard ownership is held by the process that wrote the
+/// selection; drop the `Clipboard` and the paste target may see empty data. Run
+/// the initial write on a background thread, report its result to the caller,
+/// then keep that thread alive with `SetExtLinux::wait` until another app
+/// replaces the selection (same pattern as the pre-#134 invoice copy path).
+#[cfg(target_os = "linux")]
+fn linux_clipboard_copy_worker(text: String, result_tx: std::sync::mpsc::Sender<bool>) {
+    use arboard::SetExtLinux;
+
+    let copy_result = {
+        #[cfg(unix)]
+        {
+            with_stderr_silenced(|| match arboard::Clipboard::new() {
+                Ok(mut clipboard) => {
+                    let write_result = clipboard.set().text(text.clone());
+                    let _ = result_tx.send(write_result.is_ok());
+                    if write_result.is_ok() {
+                        let _ = clipboard.set().wait().text(text);
+                    }
+                    write_result
+                }
+                Err(e) => {
+                    let _ = result_tx.send(false);
+                    Err(e)
+                }
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            match arboard::Clipboard::new() {
+                Ok(mut clipboard) => {
+                    let write_result = clipboard.set().text(text.clone());
+                    let _ = result_tx.send(write_result.is_ok());
+                    if write_result.is_ok() {
+                        let _ = clipboard.set().wait().text(text);
+                    }
+                    write_result
+                }
+                Err(e) => {
+                    let _ = result_tx.send(false);
+                    Err(e)
+                }
+            }
+        }
+    };
+
+    match copy_result {
+        Ok(_) => log::info!("Copied to clipboard"),
+        Err(e) => log::warn!("Failed to copy to clipboard: {}", e),
+    }
+}
+
+/// Handle clipboard copy for text (invoice, Shared key, etc.)
+///
+/// Returns whether the write actually succeeded — `copied_to_clipboard` at the
+/// call site should only be set to `true` when this returns `true`, not merely
+/// because a copy attempt was made. On Linux the write runs on a background
+/// thread that keeps serving the selection after the result is reported.
+fn handle_clipboard_copy(text: String) -> bool {
+    #[cfg(target_os = "linux")]
     {
-        match arboard::Clipboard::new().and_then(|mut c| c.set_text(text)) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || linux_clipboard_copy_worker(text, tx));
+        rx.recv().unwrap_or(false)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let copy_result = {
+            #[cfg(unix)]
+            {
+                with_stderr_silenced(|| {
+                    arboard::Clipboard::new().and_then(|mut c| c.set_text(text))
+                })
+            }
+            #[cfg(not(unix))]
+            {
+                arboard::Clipboard::new().and_then(|mut c| c.set_text(text))
+            }
+        };
+
+        match copy_result {
             Ok(_) => {
                 log::info!("Copied to clipboard");
                 true

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -263,8 +263,45 @@ fn handle_user_order_chat_input(
     None
 }
 
-/// Handle clipboard copy for invoice
-fn handle_clipboard_copy(invoice: String) -> bool {
+/// Reset the Shift+K Shared key disclosure popup's "copied" indicator on any
+/// key other than `c`/`C`. Mirrors the invoice-copy indicator reset above.
+fn reset_disclosure_copied_indicator(mode: &mut UiMode, code: KeyCode) {
+    if let UiMode::OperationResult(ref mut result) = mode {
+        if let OperationResult::ConversationDisclosure {
+            copied_to_clipboard,
+            ..
+        } = result.as_mut()
+        {
+            if code != KeyCode::Char('c') && code != KeyCode::Char('C') {
+                *copied_to_clipboard = false;
+            }
+        }
+    }
+}
+
+/// Copy the disclosed Shared key (`K_conv`) to the clipboard when the Shift+K
+/// disclosure popup is open, updating its "copied" indicator.
+///
+/// Only `conv_hex` (the Shared key) is ever copied — `sign_pubkey_hex`
+/// (`pub(K_sign)`) is not, and the `K_sign` secret itself is never disclosed.
+/// Returns `true` if the popup was open and handled the key.
+fn copy_disclosed_shared_key_if_open(mode: &mut UiMode) -> bool {
+    if let UiMode::OperationResult(ref mut result) = mode {
+        if let OperationResult::ConversationDisclosure {
+            conv_hex,
+            copied_to_clipboard,
+            ..
+        } = result.as_mut()
+        {
+            *copied_to_clipboard = handle_clipboard_copy(conv_hex.clone());
+            return true;
+        }
+    }
+    false
+}
+
+/// Handle clipboard copy for text (invoice, Shared key, etc.)
+fn handle_clipboard_copy(text: String) -> bool {
     #[cfg(target_os = "linux")]
     {
         // On Linux, prefer arboard (system clipboard) but run it off the UI thread.
@@ -291,7 +328,7 @@ fn handle_clipboard_copy(invoice: String) -> bool {
                     }
 
                     let r = match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set().wait().text(invoice),
+                        Ok(mut clipboard) => clipboard.set().wait().text(text),
                         Err(e) => Err(e),
                     };
 
@@ -306,15 +343,15 @@ fn handle_clipboard_copy(invoice: String) -> bool {
                 #[cfg(not(unix))]
                 {
                     match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set().wait().text(invoice),
+                        Ok(mut clipboard) => clipboard.set().wait().text(text),
                         Err(e) => Err(e),
                     }
                 }
             };
 
             match copy_result {
-                Ok(_) => log::info!("Invoice copied to clipboard"),
-                Err(e) => log::warn!("Failed to copy invoice to clipboard: {}", e),
+                Ok(_) => log::info!("Copied to clipboard"),
+                Err(e) => log::warn!("Failed to copy to clipboard: {}", e),
             }
         });
         true
@@ -325,16 +362,16 @@ fn handle_clipboard_copy(invoice: String) -> bool {
     {
         std::thread::spawn(move || {
             let copy_result = match arboard::Clipboard::new() {
-                Ok(mut clipboard) => clipboard.set_text(invoice),
+                Ok(mut clipboard) => clipboard.set_text(text),
                 Err(e) => Err(e),
             };
 
             match copy_result {
                 Ok(_) => {
-                    log::info!("Invoice copied to clipboard");
+                    log::info!("Copied to clipboard");
                 }
                 Err(e) => {
-                    log::warn!("Failed to copy invoice to clipboard: {}", e);
+                    log::warn!("Failed to copy to clipboard: {}", e);
                 }
             }
         });
@@ -999,6 +1036,9 @@ pub fn handle_key_event(
         }
     }
 
+    // Same "copied" indicator reset for the Shift+K Shared key disclosure popup.
+    reset_disclosure_copied_indicator(&mut app.mode, code);
+
     // Handle Shift+F and Shift+I BEFORE other key processing to ensure they're not intercepted
     // Check these BEFORE handle_admin_chat_input to prevent interception
     if let Tab::Admin(AdminTab::DisputesInProgress) = app.active_tab {
@@ -1135,7 +1175,7 @@ pub fn handle_key_event(
                     }
                     let Some((order_id, _)) = resolve_selected_mytrades_order_status(app) else {
                         app.mode = UiMode::operation_result(OperationResult::Info(
-                            "Select an order to reveal K_conv.".to_string(),
+                            "Select an order to reveal the Shared key.".to_string(),
                         ));
                         return Some(true);
                     };
@@ -1158,18 +1198,20 @@ pub fn handle_key_event(
                                     trade_keys.as_ref(),
                                     order.counterparty_pubkey.as_deref(),
                                 ) {
-                                    Some((conv, sign_pk)) => OperationResult::Info(format!(
-                                        "K_conv (read-only grant for solvers):\n{conv}\n\n\
-pub(K_sign) optional locator:\n{sign_pk}\n\n\
-Disclose K_conv only. Never share the K_sign secret."
-                                    )),
+                                    Some((conv, sign_pk)) => {
+                                        OperationResult::ConversationDisclosure {
+                                            conv_hex: conv,
+                                            sign_pubkey_hex: sign_pk,
+                                            copied_to_clipboard: false,
+                                        }
+                                    }
                                     None => OperationResult::Error(
-                                        "No conversation key for this order yet.".to_string(),
+                                        "No Shared key for this order yet.".to_string(),
                                     ),
                                 }
                             }
                             Err(e) => OperationResult::Error(format!(
-                                "Could not load order for K_conv: {e}"
+                                "Could not load order for Shared key: {e}"
                             )),
                         };
                         let _ = tx.send(result);
@@ -1458,6 +1500,16 @@ Disclose K_conv only. Never share the K_sign secret."
                 return Some(true);
             }
 
+            // Handle copy Shared key (K_conv) for the Shift+K disclosure popup. Only
+            // the Shared key is copyable — pub(K_sign) and the K_sign secret are not.
+            if !key_event
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::CONTROL)
+                && copy_disclosed_shared_key_if_open(&mut app.mode)
+            {
+                return Some(true);
+            }
+
             // Handle copy invoice for PayInvoice / PayBondInvoice notifications
             if let UiMode::NewMessageNotification(
                 ref notification,
@@ -1658,5 +1710,73 @@ mod key_handler_tests {
             state.action_selection,
             InvoiceNotificationActionSelection::Primary
         );
+    }
+
+    fn disclosure_mode(copied_to_clipboard: bool) -> UiMode {
+        UiMode::operation_result(OperationResult::ConversationDisclosure {
+            conv_hex: "a".repeat(64),
+            sign_pubkey_hex: "b".repeat(64),
+            copied_to_clipboard,
+        })
+    }
+
+    #[test]
+    fn copy_disclosed_shared_key_sets_copied_flag_and_handles_the_key() {
+        let mut mode = disclosure_mode(false);
+        assert!(copy_disclosed_shared_key_if_open(&mut mode));
+        let UiMode::OperationResult(result) = &mode else {
+            panic!("expected OperationResult mode");
+        };
+        match result.as_ref() {
+            OperationResult::ConversationDisclosure {
+                copied_to_clipboard,
+                ..
+            } => assert!(*copied_to_clipboard, "C should mark the Shared key copied"),
+            other => panic!("expected ConversationDisclosure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copy_disclosed_shared_key_ignores_other_modes() {
+        let mut mode = UiMode::operation_result(OperationResult::Info("hi".to_string()));
+        assert!(
+            !copy_disclosed_shared_key_if_open(&mut mode),
+            "generic Info popup must not be treated as a Shared key copy target"
+        );
+    }
+
+    #[test]
+    fn disclosure_copied_indicator_resets_on_keys_other_than_c() {
+        let mut mode = disclosure_mode(true);
+        reset_disclosure_copied_indicator(&mut mode, KeyCode::Esc);
+        let UiMode::OperationResult(result) = &mode else {
+            panic!("expected OperationResult mode");
+        };
+        match result.as_ref() {
+            OperationResult::ConversationDisclosure {
+                copied_to_clipboard,
+                ..
+            } => assert!(
+                !*copied_to_clipboard,
+                "non-C keys must clear the copied indicator"
+            ),
+            other => panic!("expected ConversationDisclosure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disclosure_copied_indicator_survives_c_key() {
+        let mut mode = disclosure_mode(true);
+        reset_disclosure_copied_indicator(&mut mode, KeyCode::Char('c'));
+        let UiMode::OperationResult(result) = &mode else {
+            panic!("expected OperationResult mode");
+        };
+        match result.as_ref() {
+            OperationResult::ConversationDisclosure {
+                copied_to_clipboard,
+                ..
+            } => assert!(*copied_to_clipboard, "C key must not clear the indicator"),
+            other => panic!("expected ConversationDisclosure, got {other:?}"),
+        }
     }
 }

--- a/src/ui/key_handler/mod.rs
+++ b/src/ui/key_handler/mod.rs
@@ -264,15 +264,21 @@ fn handle_user_order_chat_input(
 }
 
 /// Reset the Shift+K Shared key disclosure popup's "copied" indicator on any
-/// key other than `c`/`C`. Mirrors the invoice-copy indicator reset above.
-fn reset_disclosure_copied_indicator(mode: &mut UiMode, code: KeyCode) {
+/// key other than an unmodified `c`/`C`. Ctrl+C (Observer clear-all / generic
+/// clear shortcuts elsewhere) must also clear the indicator, so it is treated
+/// the same as any other non-copy key. Mirrors the invoice-copy indicator
+/// reset above.
+fn reset_disclosure_copied_indicator(mode: &mut UiMode, key_event: &KeyEvent) {
     if let UiMode::OperationResult(ref mut result) = mode {
         if let OperationResult::ConversationDisclosure {
             copied_to_clipboard,
             ..
         } = result.as_mut()
         {
-            if code != KeyCode::Char('c') && code != KeyCode::Char('C') {
+            let is_unmodified_copy_key =
+                matches!(key_event.code, KeyCode::Char('c') | KeyCode::Char('C'))
+                    && !key_event.modifiers.contains(KeyModifiers::CONTROL);
+            if !is_unmodified_copy_key {
                 *copied_to_clipboard = false;
             }
         }
@@ -282,18 +288,26 @@ fn reset_disclosure_copied_indicator(mode: &mut UiMode, code: KeyCode) {
 /// Copy the disclosed Shared key (`K_conv`) to the clipboard when the Shift+K
 /// disclosure popup is open, updating its "copied" indicator.
 ///
-/// Only `conv_hex` (the Shared key) is ever copied — `sign_pubkey_hex`
-/// (`pub(K_sign)`) is not, and the `K_sign` secret itself is never disclosed.
-/// Returns `true` if the popup was open and handled the key.
+/// Only `conv_hex` (the Shared key) is ever copied — the signing key itself
+/// is never disclosed. Returns `true` if the popup was open and handled the key.
 fn copy_disclosed_shared_key_if_open(mode: &mut UiMode) -> bool {
+    copy_disclosed_shared_key_if_open_with(mode, handle_clipboard_copy)
+}
+
+/// Testable core of [`copy_disclosed_shared_key_if_open`]; `copy_fn` is injected
+/// so tests can assert on both success and failure without touching the real
+/// system clipboard.
+fn copy_disclosed_shared_key_if_open_with(
+    mode: &mut UiMode,
+    copy_fn: impl FnOnce(String) -> bool,
+) -> bool {
     if let UiMode::OperationResult(ref mut result) = mode {
         if let OperationResult::ConversationDisclosure {
             conv_hex,
             copied_to_clipboard,
-            ..
         } = result.as_mut()
         {
-            *copied_to_clipboard = handle_clipboard_copy(conv_hex.clone());
+            *copied_to_clipboard = copy_fn(conv_hex.clone());
             return true;
         }
     }
@@ -301,81 +315,59 @@ fn copy_disclosed_shared_key_if_open(mode: &mut UiMode) -> bool {
 }
 
 /// Handle clipboard copy for text (invoice, Shared key, etc.)
+///
+/// Runs synchronously and returns whether the write actually succeeded —
+/// `copied_to_clipboard` at the call site should only be set to `true` when
+/// this returns `true`, not merely because a copy attempt was made.
 fn handle_clipboard_copy(text: String) -> bool {
-    #[cfg(target_os = "linux")]
+    // Some clipboard backends (e.g. on Linux) can emit warnings to stderr;
+    // silence stderr during the call to avoid corrupting the TUI.
+    #[cfg(unix)]
     {
-        // On Linux, prefer arboard (system clipboard) but run it off the UI thread.
-        // Some clipboard backends can emit warnings to stderr; silence stderr during the call
-        // to avoid corrupting the TUI.
-        std::thread::spawn(move || {
-            // Needed for `SetExtLinux::wait`. It keeps this thread alive serving the selection
-            // until another app takes the clipboard ownership; otherwhise the copied text is lost
-            // as soon as the thread exists. See the documentation of `SetExtLinux::wait` for
-            // details.
-            use arboard::SetExtLinux;
-            let copy_result = {
-                #[cfg(unix)]
-                {
-                    use std::os::unix::io::AsRawFd;
-                    let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
-                    let devnull = std::fs::File::open("/dev/null");
-                    if saved_stderr >= 0 {
-                        if let Ok(devnull) = devnull {
-                            unsafe {
-                                let _ = libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO);
-                            }
-                        }
-                    }
-
-                    let r = match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set().wait().text(text),
-                        Err(e) => Err(e),
-                    };
-
-                    if saved_stderr >= 0 {
-                        unsafe {
-                            let _ = libc::dup2(saved_stderr, libc::STDERR_FILENO);
-                            let _ = libc::close(saved_stderr);
-                        }
-                    }
-                    r
+        use std::os::unix::io::AsRawFd;
+        let saved_stderr = unsafe { libc::dup(libc::STDERR_FILENO) };
+        let devnull = std::fs::File::open("/dev/null");
+        if saved_stderr >= 0 {
+            if let Ok(devnull) = devnull {
+                unsafe {
+                    let _ = libc::dup2(devnull.as_raw_fd(), libc::STDERR_FILENO);
                 }
-                #[cfg(not(unix))]
-                {
-                    match arboard::Clipboard::new() {
-                        Ok(mut clipboard) => clipboard.set().wait().text(text),
-                        Err(e) => Err(e),
-                    }
-                }
-            };
-
-            match copy_result {
-                Ok(_) => log::info!("Copied to clipboard"),
-                Err(e) => log::warn!("Failed to copy to clipboard: {}", e),
             }
-        });
-        true
+        }
+
+        let result = arboard::Clipboard::new().and_then(|mut c| c.set_text(text));
+
+        if saved_stderr >= 0 {
+            unsafe {
+                let _ = libc::dup2(saved_stderr, libc::STDERR_FILENO);
+                let _ = libc::close(saved_stderr);
+            }
+        }
+
+        match result {
+            Ok(_) => {
+                log::info!("Copied to clipboard");
+                true
+            }
+            Err(e) => {
+                log::warn!("Failed to copy to clipboard: {}", e);
+                false
+            }
+        }
     }
 
-    // Non-Linux: clipboard ops can still block; run off UI thread.
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(unix))]
     {
-        std::thread::spawn(move || {
-            let copy_result = match arboard::Clipboard::new() {
-                Ok(mut clipboard) => clipboard.set_text(text),
-                Err(e) => Err(e),
-            };
-
-            match copy_result {
-                Ok(_) => {
-                    log::info!("Copied to clipboard");
-                }
-                Err(e) => {
-                    log::warn!("Failed to copy to clipboard: {}", e);
-                }
+        match arboard::Clipboard::new().and_then(|mut c| c.set_text(text)) {
+            Ok(_) => {
+                log::info!("Copied to clipboard");
+                true
             }
-        });
-        true
+            Err(e) => {
+                log::warn!("Failed to copy to clipboard: {}", e);
+                false
+            }
+        }
     }
 }
 
@@ -611,7 +603,7 @@ pub fn handle_key_event(
         if let Some(text) = read_clipboard_text_best_effort() {
             let filtered: String = text.chars().filter(|c| !c.is_control()).collect();
             if !filtered.is_empty() {
-                app.observer_active_input_mut().push_str(&filtered);
+                app.observer_shared_key_input.push_str(&filtered);
                 return Some(true);
             }
         }
@@ -1037,7 +1029,7 @@ pub fn handle_key_event(
     }
 
     // Same "copied" indicator reset for the Shift+K Shared key disclosure popup.
-    reset_disclosure_copied_indicator(&mut app.mode, code);
+    reset_disclosure_copied_indicator(&mut app.mode, &key_event);
 
     // Handle Shift+F and Shift+I BEFORE other key processing to ensure they're not intercepted
     // Check these BEFORE handle_admin_chat_input to prevent interception
@@ -1198,10 +1190,9 @@ pub fn handle_key_event(
                                     trade_keys.as_ref(),
                                     order.counterparty_pubkey.as_deref(),
                                 ) {
-                                    Some((conv, sign_pk)) => {
+                                    Some((conv, _sign_pk)) => {
                                         OperationResult::ConversationDisclosure {
                                             conv_hex: conv,
-                                            sign_pubkey_hex: sign_pk,
                                             copied_to_clipboard: false,
                                         }
                                     }
@@ -1233,8 +1224,8 @@ pub fn handle_key_event(
         return Some(result);
     }
 
-    // Observer tab: handle all character and backspace input early so y/n/m/c etc. go to the focused field.
-    // Skip when a modal owns input so we don't edit K_conv / pub(K_sign) behind an overlay.
+    // Observer tab: handle all character and backspace input early so y/n/m/c etc. go to the field.
+    // Skip when a modal owns input so we don't edit the Shared key behind an overlay.
     if app.observer_inputs_editable() {
         let is_ctrl = key_event
             .modifiers
@@ -1242,11 +1233,11 @@ pub fn handle_key_event(
         if !is_ctrl {
             match code {
                 KeyCode::Char(c) => {
-                    app.observer_active_input_mut().push(c);
+                    app.observer_shared_key_input.push(c);
                     return Some(true);
                 }
                 KeyCode::Backspace => {
-                    app.observer_active_input_mut().pop();
+                    app.observer_shared_key_input.pop();
                     return Some(true);
                 }
                 _ => {}
@@ -1501,7 +1492,7 @@ pub fn handle_key_event(
             }
 
             // Handle copy Shared key (K_conv) for the Shift+K disclosure popup. Only
-            // the Shared key is copyable — pub(K_sign) and the K_sign secret are not.
+            // the Shared key is copyable — the signing key itself is never disclosed.
             if !key_event
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::CONTROL)
@@ -1540,9 +1531,7 @@ pub fn handle_key_event(
 #[cfg(test)]
 mod key_handler_tests {
     use super::*;
-    use crate::ui::{
-        InvoiceInputState, InvoiceNotificationActionSelection, ObserverInputField, UserRole,
-    };
+    use crate::ui::{InvoiceInputState, InvoiceNotificationActionSelection, UserRole};
     use crossterm::event::KeyModifiers;
 
     #[test]
@@ -1673,14 +1662,13 @@ mod key_handler_tests {
     }
 
     #[test]
-    fn observer_tab_toggles_k_conv_and_sign_locator_focus() {
+    fn observer_tab_ignores_tab_and_backtab_with_a_single_input_field() {
         let mut app = AppState::new(UserRole::Admin);
         app.active_tab = Tab::Admin(AdminTab::Observer);
-        assert_eq!(app.observer_input_focus, ObserverInputField::ConvKey);
+        app.observer_shared_key_input = "abc".to_string();
         handle_tab_navigation(KeyCode::Tab, &mut app);
-        assert_eq!(app.observer_input_focus, ObserverInputField::SignAuthor);
         handle_tab_navigation(KeyCode::BackTab, &mut app);
-        assert_eq!(app.observer_input_focus, ObserverInputField::ConvKey);
+        assert_eq!(app.observer_shared_key_input, "abc");
     }
 
     #[test]
@@ -1715,15 +1703,18 @@ mod key_handler_tests {
     fn disclosure_mode(copied_to_clipboard: bool) -> UiMode {
         UiMode::operation_result(OperationResult::ConversationDisclosure {
             conv_hex: "a".repeat(64),
-            sign_pubkey_hex: "b".repeat(64),
             copied_to_clipboard,
         })
     }
 
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
     #[test]
-    fn copy_disclosed_shared_key_sets_copied_flag_and_handles_the_key() {
+    fn copy_disclosed_shared_key_sets_copied_flag_when_the_write_succeeds() {
         let mut mode = disclosure_mode(false);
-        assert!(copy_disclosed_shared_key_if_open(&mut mode));
+        assert!(copy_disclosed_shared_key_if_open_with(&mut mode, |_| true));
         let UiMode::OperationResult(result) = &mode else {
             panic!("expected OperationResult mode");
         };
@@ -1737,10 +1728,32 @@ mod key_handler_tests {
     }
 
     #[test]
+    fn copy_disclosed_shared_key_leaves_flag_false_when_the_write_fails() {
+        let mut mode = disclosure_mode(false);
+        assert!(
+            copy_disclosed_shared_key_if_open_with(&mut mode, |_| false),
+            "the popup was still open and handled the key even though the copy failed"
+        );
+        let UiMode::OperationResult(result) = &mode else {
+            panic!("expected OperationResult mode");
+        };
+        match result.as_ref() {
+            OperationResult::ConversationDisclosure {
+                copied_to_clipboard,
+                ..
+            } => assert!(
+                !*copied_to_clipboard,
+                "a failed clipboard write must not report success"
+            ),
+            other => panic!("expected ConversationDisclosure, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn copy_disclosed_shared_key_ignores_other_modes() {
         let mut mode = UiMode::operation_result(OperationResult::Info("hi".to_string()));
         assert!(
-            !copy_disclosed_shared_key_if_open(&mut mode),
+            !copy_disclosed_shared_key_if_open_with(&mut mode, |_| true),
             "generic Info popup must not be treated as a Shared key copy target"
         );
     }
@@ -1748,7 +1761,7 @@ mod key_handler_tests {
     #[test]
     fn disclosure_copied_indicator_resets_on_keys_other_than_c() {
         let mut mode = disclosure_mode(true);
-        reset_disclosure_copied_indicator(&mut mode, KeyCode::Esc);
+        reset_disclosure_copied_indicator(&mut mode, &key(KeyCode::Esc));
         let UiMode::OperationResult(result) = &mode else {
             panic!("expected OperationResult mode");
         };
@@ -1767,7 +1780,7 @@ mod key_handler_tests {
     #[test]
     fn disclosure_copied_indicator_survives_c_key() {
         let mut mode = disclosure_mode(true);
-        reset_disclosure_copied_indicator(&mut mode, KeyCode::Char('c'));
+        reset_disclosure_copied_indicator(&mut mode, &key(KeyCode::Char('c')));
         let UiMode::OperationResult(result) = &mode else {
             panic!("expected OperationResult mode");
         };
@@ -1776,6 +1789,26 @@ mod key_handler_tests {
                 copied_to_clipboard,
                 ..
             } => assert!(*copied_to_clipboard, "C key must not clear the indicator"),
+            other => panic!("expected ConversationDisclosure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disclosure_copied_indicator_clears_on_ctrl_c() {
+        let mut mode = disclosure_mode(true);
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        reset_disclosure_copied_indicator(&mut mode, &ctrl_c);
+        let UiMode::OperationResult(result) = &mode else {
+            panic!("expected OperationResult mode");
+        };
+        match result.as_ref() {
+            OperationResult::ConversationDisclosure {
+                copied_to_clipboard,
+                ..
+            } => assert!(
+                !*copied_to_clipboard,
+                "Ctrl+C must clear the indicator consistently with the Observer clear-all shortcut"
+            ),
             other => panic!("expected ConversationDisclosure, got {other:?}"),
         }
     }

--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -543,8 +543,6 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                     app.order_chat_selected_message_idx = None;
                     app.order_chat_scroll_tracker = None;
                 }
-            } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-                app.observer_input_focus = app.observer_input_focus.toggle();
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.next(form.use_range);
             }
@@ -560,8 +558,6 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
                 app.admin_chat_scroll_tracker = None;
             } else if matches!(app.active_tab, Tab::User(UserTab::MyTrades)) {
                 handle_tab_navigation(KeyCode::Tab, app);
-            } else if let Tab::Admin(AdminTab::Observer) = app.active_tab {
-                app.observer_input_focus = app.observer_input_focus.toggle();
             } else if let UiMode::UserMode(UserMode::CreatingOrder(ref mut form)) = app.mode {
                 form.focused = form.focused.prev(form.use_range);
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -45,9 +45,9 @@ pub use state::{
     AppState, BuyerInvoicePreference, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
     DecodedChatMessage, DisputeChatMessage, DisputeFilter, FormState, InvoiceInputState,
     InvoiceNotificationActionSelection, KeyInputState, LnAddressVerifyResult, MessageNotification,
-    MessageViewState, MostroInfoFetchResult, ObserverInputField, OperationResult,
-    OrderChatLastSeen, OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab,
-    TakeOrderState, ThreeState, UiMode, UserChatChannel, UserChatSender, UserOrderChatMessage,
-    UserRole, UserTab, ViewingMessageButtonSelection,
+    MessageViewState, MostroInfoFetchResult, OperationResult, OrderChatLastSeen,
+    OrderChatStaticHeader, OrderChatUpdate, OrderMessage, RatingOrderState, Tab, TakeOrderState,
+    ThreeState, UiMode, UserChatChannel, UserChatSender, UserOrderChatMessage, UserRole, UserTab,
+    ViewingMessageButtonSelection,
 };
 pub use user_state::UserMode;

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -1,5 +1,5 @@
 use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
@@ -49,6 +49,7 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
     let popup_width = 70;
     let popup_height = match result {
         OperationResult::Success(_) => 18,
+        OperationResult::ConversationDisclosure { .. } => 16,
         OperationResult::PaymentRequestRequired { .. }
         | OperationResult::ObserverChatLoaded { .. }
         | OperationResult::ObserverChatError { .. } => 8,
@@ -225,6 +226,66 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
         }
+        OperationResult::ConversationDisclosure {
+            conv_hex,
+            sign_pubkey_hex,
+            copied_to_clipboard,
+        } => {
+            let block = Block::default()
+                .title("✅ Operation Successful")
+                .borders(Borders::ALL)
+                .style(Style::default().bg(BACKGROUND_COLOR).fg(Color::Green));
+
+            let inner = block.inner(popup);
+            f.render_widget(block, popup);
+
+            let mut lines = vec![
+                Line::from(vec![Span::styled(
+                    "Shared key (read-only grant for solvers):",
+                    Style::default().fg(PRIMARY_COLOR),
+                )]),
+                Line::from(conv_hex.as_str()),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "pub(K_sign) optional locator:",
+                    Style::default().fg(PRIMARY_COLOR),
+                )]),
+                Line::from(sign_pubkey_hex.as_str()),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "Disclose the Shared key only. Never share the K_sign secret.",
+                    Style::default().fg(Color::Yellow),
+                )]),
+                Line::from(""),
+            ];
+
+            if *copied_to_clipboard {
+                lines.push(Line::from(vec![Span::styled(
+                    "✓ Shared key copied to clipboard!",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                )]));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::styled("Press ", Style::default()),
+                    Span::styled(
+                        "C",
+                        Style::default()
+                            .fg(PRIMARY_COLOR)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to copy the Shared key to clipboard.", Style::default()),
+                ]));
+            }
+            lines.push(Line::from(vec![Span::styled(
+                "Press ESC or ENTER to close",
+                Style::default().fg(Color::DarkGray),
+            )]));
+
+            let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+            f.render_widget(paragraph, inner);
+        }
         OperationResult::ObserverChatLoaded { .. } | OperationResult::ObserverChatError { .. } => {
             // Handled directly in handle_operation_result, should not reach render
         }
@@ -259,5 +320,79 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
         | OperationResult::OrderChatAttachmentSent { .. }
         | OperationResult::OrderChatAttachmentSendFailed { .. }
         | OperationResult::OrderChatAttachmentError { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        let mut hay = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                hay.push_str(buf[(x, y)].symbol());
+            }
+        }
+        hay.contains(needle)
+    }
+
+    fn render(result: &OperationResult) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| render_operation_result(f, result))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn conversation_disclosure_shows_shared_key_and_copy_hint() {
+        let result = OperationResult::ConversationDisclosure {
+            conv_hex: "a".repeat(64),
+            sign_pubkey_hex: "b".repeat(64),
+            copied_to_clipboard: false,
+        };
+        let buf = render(&result);
+        assert!(
+            buffer_contains(&buf, "Shared key"),
+            "popup must label the disclosed K_conv secret as Shared key"
+        );
+        assert!(
+            buffer_contains(&buf, &"a".repeat(64)),
+            "popup must show the Shared key hex"
+        );
+        assert!(
+            buffer_contains(&buf, "pub(K_sign)"),
+            "popup must still show the optional pub(K_sign) locator"
+        );
+        assert!(
+            buffer_contains(&buf, "Never share the K_sign secret"),
+            "popup must warn against disclosing the K_sign secret"
+        );
+        assert!(
+            buffer_contains(&buf, "C") && buffer_contains(&buf, "clipboard"),
+            "popup must hint that C copies the Shared key"
+        );
+        assert!(
+            !buffer_contains(&buf, "K_conv"),
+            "popup must not label the field K_conv; users see Shared key"
+        );
+    }
+
+    #[test]
+    fn conversation_disclosure_shows_copied_confirmation() {
+        let result = OperationResult::ConversationDisclosure {
+            conv_hex: "a".repeat(64),
+            sign_pubkey_hex: "b".repeat(64),
+            copied_to_clipboard: true,
+        };
+        let buf = render(&result);
+        assert!(
+            buffer_contains(&buf, "Shared key copied to clipboard"),
+            "popup must confirm the Shared key was copied"
+        );
     }
 }

--- a/src/ui/operation_result.rs
+++ b/src/ui/operation_result.rs
@@ -1,9 +1,10 @@
-use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use super::{OperationResult, BACKGROUND_COLOR, PRIMARY_COLOR};
+use crate::ui::helpers::create_centered_popup;
 use crate::ui::orders::OrderSuccess;
 
 /// Split on newlines, then wrap each paragraph at word boundaries.
@@ -44,12 +45,172 @@ fn info_popup_height(message: &str, popup_width: u16) -> u16 {
     (content_lines + 4).clamp(8, 22) as u16
 }
 
+/// Split a plain hex string into fixed-width chunks so it never gets silently
+/// truncated by `Paragraph` on narrow terminals. Hex has no whitespace for
+/// [`wrap_message_lines`] to break on, so it needs its own char-width chunking.
+fn chunk_hex_lines(hex: &str, width: usize) -> Vec<Line<'static>> {
+    let width = width.max(1);
+    let chars: Vec<char> = hex.chars().collect();
+    if chars.is_empty() {
+        return vec![Line::from("")];
+    }
+    chars
+        .chunks(width)
+        .map(|chunk| Line::from(chunk.iter().collect::<String>()))
+        .collect()
+}
+
+/// Re-wrap `text` at word boundaries and apply `style` uniformly to every resulting line.
+fn styled_wrapped_lines(text: &str, width: usize, style: Style) -> Vec<Line<'static>> {
+    wrap_message_lines(text, width)
+        .into_iter()
+        .map(|line| {
+            let content: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            Line::from(Span::styled(content, style))
+        })
+        .collect()
+}
+
+/// Wrap a sequence of styled text fragments (e.g. plain text around a bold key
+/// name) at word boundaries into possibly multiple `Line`s that fit `width`
+/// columns, preserving each word's own fragment style (so a highlighted key
+/// like "C" keeps its style even when the surrounding sentence wraps).
+fn wrap_styled_fragments(fragments: &[(&str, Style)], width: usize) -> Vec<Line<'static>> {
+    let width = width.max(1);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut current: Vec<Span<'static>> = Vec::new();
+    let mut current_len = 0usize;
+
+    for (text, style) in fragments {
+        for word in text.split_whitespace() {
+            let word_len = word.chars().count();
+            if !current.is_empty() && current_len + 1 + word_len > width {
+                lines.push(Line::from(std::mem::take(&mut current)));
+                current_len = 0;
+            }
+            if !current.is_empty() {
+                current.push(Span::raw(" "));
+                current_len += 1;
+            }
+            current.push(Span::styled(word.to_string(), *style));
+            current_len += word_len;
+        }
+    }
+    if !current.is_empty() {
+        lines.push(Line::from(current));
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
+/// Build the Shift+K Shared key disclosure popup's content lines.
+///
+/// `compact` drops the blank spacer line after the warning so the required
+/// elements — Shared key, warning, copy state, and close instruction — stay
+/// visible on short terminals instead of being clipped.
+fn conversation_disclosure_lines(
+    conv_hex: &str,
+    copied_to_clipboard: bool,
+    inner_width: usize,
+    compact: bool,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(vec![Span::styled(
+        "Shared key (read-only grant for solvers):",
+        Style::default().fg(PRIMARY_COLOR),
+    )])];
+    lines.extend(chunk_hex_lines(conv_hex, inner_width));
+    lines.push(Line::from(""));
+
+    lines.extend(styled_wrapped_lines(
+        "Disclose the Shared key only. Never share your signing key.",
+        inner_width,
+        Style::default().fg(Color::Yellow),
+    ));
+    if !compact {
+        lines.push(Line::from(""));
+    }
+
+    if copied_to_clipboard {
+        lines.extend(wrap_styled_fragments(
+            &[(
+                "✓ Shared key copied to clipboard!",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )],
+            inner_width,
+        ));
+    } else {
+        lines.extend(wrap_styled_fragments(
+            &[
+                ("Press", Style::default()),
+                (
+                    "C",
+                    Style::default()
+                        .fg(PRIMARY_COLOR)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                ("to copy the Shared key to clipboard.", Style::default()),
+            ],
+            inner_width,
+        ));
+    }
+    lines.extend(wrap_styled_fragments(
+        &[(
+            "Press ESC or ENTER to close",
+            Style::default().fg(Color::DarkGray),
+        )],
+        inner_width,
+    ));
+
+    lines
+}
+
+/// Picks the widest layout (full, then compact) whose content fits `max_height`
+/// rows, falling back to compact when even the full layout would be clipped.
+/// Returns the content lines and the popup height they need (content + borders).
+fn conversation_disclosure_layout(
+    conv_hex: &str,
+    copied_to_clipboard: bool,
+    inner_width: usize,
+    max_height: u16,
+) -> (Vec<Line<'static>>, u16) {
+    let full = conversation_disclosure_lines(conv_hex, copied_to_clipboard, inner_width, false);
+    let full_height = full.len() as u16 + 2; // + top/bottom border
+    if full_height <= max_height {
+        return (full, full_height);
+    }
+
+    let compact = conversation_disclosure_lines(conv_hex, copied_to_clipboard, inner_width, true);
+    let compact_height = (compact.len() as u16 + 2).min(max_height);
+    (compact, compact_height)
+}
+
 pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult) {
     let area: Rect = f.area();
-    let popup_width = 70;
+    let popup_width = 70u16.min(area.width.max(1));
+    let inner_width = popup_width.saturating_sub(2).max(1) as usize;
+    let disclosure_layout = if let OperationResult::ConversationDisclosure {
+        conv_hex,
+        copied_to_clipboard,
+    } = result
+    {
+        Some(conversation_disclosure_layout(
+            conv_hex,
+            *copied_to_clipboard,
+            inner_width,
+            area.height.max(1),
+        ))
+    } else {
+        None
+    };
     let popup_height = match result {
         OperationResult::Success(_) => 18,
-        OperationResult::ConversationDisclosure { .. } => 16,
+        OperationResult::ConversationDisclosure { .. } => {
+            disclosure_layout.as_ref().map(|(_, h)| *h).unwrap_or(16)
+        }
         OperationResult::PaymentRequestRequired { .. }
         | OperationResult::ObserverChatLoaded { .. }
         | OperationResult::ObserverChatError { .. } => 8,
@@ -64,16 +225,8 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
         | OperationResult::OrderChatAttachmentSendFailed { .. }
         | OperationResult::OrderChatAttachmentError { .. } => 8,
     };
-    // Center the popup using Flex::Center
-    let popup = {
-        let [popup] = Layout::horizontal([Constraint::Length(popup_width)])
-            .flex(Flex::Center)
-            .areas(area);
-        let [popup] = Layout::vertical([Constraint::Length(popup_height)])
-            .flex(Flex::Center)
-            .areas(popup);
-        popup
-    };
+    // Clamp to the available area so the popup never exceeds narrow/short terminals.
+    let popup = create_centered_popup(area, popup_width, popup_height);
 
     // Clear the popup area to make it fully opaque
     f.render_widget(Clear, popup);
@@ -226,11 +379,7 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
         }
-        OperationResult::ConversationDisclosure {
-            conv_hex,
-            sign_pubkey_hex,
-            copied_to_clipboard,
-        } => {
+        OperationResult::ConversationDisclosure { .. } => {
             let block = Block::default()
                 .title("✅ Operation Successful")
                 .borders(Borders::ALL)
@@ -239,49 +388,11 @@ pub fn render_operation_result(f: &mut ratatui::Frame, result: &OperationResult)
             let inner = block.inner(popup);
             f.render_widget(block, popup);
 
-            let mut lines = vec![
-                Line::from(vec![Span::styled(
-                    "Shared key (read-only grant for solvers):",
-                    Style::default().fg(PRIMARY_COLOR),
-                )]),
-                Line::from(conv_hex.as_str()),
-                Line::from(""),
-                Line::from(vec![Span::styled(
-                    "pub(K_sign) optional locator:",
-                    Style::default().fg(PRIMARY_COLOR),
-                )]),
-                Line::from(sign_pubkey_hex.as_str()),
-                Line::from(""),
-                Line::from(vec![Span::styled(
-                    "Disclose the Shared key only. Never share the K_sign secret.",
-                    Style::default().fg(Color::Yellow),
-                )]),
-                Line::from(""),
-            ];
-
-            if *copied_to_clipboard {
-                lines.push(Line::from(vec![Span::styled(
-                    "✓ Shared key copied to clipboard!",
-                    Style::default()
-                        .fg(Color::Green)
-                        .add_modifier(Modifier::BOLD),
-                )]));
-            } else {
-                lines.push(Line::from(vec![
-                    Span::styled("Press ", Style::default()),
-                    Span::styled(
-                        "C",
-                        Style::default()
-                            .fg(PRIMARY_COLOR)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(" to copy the Shared key to clipboard.", Style::default()),
-                ]));
-            }
-            lines.push(Line::from(vec![Span::styled(
-                "Press ESC or ENTER to close",
-                Style::default().fg(Color::DarkGray),
-            )]));
+            // Computed above (before the popup was sized) so the height clamp and
+            // the rendered content always agree on full vs. compact layout.
+            let lines = disclosure_layout
+                .map(|(lines, _)| lines)
+                .unwrap_or_default();
 
             let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
             f.render_widget(paragraph, inner);
@@ -340,7 +451,11 @@ mod tests {
     }
 
     fn render(result: &OperationResult) -> ratatui::buffer::Buffer {
-        let backend = TestBackend::new(80, 24);
+        render_at(result, 80, 24)
+    }
+
+    fn render_at(result: &OperationResult, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| render_operation_result(f, result))
@@ -352,7 +467,6 @@ mod tests {
     fn conversation_disclosure_shows_shared_key_and_copy_hint() {
         let result = OperationResult::ConversationDisclosure {
             conv_hex: "a".repeat(64),
-            sign_pubkey_hex: "b".repeat(64),
             copied_to_clipboard: false,
         };
         let buf = render(&result);
@@ -365,12 +479,12 @@ mod tests {
             "popup must show the Shared key hex"
         );
         assert!(
-            buffer_contains(&buf, "pub(K_sign)"),
-            "popup must still show the optional pub(K_sign) locator"
+            !buffer_contains(&buf, "Signer pubkey"),
+            "popup should not display a Signer pubkey locator"
         );
         assert!(
-            buffer_contains(&buf, "Never share the K_sign secret"),
-            "popup must warn against disclosing the K_sign secret"
+            buffer_contains(&buf, "Never share your signing key"),
+            "popup must warn against disclosing the signing key"
         );
         assert!(
             buffer_contains(&buf, "C") && buffer_contains(&buf, "clipboard"),
@@ -386,7 +500,6 @@ mod tests {
     fn conversation_disclosure_shows_copied_confirmation() {
         let result = OperationResult::ConversationDisclosure {
             conv_hex: "a".repeat(64),
-            sign_pubkey_hex: "b".repeat(64),
             copied_to_clipboard: true,
         };
         let buf = render(&result);
@@ -394,5 +507,84 @@ mod tests {
             buffer_contains(&buf, "Shared key copied to clipboard"),
             "popup must confirm the Shared key was copied"
         );
+    }
+
+    #[test]
+    fn conversation_disclosure_popup_fits_within_a_constrained_terminal() {
+        // Regression: on a narrow (< 70 cols) and short (< 16 rows) terminal, the
+        // popup must not exceed the terminal, and its content must not be clipped
+        // or silently truncated (the full Shared key hex must remain readable).
+        //
+        // Uses 'q' (absent from every static string in the popup) as the hex
+        // digit so counting occurrences unambiguously measures the rendered Shared
+        // key, not incidental letters from prose like "Shared" or "share".
+        let conv_hex = "q".repeat(64);
+        let result = OperationResult::ConversationDisclosure {
+            conv_hex: conv_hex.clone(),
+            copied_to_clipboard: false,
+        };
+        let (width, height) = (40, 12);
+        let buf = render_at(&result, width, height);
+
+        assert!(
+            buf.area.width <= width,
+            "popup must not exceed terminal width"
+        );
+        assert!(
+            buf.area.height <= height,
+            "popup must not exceed terminal height"
+        );
+
+        let mut flat = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                flat.push_str(buf[(x, y)].symbol());
+            }
+        }
+        let hex_char_count = flat.chars().filter(|c| *c == 'q').count();
+        assert_eq!(
+            hex_char_count,
+            conv_hex.len(),
+            "the full Shared key hex must be visible, not truncated, on a narrow terminal"
+        );
+        // Word wrap may split the warning/hint across lines (each independently
+        // centered, so exact multi-word phrases can gain extra padding spaces
+        // between wrapped lines); check for representative words instead.
+        assert!(
+            flat.contains("Disclose") && flat.contains("Never") && flat.contains("signing"),
+            "the disclosure warning must remain visible on a short terminal"
+        );
+        assert!(
+            flat.contains("Press") && flat.contains('C') && flat.contains("clipboard"),
+            "the copy-state hint must remain visible on a short terminal"
+        );
+        assert!(
+            flat.contains("ESC") && flat.contains("ENTER") && flat.contains("close"),
+            "the close instruction must remain visible on a short terminal"
+        );
+    }
+
+    #[test]
+    fn conversation_disclosure_layout_clamps_height_to_available_area() {
+        let (lines, height) = conversation_disclosure_layout(&"a".repeat(64), false, 38, 6);
+        assert!(
+            height <= 6,
+            "popup height must never exceed the available area"
+        );
+        assert!(
+            (lines.len() as u16 + 2) >= height,
+            "returned lines should justify the computed height"
+        );
+    }
+
+    #[test]
+    fn conversation_disclosure_layout_prefers_full_layout_when_it_fits() {
+        let (lines, height) = conversation_disclosure_layout(&"a".repeat(64), false, 38, 24);
+        let compact_lines = conversation_disclosure_lines(&"a".repeat(64), false, 38, true);
+        assert!(
+            lines.len() > compact_lines.len(),
+            "full layout (plenty of height) should keep the spacer line compact mode drops"
+        );
+        assert_eq!(height, lines.len() as u16 + 2);
     }
 }

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -200,6 +200,16 @@ pub enum OperationResult {
         prepared: crate::ui::helpers::PreparedOrderChatAttachment,
         error: String,
     },
+    /// My Trades Shift+K result: read-only chat disclosure for a solver.
+    ///
+    /// `conv_hex` is the disclosed `K_conv` secret (labelled "Shared key" in the
+    /// UI); `sign_pubkey_hex` is the optional `pub(K_sign)` relay locator. Only
+    /// `conv_hex` is copyable (Press `C`) — `K_sign` itself is never disclosed.
+    ConversationDisclosure {
+        conv_hex: String,
+        sign_pubkey_hex: String,
+        copied_to_clipboard: bool,
+    },
 }
 
 /// Result of async Lightning address LNURL verification and save (settings flow; not order/dispute).

--- a/src/ui/orders.rs
+++ b/src/ui/orders.rs
@@ -202,12 +202,11 @@ pub enum OperationResult {
     },
     /// My Trades Shift+K result: read-only chat disclosure for a solver.
     ///
-    /// `conv_hex` is the disclosed `K_conv` secret (labelled "Shared key" in the
-    /// UI); `sign_pubkey_hex` is the optional `pub(K_sign)` relay locator. Only
-    /// `conv_hex` is copyable (Press `C`) — `K_sign` itself is never disclosed.
+    /// `conv_hex` is the disclosed `K_conv` secret (labelled "Shared key" in
+    /// the UI) — the only field shown, and the only one copyable (Press `C`).
+    /// The signing key itself is never disclosed.
     ConversationDisclosure {
         conv_hex: String,
-        sign_pubkey_hex: String,
         copied_to_clipboard: bool,
     },
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,6 +1,6 @@
 pub use crate::shared::permissions::SolverPermission;
 pub use crate::ui::admin_state::AddSolverState;
-pub use crate::ui::app_state::{AppState, ObserverInputField, UiMode};
+pub use crate::ui::app_state::{AppState, UiMode};
 pub use crate::ui::chat::{
     AdminChatLastSeen, AdminChatUpdate, ChatAttachment, ChatAttachmentType, ChatParty, ChatSender,
     DecodedChatMessage, DisputeChatMessage, DisputeFilter, OrderChatLastSeen, OrderChatUpdate,

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -5,11 +5,18 @@ use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::helpers::build_observer_scrollview_content;
-use crate::ui::{AppState, ObserverInputField, BACKGROUND_COLOR, PRIMARY_COLOR};
+use crate::ui::{AppState, BACKGROUND_COLOR, PRIMARY_COLOR};
+
+/// Below this width the full field labels and footer (the longer footer line
+/// needs ~104 columns) no longer fit; fall back to the abbreviated compact
+/// labels/footer instead of silently clipping keyboard shortcuts.
+const OBSERVER_NARROW_WIDTH: u16 = 60;
 
 pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppState) {
-    let compact = area.height < 16;
-    let input_height = if compact { 5 } else { 8 };
+    let compact = area.height < 16 || area.width < OBSERVER_NARROW_WIDTH;
+    // Compact footer is 3 short lines (vs. 2 long ones) so shortcuts stay
+    // readable instead of being cut off; field row stays 3 rows either way.
+    let input_height = if compact { 6 } else { 5 };
     // Borders consume 2 rows. Compact: 1 inner row (status/error). Full: 2 inner rows.
     let header_height = if compact { 3 } else { 4 };
     let chunks = Layout::new(
@@ -68,7 +75,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
                         .fg(PRIMARY_COLOR)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::raw("  –  paste Shared key (read-only). Never paste K_sign."),
+                Span::raw("  –  paste Shared key (read-only). Never paste a signing key."),
             ]),
             status_line,
         ]
@@ -152,84 +159,55 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         f.render_stateful_widget(scroll_view, inner_area, &mut app.observer_scrollview_state);
     }
 
-    // Shared key / optional pub(K_sign) inputs + footer
-    let show_both_fields = !compact;
-    let input_chunks = if show_both_fields {
-        Layout::new(
-            Direction::Vertical,
-            [
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Length(2),
-            ],
-        )
-        .split(chunks[2])
-    } else {
-        Layout::new(
-            Direction::Vertical,
-            [Constraint::Length(3), Constraint::Length(2)],
-        )
-        .split(chunks[2])
-    };
+    // Shared key input + footer
+    let footer_height = if compact { 3 } else { 2 };
+    let input_chunks = Layout::new(
+        Direction::Vertical,
+        [Constraint::Length(3), Constraint::Length(footer_height)],
+    )
+    .split(chunks[2]);
 
     let focused_border = Style::default()
         .fg(PRIMARY_COLOR)
         .add_modifier(Modifier::BOLD);
-    let idle_border = Style::default().fg(Color::Gray);
     let title_style = Style::default()
         .fg(PRIMARY_COLOR)
         .add_modifier(Modifier::BOLD);
 
-    let conv_focused = app.observer_input_focus == ObserverInputField::ConvKey;
+    let conv_title = if compact {
+        "Shared key (hex)"
+    } else {
+        "Shared key (64-char hex, read-only grant)"
+    };
+
     let conv_input = Paragraph::new(app.observer_shared_key_input.as_str()).block(
         Block::default()
-            .title(Span::styled(
-                "Shared key (64-char hex, read-only grant)",
-                title_style,
-            ))
+            .title(Span::styled(conv_title, title_style))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(if conv_focused {
-                focused_border
-            } else {
-                idle_border
-            }),
+            .border_style(focused_border),
     );
-    let sign_input = Paragraph::new(app.observer_sign_pubkey_input.as_str()).block(
-        Block::default()
-            .title(Span::styled(
-                "pub(K_sign) optional locator (hex/npub)",
-                title_style,
-            ))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(if !conv_focused {
-                focused_border
-            } else {
-                idle_border
-            }),
-    );
+    f.render_widget(conv_input, input_chunks[0]);
 
-    if show_both_fields {
-        f.render_widget(conv_input, input_chunks[0]);
-        f.render_widget(sign_input, input_chunks[1]);
-    } else if conv_focused {
-        f.render_widget(conv_input, input_chunks[0]);
+    let footer_text = if compact {
+        // Shortened so shortcuts stay visible instead of clipping on narrow terminals.
+        "Ctrl+H:Help  Paste\n\
+Enter:Load  Esc:Clear  Ctrl+C:All\n\
+Ctrl+S:Save  \u{2191}\u{2193}/PgUp/PgDn:Scroll"
+            .to_string()
     } else {
-        f.render_widget(sign_input, input_chunks[0]);
-    }
-
-    let paste_hint = if cfg!(windows) {
-        "Shift+Insert / Ctrl+V / Ctrl+Shift+V / right-click"
-    } else {
-        "Ctrl+V / Ctrl+Shift+V / middle-click"
-    };
-    let footer = Paragraph::new(format!(
-        "Ctrl+H: Help | Tab: Switch Shared key / pub(K_sign) | Paste ({paste_hint})\n\
+        let paste_hint = if cfg!(windows) {
+            "Shift+Insert / Ctrl+V / Ctrl+Shift+V / right-click"
+        } else {
+            "Ctrl+V / Ctrl+Shift+V / middle-click"
+        };
+        format!(
+            "Ctrl+H: Help | Paste ({paste_hint})\n\
 Enter: Load chat | Esc: Clear error | Ctrl+C: Clear all | Ctrl+S: Save attachment | ↑↓/PgUp/PgDn: Scroll"
-    ));
-    let footer_idx = if show_both_fields { 2 } else { 1 };
-    f.render_widget(footer, input_chunks[footer_idx]);
+        )
+    };
+    let footer = Paragraph::new(footer_text);
+    f.render_widget(footer, input_chunks[1]);
 }
 
 #[cfg(test)]
@@ -263,12 +241,16 @@ mod tests {
             "missing Shared key field"
         );
         assert!(
-            buffer_contains(buf, "Never paste K_sign") || buffer_contains(buf, "K_sign"),
-            "missing K_sign warning"
+            buffer_contains(buf, "Never paste a signing key"),
+            "missing signing-key warning"
         );
         assert!(
             buffer_contains(buf, "read-only"),
             "missing read-only grant copy"
+        );
+        assert!(
+            !buffer_contains(buf, "Signer pubkey"),
+            "Signer pubkey input box should be removed"
         );
     }
 
@@ -323,5 +305,42 @@ mod tests {
             buffer_contains(buf, "Shared key"),
             "compact layout dropped Shared key"
         );
+    }
+
+    /// A narrow-but-tall terminal (plenty of height, insufficient width) should still
+    /// switch to the compact layout: abbreviated field labels and a shortened footer
+    /// so keyboard shortcuts stay fully on-screen instead of being clipped.
+    #[test]
+    fn observer_tab_narrow_width_uses_abbreviated_labels_and_footer() {
+        let buf = render_observer(&mut AppState::new(UserRole::Admin), 40, 24);
+
+        assert!(
+            buffer_contains(&buf, "Shared key (hex)"),
+            "narrow layout should use the abbreviated Shared key label"
+        );
+        assert!(
+            !buffer_contains(&buf, "Shared key (64-char hex, read-only grant)"),
+            "narrow layout should not use the full-width Shared key label"
+        );
+        // The long-form footer's second line never fits even at 80 columns, so its
+        // presence here would indicate clipped text rather than a rendered shortcut.
+        assert!(
+            !buffer_contains(&buf, "Ctrl+S: Save attachment"),
+            "narrow layout should not attempt to render the full-width footer"
+        );
+
+        for shortcut in [
+            "Ctrl+H:Help",
+            "Enter:Load",
+            "Esc:Clear",
+            "Ctrl+C:All",
+            "Ctrl+S:Save",
+            "Scroll",
+        ] {
+            assert!(
+                buffer_contains(&buf, shortcut),
+                "narrow footer is missing shortcut: {shortcut}"
+            );
+        }
     }
 }

--- a/src/ui/tabs/observer_tab.rs
+++ b/src/ui/tabs/observer_tab.rs
@@ -51,7 +51,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         Line::from(vec![
             Span::styled("Status: ", Style::default().fg(Color::Gray)),
             Span::styled(
-                "Paste K_conv and press Enter to load chat",
+                "Paste Shared key and press Enter to load chat",
                 Style::default().fg(Color::Gray),
             ),
         ])
@@ -68,7 +68,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
                         .fg(PRIMARY_COLOR)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::raw("  –  paste K_conv (read-only). Never paste K_sign."),
+                Span::raw("  –  paste Shared key (read-only). Never paste K_sign."),
             ]),
             status_line,
         ]
@@ -104,7 +104,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         let hint = if app.observer_loading {
             "Fetching messages..."
         } else {
-            "No messages yet. Paste K_conv and press Enter to load."
+            "No messages yet. Paste Shared key and press Enter to load."
         };
         let paragraph = Paragraph::new(Line::from(Span::styled(
             hint,
@@ -152,7 +152,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         f.render_stateful_widget(scroll_view, inner_area, &mut app.observer_scrollview_state);
     }
 
-    // K_conv / optional pub(K_sign) inputs + footer
+    // Shared key / optional pub(K_sign) inputs + footer
     let show_both_fields = !compact;
     let input_chunks = if show_both_fields {
         Layout::new(
@@ -184,7 +184,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
     let conv_input = Paragraph::new(app.observer_shared_key_input.as_str()).block(
         Block::default()
             .title(Span::styled(
-                "K_conv (64-char hex, read-only grant)",
+                "Shared key (64-char hex, read-only grant)",
                 title_style,
             ))
             .borders(Borders::ALL)
@@ -225,7 +225,7 @@ pub fn render_observer_tab(f: &mut ratatui::Frame, area: Rect, app: &mut AppStat
         "Ctrl+V / Ctrl+Shift+V / middle-click"
     };
     let footer = Paragraph::new(format!(
-        "Ctrl+H: Help | Tab: Switch K_conv / pub(K_sign) | Paste ({paste_hint})\n\
+        "Ctrl+H: Help | Tab: Switch Shared key / pub(K_sign) | Paste ({paste_hint})\n\
 Enter: Load chat | Esc: Clear error | Ctrl+C: Clear all | Ctrl+S: Save attachment | ↑↓/PgUp/PgDn: Scroll"
     ));
     let footer_idx = if show_both_fields { 2 } else { 1 };
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_tab_prompts_for_k_conv_not_ecdh() {
+    fn observer_tab_prompts_for_shared_key_not_ecdh() {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = AppState::new(UserRole::Admin);
@@ -258,7 +258,10 @@ mod tests {
             .draw(|f| render_observer_tab(f, f.area(), &mut app))
             .unwrap();
         let buf = terminal.backend().buffer();
-        assert!(buffer_contains(buf, "K_conv"), "missing K_conv field");
+        assert!(
+            buffer_contains(buf, "Shared key"),
+            "missing Shared key field"
+        );
         assert!(
             buffer_contains(buf, "Never paste K_sign") || buffer_contains(buf, "K_sign"),
             "missing K_sign warning"
@@ -308,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_tab_compact_height_keeps_k_conv_field() {
+    fn observer_tab_compact_height_keeps_shared_key_field() {
         let backend = TestBackend::new(80, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = AppState::new(UserRole::Admin);
@@ -317,8 +320,8 @@ mod tests {
             .unwrap();
         let buf = terminal.backend().buffer();
         assert!(
-            buffer_contains(buf, "K_conv"),
-            "compact layout dropped K_conv"
+            buffer_contains(buf, "Shared key"),
+            "compact layout dropped Shared key"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Renames the user-facing "K_conv" label to "Shared key" across the Observer tab, My Trades footer/help hints, and Shift+K validation errors. Protocol identifiers (`K_conv`, `K_sign`) in code, comments, and rustdoc are left unchanged.
- Adds a new `OperationResult::ConversationDisclosure` variant that renders a structured Shift+K popup showing the Shared key and `pub(K_sign)` hex, with an explicit warning not to share `K_sign`.
- Adds a `C` clipboard shortcut on the disclosure popup (mirrors the existing invoice-copy flow) so a solver can quickly copy their Shared key to send to an admin during a dispute, with a "✓ Shared key copied to clipboard!" confirmation.
- Generalizes the clipboard-copy key handler to accept any string (previously invoice-specific) and resets the "copied" indicator when any key other than `C` is pressed.
- Updates `docs/TUI_INTERFACE.md` and `docs/ADMIN_DISPUTES.md` (Observer Workflow, Keyboard Shortcuts, Observer State sections) to reflect the new terminology and copy shortcut.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features -- operation_result:: key_handler_tests:: observer_tab:: chat_render:: help_content_tests::observer` (22 passed)
- [ ] Manual smoke test: open a trade, press Shift+K, verify popup shows "Shared key", press `C`, confirm clipboard contains the value and confirmation message appears

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified Observer setup to use only the Shared key field.
  * Improved responsive layouts for narrow or short terminal windows.
  * Added reliable clipboard success reporting and copy-status reset behavior.
  * Updated disclosure views to display and copy only the Shared key.

* **Documentation**
  * Updated Observer and My Trades guidance to use generic signing-key terminology and reflect the streamlined workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->