### PR TITLE
fix(security): propagate trade-index DB errors and reserve atomically (MOSTRO-082)

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -158,15 +158,9 @@ The `users` table is critical for:
 #### Data Persistence
 
 - **Mnemonic**: Stored in plain text (encrypted at the filesystem level if the OS supports it). This is necessary for key derivation.
-- **Trade Index**: Updated every time a new order is created or taken to ensure no key reuse.
+- **Trade Index**: Reserved atomically via `User::reserve_next_trade_index` before create/take/`NextTrade` network I/O; `save_order` persists the order row only and does not rewrite the counter.
 
-**Source**: `src/util/db_utils.rs:25`
-
-```25:27:src/util/db_utils.rs
-                if let Err(e) = User::update_last_trade_index(pool, trade_index).await {
-                    log::error!("Failed to update user: {}", e);
-                }
-```
+**Source**: `src/models.rs` (`User::reserve_next_trade_index`), `src/util/db_utils.rs` (`save_order`)
 
 #### 2. `orders` Table
 
@@ -460,7 +454,7 @@ The database contains highly sensitive information:
 1. **User Creation**: `User::new()` - Creates a new user with a generated mnemonic
 2. **User Retrieval**: `User::get()` - Gets the single user record
 3. **Trade Index Reservation**: `User::reserve_next_trade_index()` - Atomically increments and returns the next trade index and derived keys
-4. **Trade Index Update**: `User::update_last_trade_index()` - Sets the counter to an explicit value (e.g. after `save_order`)
+4. **Trade Index Update**: `User::update_last_trade_index()` - Monotonic raise only (`MAX`); avoids regressing the counter on stale writes
 5. **Order Creation**: `Order::new()` - Creates or updates an order record
 6. **Order Retrieval**: `Order::get_by_id()` - Retrieves an order by ID
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -25,12 +25,13 @@ On first startup, Mostrix:
 
 1. Creates the `~/.mostrix/` directory if it doesn't exist
 2. Creates the SQLite database file
-3. Creates the necessary tables:
+3. Enables WAL journal mode and a 5s busy timeout (`configure_sqlite_pool`)
+4. Creates the necessary tables:
    - **User Mode Tables**: `users` and `orders`
    - **Admin Mode Tables**: `admin_disputes`
-4. Generates a new 12-word BIP-39 mnemonic if no user exists
-5. Creates the initial user record
-6. Runs database migrations for existing databases (if needed)
+5. Generates a new 12-word BIP-39 mnemonic if no user exists
+6. Creates the initial user record
+7. Runs database migrations for existing databases (if needed)
 
 **Source**: `src/db.rs:66`
 
