### PR TITLE
fix(admin): close taken disputes after cooperative cancel

### DIFF
--- a/docs/ADMIN_DISPUTES.md
+++ b/docs/ADMIN_DISPUTES.md
@@ -263,8 +263,12 @@ pub enum Status {
 stateDiagram-v2
     [*] --> Initiated: Dispute Created
     Initiated --> InProgress: Admin Takes Dispute
+    Initiated --> SellerRefunded: Users cooperatively cancel
+    Initiated --> Settled: Seller releases
     InProgress --> SellerRefunded: Resolve for Seller
+    InProgress --> SellerRefunded: Users cooperatively cancel
     InProgress --> Settled: Resolve for Buyer
+    InProgress --> Settled: Seller releases
     Settled --> Released: Seller Releases
     SellerRefunded --> [*]: Dispute Closed
     Released --> [*]: Dispute Closed
@@ -428,6 +432,21 @@ Once a dispute is finalized (status: `Settled`, `SellerRefunded`, or `Released`)
 This multi-layered protection ensures that finalized disputes cannot be accidentally or maliciously modified.
 
 **Source**: `src/models.rs` (AdminDispute::is_finalized, can_settle, can_cancel), `src/util/order_utils/execute_finalize_dispute.rs`
+
+### Auto-close when users resolve the trade
+
+Mostro closes the dispute without a solver DM when the parties finish the trade themselves:
+
+| User action | Order status | Kind-38386 `s` tag | Local admin row |
+|---|---|---|---|
+| Cooperative cancel | `CooperativelyCanceled` | `seller-refunded` | Finalized (seller refunded) |
+| Seller release | `Success` / settled hold | `settled` | Finalized (settled) |
+
+Mostrix already subscribes to kind 38386 at startup (`fetch_scheduler` live sub + 30s snapshot). Taken `admin_disputes` rows are reconciled from those events (`relay_dispute_db_reconcile.rs`). The dispute **stays in the Disputes Management sidebar** so the header `Status` field can update to `seller-refunded` / `settled`; Shift+F is disabled. Navigating away drops it from the In Progress filter (it remains under Shift+C Finalized). If the admin still presses Resolve before that lands, Mostro replies `CooperativeCancelAccepted`; Mostrix treats that as already-closed (`SellerRefunded`) instead of showing `Unexpected action in response`.
+
+Untaken (`Initiated`) disputes disappear from the Pending tab as soon as the replacement event is no longer `initiated`.
+
+**Source**: `src/util/order_utils/relay_dispute_db_reconcile.rs`, `src/util/order_utils/fetch_scheduler.rs`
 
 ### Adding a Solver
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -346,6 +346,8 @@ When saving a dispute to the database, the following fields are validated:
 
 **Note**: The `admin_disputes` table is populated when an admin takes a dispute from the Mostro network. The admin receives a `SolverDisputeInfo` struct via direct message from Mostro, which is then persisted to this table.
 
+**Relay terminal reconcile**: `src/util/order_utils/relay_dispute_db_reconcile.rs` advances taken rows from kind-38386 `s` tags (`seller-refunded` / `settled` / `released`) when users cooperatively cancel or the seller releases. Live subscription + 30s snapshot in `fetch_scheduler.rs`; targeted `#d` fetches for leftover `in-progress` rows. Does not overwrite an already-finalized status.
+
 **Source**: `SolverDisputeInfo` struct definition (see [ADMIN_DISPUTES.md](ADMIN_DISPUTES.md#dispute-information-structure))
 
 **Source**: `src/models.rs:154`

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -11,7 +11,7 @@ This document describes how admins finalize disputes in Mostrix after reviewing 
 | **`mostro-core` 0.13.0** | Done | `BondResolution`, `Payload::BondResolution`, `CantDoReason::InvalidPayload`, `Status::WaitingMakerBond`, `Transport` |
 | **`BondSlashChoice`** | Done | [`src/util/order_utils/bond_resolution.rs`](../src/util/order_utils/bond_resolution.rs) — wire mapping + unit tests |
 | **Bond submenu overlay** | Done | [`src/ui/dispute_bond_slash_popup.rs`](../src/ui/dispute_bond_slash_popup.rs) — `render_bond_slash_overlay`; **TestBackend** unit tests for selection chrome |
-| **Execute layer** (`execute_admin_settle` / `cancel`) | Done | `request_id` + `wait_for_dm` + `handle_mostro_response`; expects `AdminSettled` / `AdminCanceled`; `CantDo` before DB update |
+| **Execute layer** (`execute_admin_settle` / `cancel`) | Done | `request_id` + `wait_for_dm` + `handle_mostro_response`; expects `AdminSettled` / `AdminCanceled`, or `CooperativeCancelAccepted` when users already canceled; `CantDo` before DB update |
 | **Success / error popup** | Done | `BondSlashChoice::finalize_success_message`; word-wrapped `OperationResult::Info` in `operation_result.rs` |
 | **TUI** (slash picker + confirm summary) | Done | Inline bond button + overlay; confirm shows `bond.label()` recap |
 | **`bond_enabled` gating** (kind 38385) | Done | Parse tag in [`mostro_info.rs`](../src/util/mostro_info.rs); hide Bond button when not `"true"` |
@@ -205,7 +205,7 @@ Call chain from the TUI (today):
 
 1. [`execute_finalize_dispute_action`](../src/ui/key_handler/admin_handlers.rs) — spawns async task with `bond` from `ConfirmFinalizeDispute` (chosen on the finalize popup / overlay).
 2. [`execute_finalize_dispute`](../src/util/order_utils/execute_finalize_dispute.rs) — DB guards, then dispatches settle or cancel with the same `bond`.
-3. [`execute_admin_settle`](../src/util/order_utils/execute_admin_settle.rs) / [`execute_admin_cancel`](../src/util/order_utils/execute_admin_cancel.rs) — `Message::new_dispute(..., bond.to_optional_payload())` with `request_id`, `wait_for_dm`, and `handle_mostro_response` (surfaces `CantDo` before DB update). Success requires `AdminSettled` / `AdminCanceled` from Mostro.
+3. [`execute_admin_settle`](../src/util/order_utils/execute_admin_settle.rs) / [`execute_admin_cancel`](../src/util/order_utils/execute_admin_cancel.rs) — `Message::new_dispute(..., bond.to_optional_payload())` with `request_id`, `wait_for_dm`, and `handle_mostro_response` (surfaces `CantDo` before DB update). Success is `AdminSettled` / `AdminCanceled`, or `CooperativeCancelAccepted` when the users already canceled (local status becomes `SellerRefunded`).
 
 Success popup (`OperationResult::Info`) is built by [`BondSlashChoice::finalize_success_message`](../src/util/order_utils/bond_resolution.rs) and rendered with newline-aware, word-boundary wrapping in [`operation_result.rs`](../src/ui/operation_result.rs) (dynamic popup height).
 

--- a/docs/FINALIZE_DISPUTES.md
+++ b/docs/FINALIZE_DISPUTES.md
@@ -252,8 +252,8 @@ After sending a finalization action, Mostro replies over the same admin DM chann
 
 | Request | Success action | Failure |
 |---------|----------------|---------|
-| `AdminSettle` | `AdminSettled` | `CantDo` (e.g. `InvalidPayload` for bad bond slash) |
-| `AdminCancel` | `AdminCanceled` | same |
+| `AdminSettle` | `AdminSettled` / `CooperativeCancelAccepted` | `CantDo` (e.g. `InvalidPayload` for bad bond slash) |
+| `AdminCancel` | `AdminCanceled` / `CooperativeCancelAccepted` | same |
 
 Mostrix waits with `wait_for_dm` and validates via `handle_mostro_response` before updating `admin_disputes`.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use crate::util::{
     blossom_servers_from_settings, handle_message_notification, handle_operation_result,
     install_background_panic_hook, order_utils::validate_range_amount, set_chat_router_cmd_tx,
     set_dm_router_cmd_tx, set_fatal_error_tx, set_order_result_tx, spawn_save_attachment,
-    spawn_send_order_chat_attachment,
+    spawn_send_order_chat_attachment, untrack_dispute_chat_parties,
 };
 use crossterm::event::EventStream;
 use mostro_core::prelude::*;
@@ -721,6 +721,23 @@ async fn main() -> Result<(), anyhow::Error> {
                 }
             };
             crate::ui::helpers::clamp_pending_dispute_selection(&mut app, &disputes_lock);
+            if app.user_role == UserRole::Admin {
+                let displayed_before =
+                    crate::ui::helpers::selected_filtered_dispute(&app).map(|d| d.dispute_id);
+                let closed =
+                    crate::util::order_utils::apply_terminal_relay_statuses_to_admin_disputes(
+                        &mut app.admin_disputes_in_progress,
+                        &disputes_lock,
+                    );
+                crate::ui::helpers::retain_closed_displayed_dispute(
+                    &mut app,
+                    displayed_before.as_deref(),
+                    &closed,
+                );
+                for dispute_id in closed {
+                    untrack_dispute_chat_parties(&dispute_id);
+                }
+            }
         }
 
         // Process async completions before draw so popups appear without extra keypresses.

--- a/src/models.rs
+++ b/src/models.rs
@@ -983,6 +983,40 @@ impl AdminDispute {
         Ok(dispute)
     }
 
+    /// Get a taken dispute by its Mostro dispute UUID (`admin_disputes.dispute_id`).
+    pub async fn get_by_dispute_id(
+        pool: &SqlitePool,
+        dispute_id: &str,
+    ) -> Result<Option<AdminDispute>> {
+        let mut dispute = sqlx::query_as::<_, AdminDispute>(
+            r#"SELECT * FROM admin_disputes WHERE dispute_id = ? LIMIT 1"#,
+        )
+        .bind(dispute_id)
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(ref mut dispute) = dispute {
+            dispute.deserialize_user_info();
+        }
+
+        Ok(dispute)
+    }
+
+    /// Dispute UUIDs still locally `in-progress` (targeted kind-38386 reconcile).
+    pub async fn list_in_progress_dispute_ids(pool: &SqlitePool) -> Result<Vec<String>> {
+        let rows = sqlx::query_as::<_, (String,)>(
+            r#"SELECT dispute_id FROM admin_disputes
+               WHERE status = ?
+                 AND dispute_id IS NOT NULL
+                 AND dispute_id != ''
+               ORDER BY dispute_id"#,
+        )
+        .bind(DisputeStatus::InProgress.to_string())
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Helper method to deserialize JSON UserInfo fields
     fn deserialize_user_info(&mut self) {
         if let Some(ref json_str) = self.initiator_info {
@@ -1057,14 +1091,34 @@ impl AdminDispute {
         Ok(())
     }
 
-    /// Check if the dispute is finalized (Settled, SellerRefunded, or Released)
+    /// Advance a taken dispute to `status` by Mostro dispute UUID.
     ///
-    /// A finalized dispute cannot have further actions taken on it.
-    pub fn is_finalized(&self) -> bool {
+    /// No-op (returns `false`) when the row is missing or already finalized, so a
+    /// later `seller-refunded` event cannot overwrite `settled`.
+    pub async fn set_status_by_dispute_id(
+        pool: &SqlitePool,
+        dispute_id: &str,
+        status: DisputeStatus,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"UPDATE admin_disputes SET status = ?
+               WHERE dispute_id = ?
+                 AND (status IS NULL OR status NOT IN (?, ?, ?))"#,
+        )
+        .bind(status.to_string())
+        .bind(dispute_id)
+        .bind(DisputeStatus::Settled.to_string())
+        .bind(DisputeStatus::SellerRefunded.to_string())
+        .bind(DisputeStatus::Released.to_string())
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Whether a kebab-case dispute status is terminal (Settled, SellerRefunded, Released).
+    pub fn is_terminal_status(status: &str) -> bool {
         use std::str::FromStr;
-        self.status
-            .as_deref()
-            .and_then(|s| DisputeStatus::from_str(s).ok())
+        DisputeStatus::from_str(status)
             .map(|s| {
                 matches!(
                     s,
@@ -1074,6 +1128,13 @@ impl AdminDispute {
                 )
             })
             .unwrap_or(false)
+    }
+
+    /// Check if the dispute is finalized (Settled, SellerRefunded, or Released)
+    ///
+    /// A finalized dispute cannot have further actions taken on it.
+    pub fn is_finalized(&self) -> bool {
+        self.status.as_deref().is_some_and(Self::is_terminal_status)
     }
 
     /// Check if AdminSettle action can be performed on this dispute

--- a/src/ui/helpers/chat_render.rs
+++ b/src/ui/helpers/chat_render.rs
@@ -67,7 +67,7 @@ fn format_message_lines(
     let (sender_label, sender_color, is_right_aligned) = match msg.sender {
         ChatSender::Admin => ("Admin", Color::Cyan, false),
         ChatSender::Buyer => ("Buyer", Color::Green, true),
-        ChatSender::Seller => ("Seller", Color::Magenta, false),
+        ChatSender::Seller => ("Seller", Color::Magenta, true),
     };
     let content_color = msg
         .attachment

--- a/src/ui/helpers/dispute_selection.rs
+++ b/src/ui/helpers/dispute_selection.rs
@@ -104,7 +104,15 @@ pub fn get_filtered_disputes(app: &AppState) -> Vec<(usize, AdminDispute)> {
                 .as_deref()
                 .and_then(|s| DisputeStatus::from_str(s).ok());
             match app.dispute_filter {
-                DisputeFilter::InProgress => status == Some(DisputeStatus::InProgress),
+                DisputeFilter::InProgress => {
+                    // Keep the highlighted dispute visible after auto-close so the
+                    // header can show the new status without the row vanishing.
+                    status == Some(DisputeStatus::InProgress)
+                        || app
+                            .selected_dispute_id
+                            .as_deref()
+                            .is_some_and(|id| d.dispute_id == id)
+                }
                 DisputeFilter::Finalized => matches!(
                     status,
                     Some(DisputeStatus::Settled)
@@ -156,6 +164,23 @@ pub fn move_dispute_selection(app: &mut AppState, delta: isize) {
         .saturating_add_signed(delta)
         .min(filtered.len().saturating_sub(1));
     app.selected_dispute_id = Some(filtered[new_idx].1.dispute_id.clone());
+}
+
+/// Persist the sidebar selection when that dispute just became terminal.
+///
+/// `displayed_before` is the dispute id shown before the status copy, including
+/// the first-row fallback when `selected_dispute_id` is unset.
+pub fn retain_closed_displayed_dispute(
+    app: &mut AppState,
+    displayed_before: Option<&str>,
+    closed_dispute_ids: &[String],
+) {
+    let Some(displayed_id) = displayed_before else {
+        return;
+    };
+    if closed_dispute_ids.iter().any(|id| id == displayed_id) {
+        app.selected_dispute_id = Some(displayed_id.to_string());
+    }
 }
 
 #[cfg(test)]
@@ -224,11 +249,10 @@ mod tests {
         assert_eq!(selected.dispute_id, "in-progress-d");
     }
 
-    /// When the selected dispute stops being visible under the current filter
-    /// (e.g. it was just finalized), resolution falls back to the first
-    /// visible row instead of a hidden one.
+    /// When the selected dispute is auto-closed (e.g. cooperative cancel), it
+    /// stays in the In Progress sidebar so the header can show the new status.
     #[test]
-    fn hidden_selection_falls_back_to_first_visible() {
+    fn selected_finalized_row_stays_visible_in_in_progress_filter() {
         let mut app = admin_app(vec![
             dispute("in-progress-c", "in-progress"),
             dispute("in-progress-d", "in-progress"),
@@ -238,9 +262,56 @@ mod tests {
         app.admin_disputes_in_progress[0] = dispute("in-progress-c", "seller-refunded");
 
         let filtered = get_filtered_disputes(&app);
-        assert_eq!(selected_display_idx(&app, &filtered), Some(0));
-        let selected = selected_filtered_dispute(&app).expect("fallback resolves");
-        assert_eq!(selected.dispute_id, "in-progress-d");
+        let ids: Vec<&str> = filtered
+            .iter()
+            .map(|(_, d)| d.dispute_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["in-progress-c", "in-progress-d"]);
+        let selected = selected_filtered_dispute(&app).expect("selection stays");
+        assert_eq!(selected.dispute_id, "in-progress-c");
+        assert_eq!(selected.status.as_deref(), Some("seller-refunded"));
+    }
+
+    #[test]
+    fn navigating_away_hides_unselected_finalized_row() {
+        let mut app = admin_app(vec![
+            dispute("in-progress-c", "seller-refunded"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+        app.selected_dispute_id = Some("in-progress-c".to_string());
+        assert_eq!(get_filtered_disputes(&app).len(), 2);
+
+        move_dispute_selection(&mut app, 1);
+        assert_eq!(app.selected_dispute_id.as_deref(), Some("in-progress-d"));
+        let filtered = get_filtered_disputes(&app);
+        let ids: Vec<&str> = filtered
+            .iter()
+            .map(|(_, d)| d.dispute_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["in-progress-d"]);
+    }
+
+    #[test]
+    fn retain_closed_pins_fallback_displayed_row() {
+        let mut app = admin_app(vec![
+            dispute("in-progress-c", "in-progress"),
+            dispute("in-progress-d", "in-progress"),
+        ]);
+        let displayed = selected_filtered_dispute(&app)
+            .expect("fallback selection")
+            .dispute_id;
+        assert_eq!(displayed, "in-progress-c");
+
+        app.admin_disputes_in_progress[0] = dispute("in-progress-c", "seller-refunded");
+        retain_closed_displayed_dispute(
+            &mut app,
+            Some(displayed.as_str()),
+            std::slice::from_ref(&displayed),
+        );
+        assert_eq!(app.selected_dispute_id.as_deref(), Some("in-progress-c"));
+        let selected = selected_filtered_dispute(&app).expect("pinned selection");
+        assert_eq!(selected.dispute_id, "in-progress-c");
+        assert_eq!(selected.status.as_deref(), Some("seller-refunded"));
     }
 
     /// The Finalized filter shows only settled/refunded/released disputes and

--- a/src/ui/helpers/formatting.rs
+++ b/src/ui/helpers/formatting.rs
@@ -204,5 +204,6 @@ mod premium_tests {
         assert_eq!(dispute_status_color(Some("settled")), Color::Green);
         assert_eq!(dispute_status_color(Some("initiated")), Color::Yellow);
         assert_eq!(dispute_status_color(None), Color::White);
+        assert_eq!(dispute_status_color(Some("unknown")), Color::White);
     }
 }

--- a/src/ui/helpers/formatting.rs
+++ b/src/ui/helpers/formatting.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Local, Utc};
-use mostro_core::prelude::UserInfo;
+use mostro_core::prelude::{DisputeStatus, UserInfo};
 use ratatui::style::Color;
+use std::str::FromStr;
 
 use crate::models::AdminDispute;
 
@@ -23,6 +24,17 @@ pub fn format_user_rating(info: Option<&UserInfo>) -> String {
 /// Check if a dispute is finalized (Settled, SellerRefunded, or Released).
 pub fn is_dispute_finalized(selected_dispute: &AdminDispute) -> Option<bool> {
     Some(selected_dispute.is_finalized())
+}
+
+/// Color for a kebab-case dispute status in the admin header/sidebar.
+pub fn dispute_status_color(status: Option<&str>) -> Color {
+    match status.and_then(|s| DisputeStatus::from_str(s).ok()) {
+        Some(DisputeStatus::Initiated) => Color::Yellow,
+        Some(DisputeStatus::InProgress) => Color::Green,
+        Some(DisputeStatus::Settled) | Some(DisputeStatus::Released) => Color::Green,
+        Some(DisputeStatus::SellerRefunded) => Color::Red,
+        None => Color::White,
+    }
 }
 
 /// Formats an order ID for display (truncates to 8 chars).
@@ -183,5 +195,14 @@ mod premium_tests {
         assert_eq!(format_premium(2), ("+2%".to_string(), Color::Green));
         assert_eq!(format_premium(-3), ("-3%".to_string(), Color::Red));
         assert_eq!(format_premium(0), ("0%".to_string(), Color::Gray));
+    }
+
+    #[test]
+    fn dispute_status_color_matches_lifecycle() {
+        assert_eq!(dispute_status_color(Some("in-progress")), Color::Green);
+        assert_eq!(dispute_status_color(Some("seller-refunded")), Color::Red);
+        assert_eq!(dispute_status_color(Some("settled")), Color::Green);
+        assert_eq!(dispute_status_color(Some("initiated")), Color::Yellow);
+        assert_eq!(dispute_status_color(None), Color::White);
     }
 }

--- a/src/ui/helpers/mod.rs
+++ b/src/ui/helpers/mod.rs
@@ -39,12 +39,13 @@ pub use chat_visibility::{
 };
 pub use dispute_selection::{
     clamp_pending_dispute_selection, get_filtered_disputes, get_initiated_disputes,
-    move_dispute_selection, move_pending_dispute_selection, selected_display_idx,
-    selected_filtered_dispute, selected_pending_display_idx, selected_pending_dispute,
+    move_dispute_selection, move_pending_dispute_selection, retain_closed_displayed_dispute,
+    selected_display_idx, selected_filtered_dispute, selected_pending_display_idx,
+    selected_pending_dispute,
 };
 pub use formatting::{
-    format_local_timestamp, format_order_id, format_premium, format_user_rating,
-    is_dispute_finalized, relative_time_compact, short_order_id,
+    dispute_status_color, format_local_timestamp, format_order_id, format_premium,
+    format_user_rating, is_dispute_finalized, relative_time_compact, short_order_id,
 };
 pub use layout::{
     create_centered_popup, render_help_text, render_table_list_scrollbar, render_yes_no_buttons,

--- a/src/ui/key_handler/admin_handlers.rs
+++ b/src/ui/key_handler/admin_handlers.rs
@@ -3,7 +3,7 @@ use crate::ui::key_handler::EnterKeyContext;
 use crate::ui::{AddSolverState, AdminMode, AppState, UiMode};
 use crate::util::fatal::request_fatal_restart;
 use crate::util::order_utils::{
-    execute_admin_add_solver, execute_finalize_dispute, BondSlashChoice,
+    execute_admin_add_solver, execute_finalize_dispute, AdminFinalizeAck, BondSlashChoice,
 };
 use uuid::Uuid;
 
@@ -175,10 +175,18 @@ pub(crate) fn execute_finalize_dispute_action(
         )
         .await
         {
-            Ok(_) => {
-                let _ = result_tx.send(OperationResult::Info(
-                    bond.finalize_success_message(dispute_id, is_settle),
-                ));
+            Ok(ack) => {
+                let msg = match ack {
+                    AdminFinalizeAck::Confirmed => {
+                        bond.finalize_success_message(dispute_id, is_settle)
+                    }
+                    AdminFinalizeAck::AlreadyCooperativelyCanceled => {
+                        format!(
+                            "Dispute finalized\n\nOutcome:\nCooperative cancellation accepted — seller refunded\n\nDispute ID:\n{dispute_id}"
+                        )
+                    }
+                };
+                let _ = result_tx.send(OperationResult::Info(msg));
             }
             Err(e) => {
                 log::error!("Failed to finalize dispute: {}", e);

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -91,11 +91,16 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         // Stateful List keeps the selected row in view when the sidebar overflows
         // (same pattern as Orders / Disputes Pending tables). Scrollbar uses the
         // shared data-row track helper after ListState computes its offset.
+        // Reserve: borders (2) + highlight symbol (2) + gap between id and status (2).
+        let inner_width = sidebar_area.width.saturating_sub(6) as usize;
         let items: Vec<ListItem> = filtered_disputes
             .iter()
             .map(|(_original_idx, d)| {
-                let truncated_id = truncate_dispute_id_label(&d.dispute_id, 16);
                 let status = d.status.as_deref().unwrap_or("unknown");
+                let id_budget = inner_width
+                    .saturating_sub(status.chars().count())
+                    .clamp(4, 16);
+                let truncated_id = truncate_dispute_id_label(&d.dispute_id, id_budget);
                 ListItem::new(Line::from(Span::styled(
                     format!("{truncated_id}  {status}"),
                     Style::default().fg(dispute_status_color(d.status.as_deref())),

--- a/src/ui/tabs/disputes_in_progress_tab.rs
+++ b/src/ui/tabs/disputes_in_progress_tab.rs
@@ -10,8 +10,8 @@ use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use crate::ui::constants::*;
 use crate::ui::helpers::{
-    build_chat_scrollview_content, count_visible_attachments, format_local_timestamp,
-    format_user_rating, get_filtered_disputes, get_selected_chat_message,
+    build_chat_scrollview_content, count_visible_attachments, dispute_status_color,
+    format_local_timestamp, format_user_rating, get_filtered_disputes, get_selected_chat_message,
     render_table_list_scrollbar,
 };
 use crate::ui::ChatParty;
@@ -94,10 +94,11 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
         let items: Vec<ListItem> = filtered_disputes
             .iter()
             .map(|(_original_idx, d)| {
-                let truncated_id = truncate_dispute_id_label(&d.dispute_id, 20);
+                let truncated_id = truncate_dispute_id_label(&d.dispute_id, 16);
+                let status = d.status.as_deref().unwrap_or("unknown");
                 ListItem::new(Line::from(Span::styled(
-                    format!("Dispute ID: {}", truncated_id),
-                    Style::default().fg(Color::White),
+                    format!("{truncated_id}  {status}"),
+                    Style::default().fg(dispute_status_color(d.status.as_deref())),
                 )))
             })
             .collect();
@@ -125,7 +126,7 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
     // 2. Main Area
     if let Some((_original_idx, ref selected_dispute)) = filtered_disputes.get(valid_selected_idx) {
         // Determine layout based on filter state
-        let is_finalized = app.dispute_filter == DisputeFilter::Finalized;
+        let is_finalized = selected_dispute.is_finalized();
 
         let main_chunks = if is_finalized {
             // For finalized disputes: no chat/input, just expanded header and footer
@@ -342,7 +343,9 @@ pub fn render_disputes_in_progress(f: &mut ratatui::Frame, area: Rect, app: &mut
                 Span::styled("Status: ", Style::default().fg(Color::Gray)),
                 Span::styled(
                     selected_dispute.status.as_deref().unwrap_or("Unknown"),
-                    Style::default().add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(dispute_status_color(selected_dispute.status.as_deref()))
+                        .add_modifier(Modifier::BOLD),
                 ),
             ]),
             Line::from(vec![

--- a/src/util/order_utils/execute_admin_cancel.rs
+++ b/src/util/order_utils/execute_admin_cancel.rs
@@ -85,11 +85,18 @@ pub async fn execute_admin_cancel(
     let inner_message = handle_mostro_response(response_message, request_id)?;
     let ack = admin_finalize_ack(inner_message.action.clone(), Action::AdminCanceled)?;
 
-    log::info!(
-        "✅ Admin cancel (refund seller) confirmed for order {} ({})",
-        order_id,
-        bond.log_context()
-    );
+    match &ack {
+        AdminFinalizeAck::Confirmed => log::info!(
+            "✅ Admin cancel (refund seller) confirmed for order {} ({})",
+            order_id,
+            bond.log_context()
+        ),
+        AdminFinalizeAck::AlreadyCooperativelyCanceled => log::info!(
+            "ℹ️ Order {} already cooperatively canceled ({})",
+            order_id,
+            bond.log_context()
+        ),
+    }
     Ok(ack)
 }
 

--- a/src/util/order_utils/execute_admin_cancel.rs
+++ b/src/util/order_utils/execute_admin_cancel.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 use super::BondSlashChoice;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
 use crate::util::mostro_info::MostroInstanceInfo;
-use crate::util::order_utils::helper::handle_mostro_response;
+use crate::util::order_utils::helper::{
+    admin_finalize_ack, handle_mostro_response, AdminFinalizeAck,
+};
 
 /// Cancel a dispute and refund the seller (AdminCancel action).
 /// This refunds the full escrow amount to the seller.
@@ -28,8 +30,9 @@ use crate::util::order_utils::helper::handle_mostro_response;
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` if Mostro confirms with `AdminCanceled`, or an error
-/// if the operation failed (including `CantDo` from the daemon).
+/// Returns `Ok(AdminFinalizeAck::Confirmed)` if Mostro confirms with `AdminCanceled`,
+/// `Ok(AdminFinalizeAck::AlreadyCooperativelyCanceled)` if the order was already
+/// cooperatively canceled, or an error if the operation failed (including `CantDo`).
 ///
 /// # Errors
 ///
@@ -47,7 +50,7 @@ pub async fn execute_admin_cancel(
     client: &Client,
     mostro_pubkey: PublicKey,
     mostro_instance: Option<&MostroInstanceInfo>,
-) -> Result<()> {
+) -> Result<AdminFinalizeAck> {
     let request_id = Uuid::new_v4().as_u128() as u64;
     let payload = bond.to_optional_payload();
     let cancel_message = Message::new_dispute(
@@ -80,19 +83,14 @@ pub async fn execute_admin_cancel(
     }
 
     let inner_message = handle_mostro_response(response_message, request_id)?;
-    if inner_message.action != Action::AdminCanceled {
-        return Err(anyhow::anyhow!(
-            "Unexpected action in response: {:?}",
-            inner_message.action
-        ));
-    }
+    let ack = admin_finalize_ack(inner_message.action.clone(), Action::AdminCanceled)?;
 
     log::info!(
         "✅ Admin cancel (refund seller) confirmed for order {} ({})",
         order_id,
         bond.log_context()
     );
-    Ok(())
+    Ok(ack)
 }
 
 #[cfg(test)]

--- a/src/util/order_utils/execute_admin_settle.rs
+++ b/src/util/order_utils/execute_admin_settle.rs
@@ -85,11 +85,18 @@ pub async fn execute_admin_settle(
     let inner_message = handle_mostro_response(response_message, request_id)?;
     let ack = admin_finalize_ack(inner_message.action.clone(), Action::AdminSettled)?;
 
-    log::info!(
-        "✅ Admin settle (pay buyer) confirmed for order {} ({})",
-        order_id,
-        bond.log_context()
-    );
+    match &ack {
+        AdminFinalizeAck::Confirmed => log::info!(
+            "✅ Admin settle (pay buyer) confirmed for order {} ({})",
+            order_id,
+            bond.log_context()
+        ),
+        AdminFinalizeAck::AlreadyCooperativelyCanceled => log::info!(
+            "ℹ️ Order {} already cooperatively canceled ({})",
+            order_id,
+            bond.log_context()
+        ),
+    }
     Ok(ack)
 }
 

--- a/src/util/order_utils/execute_admin_settle.rs
+++ b/src/util/order_utils/execute_admin_settle.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 use super::BondSlashChoice;
 use crate::util::dm_utils::{parse_dm_events, send_dm, wait_for_dm, FETCH_EVENTS_TIMEOUT};
 use crate::util::mostro_info::MostroInstanceInfo;
-use crate::util::order_utils::helper::handle_mostro_response;
+use crate::util::order_utils::helper::{
+    admin_finalize_ack, handle_mostro_response, AdminFinalizeAck,
+};
 
 /// Settle a dispute in favor of the buyer (AdminSettle action).
 /// This pays the full escrow amount to the buyer.
@@ -28,8 +30,9 @@ use crate::util::order_utils::helper::handle_mostro_response;
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` if Mostro confirms with `AdminSettled`, or an error
-/// if the operation failed (including `CantDo` from the daemon).
+/// Returns `Ok(AdminFinalizeAck::Confirmed)` if Mostro confirms with `AdminSettled`,
+/// `Ok(AdminFinalizeAck::AlreadyCooperativelyCanceled)` if the order was already
+/// cooperatively canceled, or an error if the operation failed (including `CantDo`).
 ///
 /// # Errors
 ///
@@ -47,7 +50,7 @@ pub async fn execute_admin_settle(
     client: &Client,
     mostro_pubkey: PublicKey,
     mostro_instance: Option<&MostroInstanceInfo>,
-) -> Result<()> {
+) -> Result<AdminFinalizeAck> {
     let request_id = Uuid::new_v4().as_u128() as u64;
     let payload = bond.to_optional_payload();
     let settle_message = Message::new_dispute(
@@ -80,19 +83,14 @@ pub async fn execute_admin_settle(
     }
 
     let inner_message = handle_mostro_response(response_message, request_id)?;
-    if inner_message.action != Action::AdminSettled {
-        return Err(anyhow::anyhow!(
-            "Unexpected action in response: {:?}",
-            inner_message.action
-        ));
-    }
+    let ack = admin_finalize_ack(inner_message.action.clone(), Action::AdminSettled)?;
 
     log::info!(
         "✅ Admin settle (pay buyer) confirmed for order {} ({})",
         order_id,
         bond.log_context()
     );
-    Ok(())
+    Ok(ack)
 }
 
 #[cfg(test)]

--- a/src/util/order_utils/execute_finalize_dispute.rs
+++ b/src/util/order_utils/execute_finalize_dispute.rs
@@ -9,6 +9,7 @@ use crate::util::chat_listener::untrack_dispute_chat_parties;
 use crate::util::mostro_info::MostroInstanceInfo;
 
 use super::{execute_admin_cancel, execute_admin_settle, BondSlashChoice};
+use crate::util::order_utils::helper::AdminFinalizeAck;
 
 /// Finalize a dispute by either settling (paying buyer) or canceling (refunding seller).
 ///
@@ -32,8 +33,8 @@ use super::{execute_admin_cancel, execute_admin_settle, BondSlashChoice};
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` if the finalization message was successfully sent and the database
-/// was updated, or an error if the operation failed.
+/// Returns `Ok(AdminFinalizeAck)` if the message was sent and the database was
+/// updated, or an error if the operation failed.
 ///
 /// # Errors
 ///
@@ -55,7 +56,7 @@ pub async fn execute_finalize_dispute(
     pool: &SqlitePool,
     is_settle: bool,
     mostro_instance: Option<&MostroInstanceInfo>,
-) -> Result<()> {
+) -> Result<AdminFinalizeAck> {
     let dispute_id_str = dispute_id.to_string();
     let dispute: AdminDispute = sqlx::query_as::<_, AdminDispute>(
         r#"SELECT * FROM admin_disputes WHERE dispute_id = ? LIMIT 1"#,
@@ -93,7 +94,7 @@ pub async fn execute_finalize_dispute(
 
     let order_id = Uuid::parse_str(&dispute.id)?;
 
-    let result = if is_settle {
+    let ack = if is_settle {
         execute_admin_settle(
             &order_id,
             bond,
@@ -102,7 +103,7 @@ pub async fn execute_finalize_dispute(
             mostro_pubkey,
             mostro_instance,
         )
-        .await
+        .await?
     } else {
         execute_admin_cancel(
             &order_id,
@@ -112,21 +113,22 @@ pub async fn execute_finalize_dispute(
             mostro_pubkey,
             mostro_instance,
         )
-        .await
+        .await?
     };
 
-    result?;
-
-    if is_settle {
-        AdminDispute::set_status_settled(pool, &dispute.id).await?;
-    } else {
+    let cooperatively_canceled = matches!(ack, AdminFinalizeAck::AlreadyCooperativelyCanceled);
+    if cooperatively_canceled || !is_settle {
         AdminDispute::set_status_seller_refunded(pool, &dispute.id).await?;
+    } else {
+        AdminDispute::set_status_settled(pool, &dispute.id).await?;
     }
 
     // Dispute left InProgress: drop buyer/seller shared-key chat subscriptions.
     untrack_dispute_chat_parties(&dispute_id_str);
 
-    let action_name = if is_settle {
+    let action_name = if cooperatively_canceled {
+        "closed (cooperative cancellation accepted)"
+    } else if is_settle {
         "settled (buyer paid)"
     } else {
         "canceled (seller refunded)"
@@ -138,5 +140,5 @@ pub async fn execute_finalize_dispute(
         action_name,
         bond.log_context()
     );
-    Ok(())
+    Ok(ack)
 }

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -83,9 +83,24 @@ fn apply_live_order_update(orders: &Arc<Mutex<Vec<SmallOrder>>>, order: SmallOrd
     );
 }
 
-fn apply_live_dispute_update(disputes: &Arc<Mutex<Vec<Dispute>>>, dispute: Dispute) {
+fn apply_live_dispute_update_inner(disputes: &mut Vec<Dispute>, dispute: Dispute) {
     let dispute_id = dispute.id;
     let dispute_status = dispute.status.clone();
+    if let Some(existing) = disputes.iter_mut().find(|e| e.id == dispute.id) {
+        *existing = dispute;
+    } else {
+        disputes.push(dispute);
+    }
+    disputes.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+    log::debug!(
+        "[disputes_live] upserted dispute_id={} status={} total_disputes={}",
+        dispute_id,
+        dispute_status,
+        disputes.len()
+    );
+}
+
+fn apply_live_dispute_update(disputes: &Arc<Mutex<Vec<Dispute>>>, dispute: Dispute) {
     let mut disputes_lock = match disputes.lock() {
         Ok(guard) => guard,
         Err(e) => {
@@ -95,26 +110,7 @@ fn apply_live_dispute_update(disputes: &Arc<Mutex<Vec<Dispute>>>, dispute: Dispu
             return;
         }
     };
-    // Live subscription is `.since(now)` — always take the incoming revision.
-    // Do not compare `dispute.created_at`: after Mostro #878 that field is the
-    // stable open-time tag, not the Nostr publish stamp, so a status update
-    // would otherwise fail to replace when open times are equal (or when a
-    // tagged open time is older than a legacy event-stamp fallback).
-    if let Some(existing) = disputes_lock
-        .iter_mut()
-        .find(|existing| existing.id == dispute.id)
-    {
-        *existing = dispute;
-    } else {
-        disputes_lock.push(dispute);
-    }
-    disputes_lock.sort_by_key(|b| std::cmp::Reverse(b.created_at));
-    log::debug!(
-        "[disputes_live] upserted dispute_id={} status={} total_disputes={}",
-        dispute_id,
-        dispute_status,
-        disputes_lock.len()
-    );
+    apply_live_dispute_update_inner(&mut disputes_lock, dispute);
 }
 
 /// Start background tasks to periodically fetch orders and disputes
@@ -378,7 +374,7 @@ pub fn spawn_fetch_scheduler_loops(
                                     return;
                                 }
                             };
-                        if let Ok(fetched_disputes) =
+                        let seen: std::collections::HashSet<Uuid> = if let Ok(fetched_disputes) =
                             get_disputes(&client_for_disputes, mostro_pubkey_for_disputes).await
                         {
                             reconcile_terminal_admin_disputes_from_relay(
@@ -388,20 +384,6 @@ pub fn spawn_fetch_scheduler_loops(
                             .await;
                             let seen: std::collections::HashSet<Uuid> =
                                 fetched_disputes.iter().map(|d| d.id).collect();
-                            if let Err(e) = run_targeted_relay_dispute_db_reconcile_tick(
-                                &client_for_disputes,
-                                &pool_for_disputes,
-                                mostro_pubkey_for_disputes,
-                                &targeted_dispute_reconcile_cursor,
-                                &seen,
-                            )
-                            .await
-                            {
-                                log::warn!(
-                                    "[disputes_reconcile_targeted] relay DB status reconcile failed: {}",
-                                    e
-                                );
-                            }
                             let mut disputes_lock = match disputes_clone.lock() {
                                 Ok(g) => g,
                                 Err(e) => {
@@ -417,6 +399,42 @@ pub fn spawn_fetch_scheduler_loops(
                                 "[disputes_reconcile] refreshed disputes count={}",
                                 disputes_lock.len()
                             );
+                            drop(disputes_lock);
+                            seen
+                        } else {
+                            std::collections::HashSet::new()
+                        };
+                        match run_targeted_relay_dispute_db_reconcile_tick(
+                            &client_for_disputes,
+                            &pool_for_disputes,
+                            mostro_pubkey_for_disputes,
+                            &targeted_dispute_reconcile_cursor,
+                            &seen,
+                        )
+                        .await
+                        {
+                            Ok(resolved) => {
+                                if !resolved.is_empty() {
+                                    let mut disputes_lock = match disputes_clone.lock() {
+                                        Ok(g) => g,
+                                        Err(e) => {
+                                            crate::util::request_fatal_restart(format!(
+                                                "Mostrix encountered an internal error while reconciling disputes (poisoned disputes lock: {e}). Please restart the app."
+                                            ));
+                                            return;
+                                        }
+                                    };
+                                    for d in resolved {
+                                        apply_live_dispute_update_inner(&mut disputes_lock, d);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "[disputes_reconcile_targeted] relay DB status reconcile failed: {}",
+                                    e
+                                );
+                            }
                         }
                     }
                     notification = notifications.next() => {

--- a/src/util/order_utils/fetch_scheduler.rs
+++ b/src/util/order_utils/fetch_scheduler.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 use futures::StreamExt;
 use mostro_core::prelude::*;
@@ -14,6 +15,10 @@ use sqlx::SqlitePool;
 use super::get_disputes;
 use super::helper::{
     aggregate_latest_orders_by_id, fetch_mostro_order_events, pending_orders_for_book,
+};
+use super::relay_dispute_db_reconcile::{
+    reconcile_one_admin_dispute_if_terminal, reconcile_terminal_admin_disputes_from_relay,
+    run_targeted_relay_dispute_db_reconcile_tick,
 };
 use super::relay_order_db_reconcile::{
     reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,
@@ -323,6 +328,7 @@ pub fn spawn_fetch_scheduler_loops(
     // Spawn task to periodically fetch disputes
     let disputes_clone = Arc::clone(&disputes);
     let client_for_disputes = client.clone();
+    let pool_for_disputes = pool.clone();
     let current_mostro_pubkey_for_disputes = Arc::clone(&current_mostro_pubkey);
     let dispute_task = tokio::spawn(async move {
         catch_unwind_request_fatal_restart("disputes scheduler", async move {
@@ -358,6 +364,7 @@ pub fn spawn_fetch_scheduler_loops(
                 Instant::now(),
                 Duration::from_secs(RECONCILIATION_INTERVAL_SECS),
             );
+            let targeted_dispute_reconcile_cursor = Arc::new(Mutex::new(0usize));
             loop {
                 tokio::select! {
                     _ = refresh_interval.tick() => {
@@ -374,6 +381,27 @@ pub fn spawn_fetch_scheduler_loops(
                         if let Ok(fetched_disputes) =
                             get_disputes(&client_for_disputes, mostro_pubkey_for_disputes).await
                         {
+                            reconcile_terminal_admin_disputes_from_relay(
+                                &pool_for_disputes,
+                                &fetched_disputes,
+                            )
+                            .await;
+                            let seen: std::collections::HashSet<Uuid> =
+                                fetched_disputes.iter().map(|d| d.id).collect();
+                            if let Err(e) = run_targeted_relay_dispute_db_reconcile_tick(
+                                &client_for_disputes,
+                                &pool_for_disputes,
+                                mostro_pubkey_for_disputes,
+                                &targeted_dispute_reconcile_cursor,
+                                &seen,
+                            )
+                            .await
+                            {
+                                log::warn!(
+                                    "[disputes_reconcile_targeted] relay DB status reconcile failed: {}",
+                                    e
+                                );
+                            }
                             let mut disputes_lock = match disputes_clone.lock() {
                                 Ok(g) => g,
                                 Err(e) => {
@@ -411,6 +439,11 @@ pub fn spawn_fetch_scheduler_loops(
                             parsed.len()
                         );
                         if let Some(dispute) = parsed.pop() {
+                            reconcile_one_admin_dispute_if_terminal(
+                                &pool_for_disputes,
+                                &dispute,
+                            )
+                            .await;
                             apply_live_dispute_update(&disputes_clone, dispute);
                         }
                     }

--- a/src/util/order_utils/helper.rs
+++ b/src/util/order_utils/helper.rs
@@ -148,6 +148,29 @@ pub(crate) fn is_terminal_trade_status(status: Status) -> bool {
     )
 }
 
+/// Outcome of an admin settle/cancel request after Mostro replies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdminFinalizeAck {
+    /// Mostro confirmed `AdminSettled` or `AdminCanceled`.
+    Confirmed,
+    /// Order was already cooperatively canceled; Mostro replied `CooperativeCancelAccepted`.
+    AlreadyCooperativelyCanceled,
+}
+
+/// Map a settle/cancel DM action to [`AdminFinalizeAck`].
+pub(super) fn admin_finalize_ack(action: Action, expected: Action) -> Result<AdminFinalizeAck> {
+    if action == expected {
+        Ok(AdminFinalizeAck::Confirmed)
+    } else if action == Action::CooperativeCancelAccepted {
+        Ok(AdminFinalizeAck::AlreadyCooperativelyCanceled)
+    } else {
+        Err(anyhow::anyhow!(
+            "Unexpected action in response: {:?}",
+            action
+        ))
+    }
+}
+
 /// Guard status writes against backward transitions from stale/out-of-order DMs.
 ///
 /// Returns `true` when `candidate` is equal/newer than `current` in the actor-aware phase graph.
@@ -532,6 +555,34 @@ pub async fn fetch_small_order_by_id_from_relay(
     Ok(Some(order_from_tags(best.tags.clone())?))
 }
 
+/// Fetch the latest kind-38386 [`Dispute`] for one dispute id (`d` tag).
+///
+/// Uses `limit(10)` and picks the event with the greatest [`Event::created_at`].
+pub async fn fetch_dispute_by_id_from_relay(
+    client: &Client,
+    mostro_pubkey: PublicKey,
+    dispute_id: Uuid,
+) -> Result<Option<Dispute>> {
+    let filter = Filter::new()
+        .author(mostro_pubkey)
+        .kind(nostr_sdk::prelude::Kind::Custom(NOSTR_DISPUTE_EVENT_KIND))
+        .identifier(dispute_id.to_string())
+        .limit(10);
+    let events = client
+        .fetch_events(filter)
+        .timeout(FETCH_EVENTS_TIMEOUT)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to fetch dispute from relay by id: {}", e))?;
+    let Some(best) = events.iter().max_by_key(|e| e.created_at) else {
+        return Ok(None);
+    };
+    let mut dispute = dispute_from_tags(best.tags.clone())?;
+    if dispute.created_at <= 0 {
+        dispute.created_at = best.created_at.as_secs() as i64;
+    }
+    Ok(Some(dispute))
+}
+
 /// Fetch a single order's fiat code from the relay by order id (identifier "d" tag).
 /// Used when the order is not in the local DB (e.g. admin taking a dispute for an order they did not create).
 pub async fn fetch_order_fiat_from_relay(
@@ -733,8 +784,9 @@ pub(super) fn handle_mostro_response(
 #[cfg(test)]
 mod tests {
     use super::{
-        dispute_from_tags, inferred_status_from_trade_action, is_terminal_trade_status,
-        parse_disputes_events, should_apply_status_transition, should_strictly_advance_status,
+        admin_finalize_ack, dispute_from_tags, inferred_status_from_trade_action,
+        is_terminal_trade_status, parse_disputes_events, should_apply_status_transition,
+        should_strictly_advance_status, AdminFinalizeAck,
     };
     use crate::models::TERMINAL_ORDER_HISTORY_STATUSES;
     use mostro_core::prelude::{Action, DisputeStatus, Status, NOSTR_DISPUTE_EVENT_KIND};
@@ -946,5 +998,26 @@ mod tests {
             Status::WaitingPayment,
             kind,
         ));
+    }
+
+    #[test]
+    fn admin_finalize_ack_accepts_expected_and_cooperative_cancel() {
+        assert_eq!(
+            admin_finalize_ack(Action::AdminCanceled, Action::AdminCanceled).unwrap(),
+            AdminFinalizeAck::Confirmed
+        );
+        assert_eq!(
+            admin_finalize_ack(Action::AdminSettled, Action::AdminSettled).unwrap(),
+            AdminFinalizeAck::Confirmed
+        );
+        assert_eq!(
+            admin_finalize_ack(Action::CooperativeCancelAccepted, Action::AdminCanceled).unwrap(),
+            AdminFinalizeAck::AlreadyCooperativelyCanceled
+        );
+        assert_eq!(
+            admin_finalize_ack(Action::CooperativeCancelAccepted, Action::AdminSettled).unwrap(),
+            AdminFinalizeAck::AlreadyCooperativelyCanceled
+        );
+        assert!(admin_finalize_ack(Action::Canceled, Action::AdminCanceled).is_err());
     }
 }

--- a/src/util/order_utils/mod.rs
+++ b/src/util/order_utils/mod.rs
@@ -9,6 +9,7 @@ mod execute_send_msg;
 mod execute_take_dispute;
 mod fetch_scheduler;
 mod helper;
+mod relay_dispute_db_reconcile;
 mod relay_order_db_reconcile;
 mod send_new_order;
 mod take_order;
@@ -30,6 +31,11 @@ pub use helper::{
     get_disputes, get_orders, inferred_status_from_trade_action, map_action_to_status,
     order_from_tags, parse_disputes_events, parse_orders_events, pending_orders_for_book,
     should_apply_status_transition, should_strictly_advance_status, validate_range_amount,
+    AdminFinalizeAck,
+};
+pub use relay_dispute_db_reconcile::{
+    apply_terminal_relay_statuses_to_admin_disputes, reconcile_one_admin_dispute_if_terminal,
+    reconcile_terminal_admin_disputes_from_relay, run_targeted_relay_dispute_db_reconcile_tick,
 };
 pub use relay_order_db_reconcile::{
     reconcile_one_order_if_terminal, reconcile_terminal_order_statuses_from_relay,

--- a/src/util/order_utils/relay_dispute_db_reconcile.rs
+++ b/src/util/order_utils/relay_dispute_db_reconcile.rs
@@ -88,24 +88,30 @@ pub async fn reconcile_terminal_admin_disputes_from_relay(
 }
 
 /// Per-dispute `#d` fetch for local InProgress rows missing from the latest snapshot.
+///
+/// Returns terminal disputes fetched from relays so the caller can feed them into
+/// the shared live dispute vec (ensuring the UI stays in sync with DB updates).
 pub async fn run_targeted_relay_dispute_db_reconcile_tick(
     client: &Client,
     pool: &SqlitePool,
     mostro_pubkey: PublicKey,
     cursor: &Arc<Mutex<usize>>,
     already_seen: &HashSet<Uuid>,
-) -> Result<()> {
+) -> Result<Vec<Dispute>> {
     let ids = AdminDispute::list_in_progress_dispute_ids(pool).await?;
-    let ids: Vec<String> = ids
+    let ids: Vec<(Uuid, String)> = ids
         .into_iter()
-        .filter(|id| {
-            Uuid::parse_str(id)
-                .ok()
-                .is_none_or(|u| !already_seen.contains(&u))
+        .filter_map(|id| {
+            let uuid = Uuid::parse_str(&id).ok()?;
+            if already_seen.contains(&uuid) {
+                None
+            } else {
+                Some((uuid, id))
+            }
         })
         .collect();
     if ids.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     let len = ids.len();
     let (start, take) = {
@@ -116,21 +122,15 @@ pub async fn run_targeted_relay_dispute_db_reconcile_tick(
         let take = TARGETED_RELAY_RECONCILE_MAX_PER_TICK.min(len);
         (start, take)
     };
+    let mut resolved = Vec::new();
     for i in 0..take {
-        let id_str = &ids[(start + i) % len];
-        let dispute_id = match Uuid::parse_str(id_str) {
-            Ok(u) => u,
-            Err(_) => {
-                log::debug!(
-                    "[disputes_reconcile_targeted] skip invalid dispute id in DB: {}",
-                    id_str
-                );
-                continue;
-            }
-        };
-        match fetch_dispute_by_id_from_relay(client, mostro_pubkey, dispute_id).await {
+        let (dispute_id, _) = &ids[(start + i) % len];
+        match fetch_dispute_by_id_from_relay(client, mostro_pubkey, *dispute_id).await {
             Ok(Some(relay_dispute)) => {
                 reconcile_one_admin_dispute_if_terminal(pool, &relay_dispute).await;
+                if AdminDispute::is_terminal_status(&relay_dispute.status) {
+                    resolved.push(relay_dispute);
+                }
             }
             Ok(None) => {
                 log::debug!(
@@ -153,7 +153,7 @@ pub async fn run_targeted_relay_dispute_db_reconcile_tick(
             .map_err(|_| anyhow::anyhow!("targeted dispute reconcile cursor mutex poisoned"))?;
         *c = (start + take) % len;
     }
-    Ok(())
+    Ok(resolved)
 }
 
 #[cfg(test)]

--- a/src/util/order_utils/relay_dispute_db_reconcile.rs
+++ b/src/util/order_utils/relay_dispute_db_reconcile.rs
@@ -1,0 +1,350 @@
+//! Align local `admin_disputes` rows with terminal statuses seen on kind-38386 events.
+//!
+//! Mostro auto-closes a dispute on cooperative cancel (`seller-refunded`) or seller
+//! release (`settled`) by publishing a NIP-33 replacement. It does not DM the solver,
+//! so taken rows must be advanced from that event.
+
+use anyhow::Result;
+use mostro_core::prelude::*;
+use nostr_sdk::prelude::*;
+use sqlx::SqlitePool;
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+use crate::models::AdminDispute;
+use crate::util::chat_listener::untrack_dispute_chat_parties;
+
+use super::helper::fetch_dispute_by_id_from_relay;
+use super::relay_order_db_reconcile::TARGETED_RELAY_RECONCILE_MAX_PER_TICK;
+
+/// Copy terminal kind-38386 statuses onto matching in-memory taken rows.
+///
+/// Returns dispute ids whose local status actually changed (for chat untrack).
+pub fn apply_terminal_relay_statuses_to_admin_disputes(
+    admin_disputes: &mut [AdminDispute],
+    relay_disputes: &[Dispute],
+) -> Vec<String> {
+    let mut closed = Vec::new();
+    for relay in relay_disputes {
+        if !AdminDispute::is_terminal_status(&relay.status) {
+            continue;
+        }
+        let relay_id = relay.id.to_string();
+        let Some(local) = admin_disputes.iter_mut().find(|d| d.dispute_id == relay_id) else {
+            continue;
+        };
+        if local.is_finalized() {
+            continue;
+        }
+        if local.status.as_deref() == Some(relay.status.as_str()) {
+            continue;
+        }
+        local.status = Some(relay.status.clone());
+        closed.push(relay_id);
+    }
+    closed
+}
+
+/// If `relay_dispute` is terminal and a non-finalized local row exists, update SQLite.
+pub async fn reconcile_one_admin_dispute_if_terminal(pool: &SqlitePool, relay_dispute: &Dispute) {
+    if !AdminDispute::is_terminal_status(&relay_dispute.status) {
+        return;
+    }
+    let Ok(status) = DisputeStatus::from_str(&relay_dispute.status) else {
+        return;
+    };
+    let dispute_id = relay_dispute.id.to_string();
+    match AdminDispute::set_status_by_dispute_id(pool, &dispute_id, status).await {
+        Ok(true) => {
+            log::info!(
+                "Relay reconcile: dispute {} advanced to {}",
+                dispute_id,
+                relay_dispute.status
+            );
+            untrack_dispute_chat_parties(&dispute_id);
+        }
+        Ok(false) => {}
+        Err(e) => {
+            log::warn!(
+                "Relay reconcile: failed to update dispute {} to {}: {}",
+                dispute_id,
+                relay_dispute.status,
+                e
+            );
+        }
+    }
+}
+
+/// Apply [`reconcile_one_admin_dispute_if_terminal`] for each snapshot row.
+pub async fn reconcile_terminal_admin_disputes_from_relay(
+    pool: &SqlitePool,
+    relay_disputes: &[Dispute],
+) {
+    for relay_dispute in relay_disputes {
+        reconcile_one_admin_dispute_if_terminal(pool, relay_dispute).await;
+    }
+}
+
+/// Per-dispute `#d` fetch for local InProgress rows missing from the latest snapshot.
+pub async fn run_targeted_relay_dispute_db_reconcile_tick(
+    client: &Client,
+    pool: &SqlitePool,
+    mostro_pubkey: PublicKey,
+    cursor: &Arc<Mutex<usize>>,
+    already_seen: &HashSet<Uuid>,
+) -> Result<()> {
+    let ids = AdminDispute::list_in_progress_dispute_ids(pool).await?;
+    let ids: Vec<String> = ids
+        .into_iter()
+        .filter(|id| {
+            Uuid::parse_str(id)
+                .ok()
+                .is_none_or(|u| !already_seen.contains(&u))
+        })
+        .collect();
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let len = ids.len();
+    let (start, take) = {
+        let c = cursor
+            .lock()
+            .map_err(|_| anyhow::anyhow!("targeted dispute reconcile cursor mutex poisoned"))?;
+        let start = *c % len;
+        let take = TARGETED_RELAY_RECONCILE_MAX_PER_TICK.min(len);
+        (start, take)
+    };
+    for i in 0..take {
+        let id_str = &ids[(start + i) % len];
+        let dispute_id = match Uuid::parse_str(id_str) {
+            Ok(u) => u,
+            Err(_) => {
+                log::debug!(
+                    "[disputes_reconcile_targeted] skip invalid dispute id in DB: {}",
+                    id_str
+                );
+                continue;
+            }
+        };
+        match fetch_dispute_by_id_from_relay(client, mostro_pubkey, dispute_id).await {
+            Ok(Some(relay_dispute)) => {
+                reconcile_one_admin_dispute_if_terminal(pool, &relay_dispute).await;
+            }
+            Ok(None) => {
+                log::debug!(
+                    "[disputes_reconcile_targeted] no relay event for dispute_id={}",
+                    dispute_id
+                );
+            }
+            Err(e) => {
+                log::debug!(
+                    "[disputes_reconcile_targeted] fetch failed dispute_id={}: {}",
+                    dispute_id,
+                    e
+                );
+            }
+        }
+    }
+    {
+        let mut c = cursor
+            .lock()
+            .map_err(|_| anyhow::anyhow!("targeted dispute reconcile cursor mutex poisoned"))?;
+        *c = (start + take) % len;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+
+    async fn test_pool() -> SqlitePool {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory pool")
+    }
+
+    async fn create_admin_disputes_table(pool: &SqlitePool) {
+        sqlx::query(
+            r#"
+            CREATE TABLE admin_disputes (
+                id TEXT PRIMARY KEY,
+                dispute_id TEXT NOT NULL,
+                kind TEXT,
+                status TEXT,
+                hash TEXT,
+                preimage TEXT,
+                order_previous_status TEXT,
+                initiator_pubkey TEXT NOT NULL,
+                buyer_pubkey TEXT,
+                seller_pubkey TEXT,
+                initiator_full_privacy INTEGER NOT NULL,
+                counterpart_full_privacy INTEGER NOT NULL,
+                initiator_info TEXT,
+                counterpart_info TEXT,
+                premium INTEGER NOT NULL,
+                payment_method TEXT NOT NULL,
+                amount INTEGER NOT NULL,
+                fiat_amount INTEGER NOT NULL,
+                fiat_code TEXT NOT NULL,
+                fee INTEGER NOT NULL,
+                routing_fee INTEGER NOT NULL,
+                buyer_invoice TEXT,
+                invoice_held_at INTEGER,
+                taken_at INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                buyer_chat_last_seen INTEGER,
+                seller_chat_last_seen INTEGER,
+                buyer_shared_key_hex TEXT,
+                seller_shared_key_hex TEXT
+            );
+            "#,
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_admin_dispute(pool: &SqlitePool, dispute_id: &str, status: &str) {
+        sqlx::query(
+            r#"INSERT INTO admin_disputes (
+                id, dispute_id, initiator_pubkey, initiator_full_privacy,
+                counterpart_full_privacy, premium, payment_method, amount, fiat_amount,
+                fiat_code, fee, routing_fee, taken_at, created_at, status
+            ) VALUES (?, ?, 'npub1initiator', 0, 0, 0, 'sepa', 0, 0, 'USD', 0, 0, 1, 1, ?)"#,
+        )
+        .bind(format!("order-{dispute_id}"))
+        .bind(dispute_id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn relay_dispute(id: Uuid, status: &str) -> Dispute {
+        Dispute {
+            id,
+            status: status.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn admin_row(dispute_id: &str, status: &str) -> AdminDispute {
+        AdminDispute {
+            dispute_id: dispute_id.to_string(),
+            status: Some(status.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_updates_in_progress_row_when_relay_seller_refunded() {
+        let pool = test_pool().await;
+        create_admin_disputes_table(&pool).await;
+        let id = Uuid::new_v4();
+        insert_admin_dispute(&pool, &id.to_string(), "in-progress").await;
+
+        reconcile_one_admin_dispute_if_terminal(&pool, &relay_dispute(id, "seller-refunded")).await;
+
+        let row = AdminDispute::get_by_dispute_id(&pool, &id.to_string())
+            .await
+            .unwrap()
+            .expect("row exists");
+        assert_eq!(row.status.as_deref(), Some("seller-refunded"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_updates_in_progress_row_when_relay_settled() {
+        let pool = test_pool().await;
+        create_admin_disputes_table(&pool).await;
+        let id = Uuid::new_v4();
+        insert_admin_dispute(&pool, &id.to_string(), "in-progress").await;
+
+        reconcile_one_admin_dispute_if_terminal(&pool, &relay_dispute(id, "settled")).await;
+
+        let row = AdminDispute::get_by_dispute_id(&pool, &id.to_string())
+            .await
+            .unwrap()
+            .expect("row exists");
+        assert_eq!(row.status.as_deref(), Some("settled"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_does_not_overwrite_already_settled() {
+        let pool = test_pool().await;
+        create_admin_disputes_table(&pool).await;
+        let id = Uuid::new_v4();
+        insert_admin_dispute(&pool, &id.to_string(), "settled").await;
+
+        reconcile_one_admin_dispute_if_terminal(&pool, &relay_dispute(id, "seller-refunded")).await;
+
+        let row = AdminDispute::get_by_dispute_id(&pool, &id.to_string())
+            .await
+            .unwrap()
+            .expect("row exists");
+        assert_eq!(row.status.as_deref(), Some("settled"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_noop_for_unknown_dispute_id() {
+        let pool = test_pool().await;
+        create_admin_disputes_table(&pool).await;
+        let id = Uuid::new_v4();
+
+        reconcile_one_admin_dispute_if_terminal(&pool, &relay_dispute(id, "seller-refunded")).await;
+
+        assert!(AdminDispute::get_by_dispute_id(&pool, &id.to_string())
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_ignores_non_terminal_relay_status() {
+        let pool = test_pool().await;
+        create_admin_disputes_table(&pool).await;
+        let id = Uuid::new_v4();
+        insert_admin_dispute(&pool, &id.to_string(), "in-progress").await;
+
+        reconcile_one_admin_dispute_if_terminal(&pool, &relay_dispute(id, "in-progress")).await;
+
+        let row = AdminDispute::get_by_dispute_id(&pool, &id.to_string())
+            .await
+            .unwrap()
+            .expect("row exists");
+        assert_eq!(row.status.as_deref(), Some("in-progress"));
+    }
+
+    #[test]
+    fn in_memory_sync_copies_seller_refunded_onto_in_progress_row() {
+        let id = Uuid::new_v4();
+        let mut admin = vec![admin_row(&id.to_string(), "in-progress")];
+        let relay = vec![relay_dispute(id, "seller-refunded")];
+
+        let closed = apply_terminal_relay_statuses_to_admin_disputes(&mut admin, &relay);
+
+        assert_eq!(closed, vec![id.to_string()]);
+        assert_eq!(admin[0].status.as_deref(), Some("seller-refunded"));
+    }
+
+    #[test]
+    fn in_memory_sync_skips_already_finalized_and_unknown_ids() {
+        let settled_id = Uuid::new_v4();
+        let unknown_id = Uuid::new_v4();
+        let mut admin = vec![admin_row(&settled_id.to_string(), "settled")];
+        let relay = vec![
+            relay_dispute(settled_id, "seller-refunded"),
+            relay_dispute(unknown_id, "seller-refunded"),
+        ];
+
+        let closed = apply_terminal_relay_statuses_to_admin_disputes(&mut admin, &relay);
+
+        assert!(closed.is_empty());
+        assert_eq!(admin[0].status.as_deref(), Some("settled"));
+    }
+}


### PR DESCRIPTION
## Summary
- Reconcile taken `admin_disputes` from the existing kind-38386 subscription when Mostro auto-closes a dispute (`seller-refunded` on cooperative cancel, `settled` on seller release). The daemon never DMs the solver.
- Keep the selected dispute in the Disputes Management sidebar and update the header `Status` instead of dropping the row from In Progress.
- If the admin still presses Resolve, treat `CooperativeCancelAccepted` as already closed (`SellerRefunded`) instead of `Unexpected action in response`.

## Breaking changes
None.

## Test plan
- [x] `cargo test --all-features --lib helpers::`
- [x] `cargo test --all-features --lib relay_dispute_db_reconcile`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual: take two disputes → users cooperatively cancel → rows stay selected with `seller-refunded` in the header; Shift+F disabled
- [ ] Manual: Restart after offline cooperative cancel → 30s/targeted reconcile marks taken rows closed
- [ ] Manual: Shift+C Finalized still lists closed disputes after navigating away


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispute statuses now update automatically from relay activity, including seller refunds, settlements, releases, and cooperative cancellations.
  * Cooperative cancellations are recognized as successful outcomes and displayed as seller-refunded.
  * In-progress disputes show current statuses with status-specific colors.
  * The selected dispute remains visible until you navigate away after it closes.

* **Bug Fixes**
  * Finalized statuses are protected from being overwritten.
  * Closed disputes are removed from pending views and chat tracking after reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->