### PR TITLE
fix(keys): correct NIP-06 trade key derivation path

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1224,37 +1224,51 @@ impl AdminDispute {
 #[cfg(test)]
 mod derive_trade_keys_tests {
     use super::User;
-    use mostro_core::prelude::NOSTR_ORDER_EVENT_KIND;
-    use nostr_sdk::prelude::{FromMnemonic, Keys};
 
     /// Same mnemonic as mostro-webtool trade-key API tests.
     const SAMPLE_MNEMONIC: &str =
         "leader monkey parrot ring guide accident before fence cannon height naive bean";
 
-    fn expected_trade_keys(mnemonic: &str, trade_index: u32) -> Keys {
-        Keys::from_mnemonic_advanced(
-            mnemonic,
-            None,
-            Some(NOSTR_ORDER_EVENT_KIND as u32),
-            Some(0),
-            Some(trade_index),
-        )
-        .expect("reference trade key derivation")
-    }
+    /// Independent cross-client vectors for `m/44'/1237'/38383'/0/{index}`.
+    const TRADE_KEY_VECTORS: &[(i64, &str, &str)] = &[
+        (
+            1,
+            "1c71f0a29c9d14198781f36897c6d6c08e2c4f905ba69fc5f8e67d375d705a8a",
+            "977b9da8056e6a83a991cb31ac507b0a618fbbee355e36e107e0e348686ab833",
+        ),
+        (
+            2,
+            "5011d0e7a57ae27627ab76962537072c6809ef3b9e24c2e3db4e672c61624eef",
+            "03c78114b80a2db782bb86be47c8062388d78a0585dfa79b8594e105740758c3",
+        ),
+        (
+            5,
+            "088bb3266bde36a0d7080b8ae655e86f5c12ac13ec59fa12754f277cdc2c970b",
+            "542fe37421c128dd421289d45f498cd99a06701706f33a1a74926e6d2d32182d",
+        ),
+    ];
+
+    /// Pre-fix swapped-path pubkey for index 2 (`m/44'/1237'/38383'/2/0`).
+    const WRONG_PATH_INDEX_TWO_PUBKEY: &str =
+        "7da91a7dec95859f279866bc0bb3a86ff3d67a43da3f43cd722d1dbc948e0d02";
 
     #[test]
     fn derive_trade_keys_matches_mostro_derivation_path() {
         let user = User::from_mnemonic(SAMPLE_MNEMONIC.to_string()).expect("user from mnemonic");
 
-        for trade_index in [1_i64, 2, 5] {
+        for &(trade_index, expected_pubkey_hex, expected_secret_hex) in TRADE_KEY_VECTORS {
             let derived = user
                 .derive_trade_keys(trade_index)
                 .expect("derive_trade_keys");
-            let expected = expected_trade_keys(SAMPLE_MNEMONIC, trade_index as u32);
             assert_eq!(
-                derived.secret_key(),
-                expected.secret_key(),
-                "trade index {trade_index} must use m/44'/1237'/38383'/0/{trade_index}"
+                derived.public_key().to_hex(),
+                expected_pubkey_hex,
+                "trade index {trade_index} pubkey"
+            );
+            assert_eq!(
+                derived.secret_key().to_secret_hex(),
+                expected_secret_hex,
+                "trade index {trade_index} secret"
             );
         }
     }
@@ -1266,20 +1280,9 @@ mod derive_trade_keys_tests {
 
         assert_eq!(
             keys.public_key().to_hex(),
-            expected_trade_keys(SAMPLE_MNEMONIC, 2)
-                .public_key()
-                .to_hex()
+            "5011d0e7a57ae27627ab76962537072c6809ef3b9e24c2e3db4e672c61624eef"
         );
-        // Regression guard: swapped change/index produced this pubkey before the fix.
-        let wrong = Keys::from_mnemonic_advanced(
-            SAMPLE_MNEMONIC,
-            None,
-            Some(NOSTR_ORDER_EVENT_KIND as u32),
-            Some(2),
-            Some(0),
-        )
-        .expect("wrong-path derivation");
-        assert_ne!(keys.public_key(), wrong.public_key());
+        assert_ne!(keys.public_key().to_hex(), WRONG_PATH_INDEX_TWO_PUBKEY);
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -174,6 +174,13 @@ impl User {
 
     /// Derive the trade key at `m/44'/1237'/38383'/0/{trade_index}` (NIP-06).
     pub fn derive_trade_keys(&self, trade_index: i64) -> Result<Keys> {
+        if trade_index < 0 || trade_index > u32::MAX as i64 {
+            anyhow::bail!(
+                "Invalid trade_index {} for key derivation; expected 0..={}",
+                trade_index,
+                u32::MAX
+            );
+        }
         let account: u32 = NOSTR_ORDER_EVENT_KIND as u32;
         let keys = Keys::from_mnemonic_advanced(
             &self.mnemonic,
@@ -1273,6 +1280,21 @@ mod derive_trade_keys_tests {
         )
         .expect("wrong-path derivation");
         assert_ne!(keys.public_key(), wrong.public_key());
+    }
+
+    #[test]
+    fn derive_trade_keys_rejects_out_of_range_indices() {
+        let user = User::from_mnemonic(SAMPLE_MNEMONIC.to_string()).expect("user from mnemonic");
+
+        for invalid in [-1_i64, i64::from(u32::MAX) + 1] {
+            let err = user
+                .derive_trade_keys(invalid)
+                .expect_err("out-of-range trade_index must fail");
+            assert!(
+                err.to_string().contains("Invalid trade_index"),
+                "unexpected error: {err}"
+            );
+        }
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -172,14 +172,15 @@ impl User {
         Ok(keys)
     }
 
+    /// Derive the trade key at `m/44'/1237'/38383'/0/{trade_index}` (NIP-06).
     pub fn derive_trade_keys(&self, trade_index: i64) -> Result<Keys> {
         let account: u32 = NOSTR_ORDER_EVENT_KIND as u32;
         let keys = Keys::from_mnemonic_advanced(
             &self.mnemonic,
             None,
             Some(account),
-            Some(trade_index as u32),
             Some(0),
+            Some(trade_index as u32),
         )?;
         Ok(keys)
     }
@@ -1210,6 +1211,68 @@ impl AdminDispute {
     /// Returns true if the dispute is not finalized and can be canceled.
     pub fn can_cancel(&self) -> bool {
         !self.is_finalized()
+    }
+}
+
+#[cfg(test)]
+mod derive_trade_keys_tests {
+    use super::User;
+    use mostro_core::prelude::NOSTR_ORDER_EVENT_KIND;
+    use nostr_sdk::prelude::{FromMnemonic, Keys};
+
+    /// Same mnemonic as mostro-webtool trade-key API tests.
+    const SAMPLE_MNEMONIC: &str =
+        "leader monkey parrot ring guide accident before fence cannon height naive bean";
+
+    fn expected_trade_keys(mnemonic: &str, trade_index: u32) -> Keys {
+        Keys::from_mnemonic_advanced(
+            mnemonic,
+            None,
+            Some(NOSTR_ORDER_EVENT_KIND as u32),
+            Some(0),
+            Some(trade_index),
+        )
+        .expect("reference trade key derivation")
+    }
+
+    #[test]
+    fn derive_trade_keys_matches_mostro_derivation_path() {
+        let user = User::from_mnemonic(SAMPLE_MNEMONIC.to_string()).expect("user from mnemonic");
+
+        for trade_index in [1_i64, 2, 5] {
+            let derived = user
+                .derive_trade_keys(trade_index)
+                .expect("derive_trade_keys");
+            let expected = expected_trade_keys(SAMPLE_MNEMONIC, trade_index as u32);
+            assert_eq!(
+                derived.secret_key(),
+                expected.secret_key(),
+                "trade index {trade_index} must use m/44'/1237'/38383'/0/{trade_index}"
+            );
+        }
+    }
+
+    #[test]
+    fn derive_trade_keys_index_two_matches_mostro_webtool_vector() {
+        let user = User::from_mnemonic(SAMPLE_MNEMONIC.to_string()).expect("user from mnemonic");
+        let keys = user.derive_trade_keys(2).expect("trade index 2");
+
+        assert_eq!(
+            keys.public_key().to_hex(),
+            expected_trade_keys(SAMPLE_MNEMONIC, 2)
+                .public_key()
+                .to_hex()
+        );
+        // Regression guard: swapped change/index produced this pubkey before the fix.
+        let wrong = Keys::from_mnemonic_advanced(
+            SAMPLE_MNEMONIC,
+            None,
+            Some(NOSTR_ORDER_EVENT_KIND as u32),
+            Some(2),
+            Some(0),
+        )
+        .expect("wrong-path derivation");
+        assert_ne!(keys.public_key(), wrong.public_key());
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix swapped `change` / `address index` arguments in `User::derive_trade_keys`, which produced `m/44'/1237'/38383'/X/0` instead of the protocol path `m/44'/1237'/38383'/0/X` used by mostro-cli, mobile, and mostro-webtool.
- Identity key derivation (`/0/0`) was already correct; only trade keys (index ≥ 1) were affected.
- Add regression tests using the same mnemonic vector as mostro-webtool, including a guard that the old swapped path produces a different pubkey.

## Context

Mostrix could not interoperate with other Mostro clients: messages signed with the wrong derived trade key would not match the pubkey Mostro expects for a given `trade_index`.

## Breaking / migration note

Orders created under the buggy build may have incorrect `trade_keys` persisted locally. New trades after this fix use the correct path. Users with in-flight orders from the old build may need to clear local order rows and re-sync.

## Test plan

- [x] `cargo test --all-features derive_trade_keys`
- [x] Unit tests assert `derive_trade_keys(N)` matches `from_mnemonic_advanced(..., change=0, index=N)`
- [x] Regression test confirms index 2 differs from the pre-fix swapped path
- [ ] Manual: derive trade key index 1 from a known mnemonic in mostrix vs mostro-cli and confirm matching pubkeys


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected trade key derivation to use the trade index, ensuring generated keys match the expected derivation path.
  * Added validation covering multiple trade indices and preventing incorrect key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->