@@ -143,7 +144,7 @@ CREATE TABLE IF NOT EXISTS users (
 |-------|------|-------------|
 | `i0_pubkey` | `char(64)` | Primary key. The public key derived from the identity key (index 0). Used as the unique identifier for the user. |
 | `mnemonic` | `TEXT` | The 12-word BIP-39 mnemonic phrase. **Critical**: This is the root of all key derivation. Must be kept secure. |
-| `last_trade_index` | `INTEGER` | The highest trade index that has been used. Used to ensure each new trade gets a unique key. Starts at `NULL` (treated as 0 or 1). |
+| `last_trade_index` | `INTEGER` | The highest trade index reserved for a trade. Ensures each new trade gets a unique key. Starts at `NULL`; reservation uses `none_base` (`1` for create/take, `0` for range `NextTrade`). |
 | `created_at` | `INTEGER` | Unix timestamp when the user record was created. |
 
 #### Purpose
@@ -381,23 +382,20 @@ When saving a dispute to the database, the following fields are validated:
 The relationship between `users.last_trade_index` and `orders.trade_keys` is critical:
 
 1. **Order Creation**: When creating a new order:
-   - `last_trade_index` is read from the `users` table
-   - A new trade key is derived using `trade_index = last_trade_index + 1`
-   - The trade keys are stored in the `orders` table
-   - `last_trade_index` is updated in the `users` table
+   - `User::reserve_next_trade_index` atomically increments `last_trade_index` in a transaction
+   - Trade keys are derived for the reserved index
+   - The trade keys are stored in the `orders` table when Mostro confirms
 
 2. **Trade Recovery**: On startup:
    - All orders are loaded from the `orders` table
    - Trade keys are retrieved for each active order
    - The client can decrypt messages and interact with active trades
 
-**Source**: `src/util/order_utils/send_new_order.rs:84`
+**Source**: `src/util/order_utils/send_new_order.rs:88`
 
-```84:87:src/util/order_utils/send_new_order.rs
-    let user = User::get(pool).await?;
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+```88:89:src/util/order_utils/send_new_order.rs
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 ```
 
 ## Message Recovery Strategy
@@ -461,9 +459,10 @@ The database contains highly sensitive information:
 
 1. **User Creation**: `User::new()` - Creates a new user with a generated mnemonic
 2. **User Retrieval**: `User::get()` - Gets the single user record
-3. **Trade Index Update**: `User::update_last_trade_index()` - Updates the trade index counter
-4. **Order Creation**: `Order::new()` - Creates or updates an order record
-5. **Order Retrieval**: `Order::get_by_id()` - Retrieves an order by ID
+3. **Trade Index Reservation**: `User::reserve_next_trade_index()` - Atomically increments and returns the next trade index and derived keys
+4. **Trade Index Update**: `User::update_last_trade_index()` - Sets the counter to an explicit value (e.g. after `save_order`)
+5. **Order Creation**: `Order::new()` - Creates or updates an order record
+6. **Order Retrieval**: `Order::get_by_id()` - Retrieves an order by ID
 
 **Source**: `src/models.rs` for all database operation implementations.
 

--- a/docs/KEY_MANAGEMENT.md
+++ b/docs/KEY_MANAGEMENT.md
@@ -78,22 +78,23 @@ In this mode, Mostro cannot link the trade to your identity key. You operate ano
 - **Rumor (Kind 1)**: Signed by the **Trade Key (Index N)**.
 
 ## Trade Index Incrementation
-Whenever a user creates or takes an order, the `last_trade_index` is incremented and stored in the database.
+Whenever a user creates or takes an order, the next trade index is reserved atomically in the database before any network I/O.
 
-**Implementation**: `src/util/order_utils/take_order.rs:66`
-```66:68:src/util/order_utils/take_order.rs
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+**Implementation**: `src/util/order_utils/take_order.rs:69`
+```69:70:src/util/order_utils/take_order.rs
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 ```
+
+The reservation runs in a transaction (`User::reserve_next_trade_index` in `src/models.rs`); a failed commit (e.g. database locked) aborts the operation instead of reusing keys. The same helper is used in `send_new_order` (`none_base = 1`) and range-order `NextTrade` flows (`none_base = 0` in `execute_send_msg`).
 
 ## Database Persistence
 
 ### Derivation Logic
 The derivation logic for trade keys uses the `trade_index` as the child index in the derivation path.
 
-**Implementation**: `src/models.rs:86`
-```86:96:src/models.rs
+**Implementation**: `src/models.rs:165`
+```165:175:src/models.rs
     pub fn derive_trade_keys(&self, trade_index: i64) -> Result<Keys> {
         let account: u32 = NOSTR_ORDER_EVENT_KIND as u32;
         let keys = Keys::from_mnemonic_advanced(

--- a/docs/MESSAGE_FLOW_AND_PROTOCOL.md
+++ b/docs/MESSAGE_FLOW_AND_PROTOCOL.md
@@ -63,10 +63,8 @@ sequenceDiagram
 
     User->>TUI: Fill form & confirm (Enter)
     TUI->>Client: send_new_order()
-    Client->>DB: Get user & last_trade_index
-    DB-->>Client: user data
-    Client->>TradeKey: Derive key (index + 1)
-    Client->>DB: Update last_trade_index
+    Client->>DB: reserve_next_trade_index (transaction)
+    DB-->>Client: next_idx, trade_keys
     Client->>Client: Construct message (request_id, trade_index)
     Client->>IdentityKey: Sign Seal
     Client->>TradeKey: Sign Rumor
@@ -105,15 +103,13 @@ sequenceDiagram
 The user fills out the order form and confirms with **Enter** on the \"Create New Order\" form. The UI switches to `WaitingForMostro` mode.
 
 ### 2. Trade Key Derivation
-**Source**: `src/util/order_utils/send_new_order.rs:84`
-```84:87:src/util/order_utils/send_new_order.rs
-    let user = User::get(pool).await?;
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+**Source**: `src/util/order_utils/send_new_order.rs:88`
+```88:89:src/util/order_utils/send_new_order.rs
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 ```
 
-A fresh trade key is derived using the next available index. This ensures privacy by using a unique key for each order.
+A fresh trade key is derived using the next reserved index. Reservation happens in a DB transaction before any DM is sent; a failed commit aborts the flow.
 
 ### 3. Message Construction
 **Source**: `src/util/order_utils/send_new_order.rs:108`
@@ -207,10 +203,8 @@ sequenceDiagram
 
     User->>TUI: Select order & press Enter
     TUI->>Client: take_order(order_id)
-    Client->>DB: Get user & last_trade_index
-    DB-->>Client: user data
-    Client->>TradeKey: Derive new key (index + 1)
-    Client->>DB: Update last_trade_index
+    Client->>DB: reserve_next_trade_index (transaction)
+    DB-->>Client: next_idx, trade_keys
     Client->>Client: Construct TakeOrder message
     Client->>NostrRelays: Subscribe + Publish NIP-59
     NostrRelays->>Mostro: Forward TakeOrder
@@ -233,14 +227,13 @@ sequenceDiagram
 The user navigates to an order in the Orders tab and presses `Enter`.
 
 ### 2. Trade Key Derivation
-**Source**: `src/util/order_utils/take_order.rs:66`
-```66:68:src/util/order_utils/take_order.rs
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+**Source**: `src/util/order_utils/take_order.rs:69`
+```69:70:src/util/order_utils/take_order.rs
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 ```
 
-A new trade key is derived for this specific trade interaction.
+A new trade key is reserved atomically for this specific trade interaction.
 
 ### 3. Message Construction
 **Source**: `src/util/order_utils/take_order.rs:77`

--- a/docs/RANGE_ORDERS.md
+++ b/docs/RANGE_ORDERS.md
@@ -17,31 +17,14 @@ Range orders allow users to create orders with variable amounts within a specifi
 
 Before completing a range order trade, Mostrix must inform the Mostro daemon about the next trade key that will be used for the remaining amount. This is done via the `NextTrade` payload.
 
-**Source**: `src/util/order_utils/execute_send_msg.rs:17`
-```17:40:src/util/order_utils/execute_send_msg.rs
-        Action::FiatSent | Action::Release => {
-            // Check if this is a range order that needs NextTrade payload
-            if let (Some(min_amount), Some(max_amount)) = (order.min_amount, order.max_amount) {
-                if max_amount - order.fiat_amount >= min_amount {
-                    // This is a range order with remaining amount, create NextTrade payload
-                    let user = User::get(pool).await?;
-                    let next_trade_index = user.last_trade_index.unwrap_or(0) + 1;
-                    let next_trade_keys = user.derive_trade_keys(next_trade_index)?;
-
-                    // Update last trade index
-                    User::update_last_trade_index(pool, next_trade_index).await?;
+**Source**: `src/util/order_utils/execute_send_msg.rs:23`
+```23:28:src/util/order_utils/execute_send_msg.rs
+                    let (next_trade_index, next_trade_keys) =
+                        User::reserve_next_trade_index(pool, 0).await?;
 
                     Ok(Some(Payload::NextTrade(
                         next_trade_keys.public_key().to_string(),
                         next_trade_index as u32,
-                    )))
-                } else {
-                    Ok(None)
-                }
-            } else {
-                Ok(None)
-            }
-        }
 ```
 
 ## Range Order Logic
@@ -54,7 +37,7 @@ When completing a trade (`FiatSent` or `Release`):
 
 3. **Check if new order needed**:
    - If `remaining >= min_amount`: Create `NextTrade` payload with:
-     - Derive next trade key (increment `last_trade_index`)
+     - Reserve next trade key via `User::reserve_next_trade_index(pool, 0)`
      - Send the new trade key's public key and index to Mostro
      - Mostro will create a new pending order with the remaining amount
    - If `remaining < min_amount`: No new order is created (send `None` payload)
@@ -81,9 +64,8 @@ sequenceDiagram
     Client->>DB: Get order (fiat_amount = 250 remaining)
     Client->>Client: Calculate: 400 - 150 = 250 >= 100?
     alt Remaining >= min_amount
-        Client->>DB: Get user & last_trade_index
-        Client->>NextTradeKey: Derive new key (index + 1)
-        Client->>DB: Update last_trade_index
+        Client->>DB: reserve_next_trade_index (none_base=0)
+        DB-->>Client: next_trade_index, next_trade_keys
         Client->>Mostro: Send FiatSent/Release + NextTrade payload
         Note over Mostro: Create new pending order<br/>with remaining 250 USD<br/>using NextTrade key
     else Remaining < min_amount

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,21 @@ use sqlx::SqlitePool;
 use std::fs::File;
 use std::path::Path;
 
+/// SQLite pragmas for safer concurrent access (WAL + busy retry window).
+async fn configure_sqlite_pool(pool: &SqlitePool) -> Result<()> {
+    sqlx::query("PRAGMA journal_mode=WAL")
+        .execute(pool)
+        .await?;
+    sqlx::query("PRAGMA busy_timeout=5000")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Opens or creates the local SQLite pool at `~/.mostrix/mostrix.db`.
+///
+/// Applies WAL mode and a 5s busy timeout via [`configure_sqlite_pool`] to reduce
+/// `SQLITE_BUSY` failures under concurrent access.
 pub async fn init_db() -> Result<SqlitePool> {
     let pool: SqlitePool;
     let name = env!("CARGO_PKG_NAME");
@@ -30,6 +45,7 @@ pub async fn init_db() -> Result<SqlitePool> {
         }
 
         pool = SqlitePool::connect(&db_url).await?;
+        configure_sqlite_pool(&pool).await?;
 
         sqlx::query(
             r#"
@@ -110,6 +126,7 @@ pub async fn init_db() -> Result<SqlitePool> {
         }
     } else {
         pool = SqlitePool::connect(&db_url).await?;
+        configure_sqlite_pool(&pool).await?;
 
         // Run migrations for existing databases
         migrate_db(&pool).await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,9 +8,7 @@ use std::path::Path;
 
 /// SQLite pragmas for safer concurrent access (WAL + busy retry window).
 async fn configure_sqlite_pool(pool: &SqlitePool) -> Result<()> {
-    sqlx::query("PRAGMA journal_mode=WAL")
-        .execute(pool)
-        .await?;
+    sqlx::query("PRAGMA journal_mode=WAL").execute(pool).await?;
     sqlx::query("PRAGMA busy_timeout=5000")
         .execute(pool)
         .await?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -116,12 +116,14 @@ impl User {
         Ok(())
     }
 
-    /// Set `last_trade_index` to an explicit value (e.g. when persisting an order in `save_order`).
+    /// Raise `last_trade_index` to at least `idx` without decreasing the counter.
     ///
-    /// To allocate the next index before starting a trade, use [`Self::reserve_next_trade_index`].
+    /// Prefer [`Self::reserve_next_trade_index`] before starting a trade; trade flows
+    /// already commit the index at reservation time and must not write a stale value
+    /// after a delayed order save.
     pub async fn update_last_trade_index(pool: &SqlitePool, idx: i64) -> Result<()> {
         sqlx::query(
-            r#"UPDATE users SET last_trade_index = ? WHERE i0_pubkey = (SELECT i0_pubkey FROM users LIMIT 1)"#,
+            r#"UPDATE users SET last_trade_index = MAX(COALESCE(last_trade_index, 0), ?) WHERE i0_pubkey = (SELECT i0_pubkey FROM users LIMIT 1)"#,
         )
         .bind(idx)
         .execute(pool)

--- a/src/models.rs
+++ b/src/models.rs
@@ -116,6 +116,9 @@ impl User {
         Ok(())
     }
 
+    /// Set `last_trade_index` to an explicit value (e.g. when persisting an order in `save_order`).
+    ///
+    /// To allocate the next index before starting a trade, use [`Self::reserve_next_trade_index`].
     pub async fn update_last_trade_index(pool: &SqlitePool, idx: i64) -> Result<()> {
         sqlx::query(
             r#"UPDATE users SET last_trade_index = ? WHERE i0_pubkey = (SELECT i0_pubkey FROM users LIMIT 1)"#,
@@ -124,6 +127,38 @@ impl User {
         .execute(pool)
         .await?;
         Ok(())
+    }
+
+    /// Atomically increment `last_trade_index` and derive keys for the new index.
+    ///
+    /// Runs read-modify-write inside a transaction so a failed commit (e.g. `SQLITE_BUSY`)
+    /// surfaces as an error instead of silently reusing an index. `none_base` is the value
+    /// treated as the previous index when `last_trade_index` is NULL (order flows use `1`,
+    /// range-order `NextTrade` uses `0`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction cannot be started, the user row cannot be read,
+    /// the index update fails, or key derivation fails.
+    pub async fn reserve_next_trade_index(
+        pool: &SqlitePool,
+        none_base: i64,
+    ) -> Result<(i64, Keys)> {
+        let mut tx = pool.begin().await?;
+        let user: User = sqlx::query_as(
+            r#"SELECT i0_pubkey, mnemonic, last_trade_index, created_at FROM users LIMIT 1"#,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+        let next_idx = user.last_trade_index.unwrap_or(none_base) + 1;
+        sqlx::query(r#"UPDATE users SET last_trade_index = ? WHERE i0_pubkey = ?"#)
+            .bind(next_idx)
+            .bind(&user.i0_pubkey)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        let trade_keys = user.derive_trade_keys(next_idx)?;
+        Ok((next_idx, trade_keys))
     }
 
     pub async fn get_identity_keys(pool: &SqlitePool) -> Result<Keys> {

--- a/src/util/db_utils.rs
+++ b/src/util/db_utils.rs
@@ -3,7 +3,7 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use sqlx::sqlite::SqlitePool;
 
-use crate::models::{Order, User};
+use crate::models::Order;
 
 /// Delete an order row from the local database.
 ///
@@ -47,15 +47,6 @@ pub async fn save_order(
             log::info!("Order {} created", order_id);
         } else {
             log::warn!("Warning: The newly created order has no ID.");
-        }
-
-        match User::get(pool).await {
-            Ok(_user) => {
-                if let Err(e) = User::update_last_trade_index(pool, trade_index).await {
-                    log::error!("Failed to update user: {}", e);
-                }
-            }
-            Err(e) => log::error!("Failed to get user: {}", e),
         }
     }
     Ok(())

--- a/src/util/order_utils/execute_send_msg.rs
+++ b/src/util/order_utils/execute_send_msg.rs
@@ -20,12 +20,8 @@ async fn create_msg_payload(
             if let (Some(min_amount), Some(max_amount)) = (order.min_amount, order.max_amount) {
                 if max_amount - order.fiat_amount >= min_amount {
                     // This is a range order with remaining amount, create NextTrade payload
-                    let user = User::get(pool).await?;
-                    let next_trade_index = user.last_trade_index.unwrap_or(0) + 1;
-                    let next_trade_keys = user.derive_trade_keys(next_trade_index)?;
-
-                    // Update last trade index
-                    User::update_last_trade_index(pool, next_trade_index).await?;
+                    let (next_trade_index, next_trade_keys) =
+                        User::reserve_next_trade_index(pool, 0).await?;
 
                     Ok(Some(Payload::NextTrade(
                         next_trade_keys.public_key().to_string(),

--- a/src/util/order_utils/send_new_order.rs
+++ b/src/util/order_utils/send_new_order.rs
@@ -85,11 +85,8 @@ pub async fn send_new_order(
         Some(form.invoice.trim().to_string())
     };
 
-    // Get user and trade keys
-    let user = User::get(pool).await?;
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 
     // Create SmallOrder
     let small_order = SmallOrder::new(

--- a/src/util/order_utils/take_order.rs
+++ b/src/util/order_utils/take_order.rs
@@ -66,11 +66,8 @@ pub async fn take_order(
         .id
         .ok_or_else(|| anyhow::anyhow!("Order ID is missing"))?;
 
-    // Get user and trade keys
-    let user = User::get(pool).await?;
-    let next_idx = user.last_trade_index.unwrap_or(1) + 1;
-    let trade_keys = user.derive_trade_keys(next_idx)?;
-    let _ = User::update_last_trade_index(pool, next_idx).await;
+    // Reserve the next trade index atomically; propagate DB errors (e.g. SQLITE_BUSY).
+    let (next_idx, trade_keys) = User::reserve_next_trade_index(pool, 1).await?;
 
     // Subscribe as early as possible for take-order flow so the first
     // Mostro response/event is not missed by the background DM listener.

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -75,7 +75,10 @@ async fn test_last_trade_index_monotonic_under_out_of_order_update() {
     User::update_last_trade_index(&pool, idx1).await.unwrap();
 
     let (idx3, _) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
-    assert_ne!(idx3, idx2, "counter must not regress and reuse a live trade index");
+    assert_ne!(
+        idx3, idx2,
+        "counter must not regress and reuse a live trade index"
+    );
     assert_eq!(idx3, 4);
 }
 

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -43,6 +43,23 @@ async fn test_user_update_last_trade_index() {
 }
 
 #[tokio::test]
+async fn test_user_reserve_next_trade_index() {
+    let pool = create_test_db().await.unwrap();
+    let mnemonic = test_mnemonic();
+
+    User::new(mnemonic, &pool).await.unwrap();
+
+    let (idx1, keys1) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
+    assert_eq!(idx1, 2);
+    let (idx2, keys2) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
+    assert_eq!(idx2, 3);
+    assert_ne!(keys1.public_key(), keys2.public_key());
+
+    let user = User::get(&pool).await.unwrap();
+    assert_eq!(user.last_trade_index, Some(3));
+}
+
+#[tokio::test]
 async fn test_user_get_identity_keys() {
     let pool = create_test_db().await.unwrap();
     let mnemonic = test_mnemonic();

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -60,6 +60,26 @@ async fn test_user_reserve_next_trade_index() {
 }
 
 #[tokio::test]
+async fn test_last_trade_index_monotonic_under_out_of_order_update() {
+    let pool = create_test_db().await.unwrap();
+    let mnemonic = test_mnemonic();
+
+    User::new(mnemonic, &pool).await.unwrap();
+
+    let (idx1, _) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
+    let (idx2, _) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
+    assert_eq!(idx1, 2);
+    assert_eq!(idx2, 3);
+
+    // Simulates delayed save_order calling update_last_trade_index for an earlier reservation.
+    User::update_last_trade_index(&pool, idx1).await.unwrap();
+
+    let (idx3, _) = User::reserve_next_trade_index(&pool, 1).await.unwrap();
+    assert_ne!(idx3, idx2, "counter must not regress and reuse a live trade index");
+    assert_eq!(idx3, 4);
+}
+
+#[tokio::test]
 async fn test_user_get_identity_keys() {
     let pool = create_test_db().await.unwrap();
     let mnemonic = test_mnemonic();


### PR DESCRIPTION
## Summary

- Fixes **MOSTRO-082**: `send_new_order` and `take_order` used `let _ = User::update_last_trade_index(...)`, silently ignoring `SQLITE_BUSY` / `database is locked` and proceeding with derived trade keys while the DB still held the old index — enabling key reuse across live trades under lock contention or a second instance.
- Adds `User::reserve_next_trade_index()` — atomic read-increment-write in a SQLite transaction; errors propagate and abort the operation before any DM is sent.
- Enables **WAL** journal mode and a **5s busy timeout** on pool init to reduce lock failures under concurrent access.
- Applies the same reservation helper to range-order `NextTrade` flows in `execute_send_msg`.
- Updates key-management and database docs to match the new API.

## Security context

| Before | After |
|--------|-------|
| DB write fails → operation continues with uncommitted index | DB write fails → operation aborts with error |
| Non-atomic read-modify-write | Transactional reservation before network I/O |

A single-instance file lock (also suggested in the audit) is out of scope for this PR.

## Test plan

- [x] `cargo test --all-features test_user_reserve_next_trade_index`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Create order — succeeds and increments `last_trade_index`
- [ ] Take order — succeeds and increments `last_trade_index`
- [ ] Range order `NextTrade` path still sends correct pubkey/index


Made with [Cursor](https://cursor.com)