### PR TITLE
fix(ui): let the key-rotation confirmation be arrowed to NO

### DIFF
--- a/src/ui/key_handler/navigation.rs
+++ b/src/ui/key_handler/navigation.rs
@@ -87,6 +87,7 @@ fn handle_left_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
         | UiMode::ConfirmClearCurrencies(ref mut selected_button)
         | UiMode::ConfirmDeleteHistoryOrder(_, ref mut selected_button)
         | UiMode::ConfirmBulkDeleteHistory(ref mut selected_button)
+        | UiMode::ConfirmGenerateNewKeys(ref mut selected_button)
         | UiMode::ConfirmExit(ref mut selected_button) => {
             // Switch to YES button (left side)
             *selected_button = true;
@@ -158,6 +159,7 @@ fn handle_right_key(app: &mut AppState, _orders: &Arc<Mutex<Vec<SmallOrder>>>) {
         | UiMode::ConfirmClearCurrencies(ref mut selected_button)
         | UiMode::ConfirmDeleteHistoryOrder(_, ref mut selected_button)
         | UiMode::ConfirmBulkDeleteHistory(ref mut selected_button)
+        | UiMode::ConfirmGenerateNewKeys(ref mut selected_button)
         | UiMode::ConfirmExit(ref mut selected_button) => {
             // Switch to NO button (right side)
             *selected_button = false;
@@ -563,5 +565,32 @@ pub fn handle_tab_navigation(code: KeyCode, app: &mut AppState) {
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod confirm_toggle_tests {
+    use super::*;
+    use crate::ui::UserRole;
+
+    #[test]
+    fn generate_new_keys_confirmation_can_be_moved_to_no() {
+        // Rotating keys replaces the user row and clears the orders table, so
+        // this confirmation must be selectable. It was missing from both
+        // Left/Right groups: arrowing to NO did nothing and Enter rotated.
+        let orders = Arc::new(Mutex::new(Vec::new()));
+        let mut app = AppState::new(UserRole::User);
+        app.mode = UiMode::ConfirmGenerateNewKeys(true);
+
+        handle_right_key(&mut app, &orders);
+        assert!(
+            matches!(app.mode, UiMode::ConfirmGenerateNewKeys(false)),
+            "Right must select NO"
+        );
+        handle_left_key(&mut app, &orders);
+        assert!(
+            matches!(app.mode, UiMode::ConfirmGenerateNewKeys(true)),
+            "Left must select YES"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`UiMode::ConfirmGenerateNewKeys` is missing from **both** Left/Right groups in `src/ui/key_handler/navigation.rs`. On the *Generate New Keys* confirmation the arrow keys therefore do nothing: the popup opens on YES, and Enter rotates the keys regardless of what the user tried to select. Only Esc cancels.

This is present on current `main` (shipped in 0.2.8), and it is the one confirmation in the app where the arrows silently do not work — every other confirm popup (Add Relay, Change Mostro Pubkey, Add Currency Filter, Delete History, Clean Up History, Exit, …) is in those groups. The muscle memory built on all of them leads straight into rotating keys.

And the action is destructive: `spawn_key_rotation_task` runs `User::replace_all_in_tx` (DELETE FROM users + insert) **and** `Order::delete_all_in_tx` in one transaction. A user who arrows to NO and presses Enter loses their identity and their whole local order history, having done what the UI told them was a cancel.

## Fix

Add `ConfirmGenerateNewKeys` to both groups in `handle_left_key` / `handle_right_key`, plus a regression test asserting Right selects NO and Left selects back to YES.

Two lines of behaviour change; no other confirmation is touched.

`cargo test --all-features` → 426 passed. Clippy `-D warnings` and fmt clean.

## Note

Found while working on #114 — adding `ConfirmRestoreSession` right next to it in those match groups is what made the omission visible. #114 currently carries the same fix in its own branch; whichever lands first, I will drop it from the other so there is no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Arrow keys now toggle between YES and NO in the generate-new-keys confirmation popup.

* **Tests**
  * Added coverage to verify button selection changes correctly with left and right navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->